### PR TITLE
re-correct target downloader so it caches jpg as downloaded but still…

### DIFF
--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -149,8 +149,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             // potential cached JPG as successful too
             if (isAlreadyDownloaded(objectID)) {
                 console.log('skip downloading JPG for', objectID);
-                onTargetJPGDownloaded(true, jpgAddress);
-                return;
+                targetDownloadStates[objectID].JPG = DownloadState.SUCCEEDED;
             }
 
             var xmlFileName = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/target/target.xml';


### PR DESCRIPTION
… prioritizes adding target via DAT if the file is available.

Previous solution always triggered the addNewMarkerJPG if it had been previously downloaded, rather than choosing between addNewMarker (DAT) and addNewMarkerJPG.