### PR TITLE
More thoroughly keep track of caching in target downloader 

### DIFF
--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -274,8 +274,7 @@ createNameSpace("realityEditor.app.targetDownloader");
                 checksum: temporaryChecksumMap[objectID],
                 xmlDownloaded: targetDownloadStates[objectID].XML,
                 datDownloaded: targetDownloadStates[objectID].DAT,
-                jpgDownloaded: targetDownloadStates[objectID].JPG,
-                markerSuccessful: targetDownloadStates[objectID].MARKER_ADDED
+                jpgDownloaded: targetDownloadStates[objectID].JPG
             }));
         }
     }

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -87,7 +87,7 @@ createNameSpace("realityEditor.app.targetDownloader");
      */
     function downloadAvailableTargetFiles(objectHeartbeat) {
         if (!shouldStartDownloadingFiles(objectHeartbeat)) {
-            onDownloadFailed(objectID);
+            onDownloadFailed(); // reschedule this attempt for later
             return;
         }
 
@@ -109,7 +109,7 @@ createNameSpace("realityEditor.app.targetDownloader");
         } else {
             // count down the number of re-download attempts
             retryMap[objectHeartbeat.id].attemptsLeft -= 1;
-            console.log(objectName + ' has ' + retryMap[objectID].attemptsLeft + ' redownload attempts left');
+            console.log(objectName + ' has ' + retryMap[objectID].attemptsLeft + ' download attempts left');
         }
         retryMap[objectHeartbeat.id].previousTimestamp = Date.now();
 
@@ -295,13 +295,15 @@ createNameSpace("realityEditor.app.targetDownloader");
 
     /**
      * Respond to a failed download by trying to re-download after a delay
-     * Sends a UDP ping to start object discovery again.
      * Only schedules one at a time because a single ping has the potential
      * to re-download every object that still needs a target.
-     * Also clears the cache for that object so it freshly downloads next time
+     * Also clears the cache for the failed object so it freshly downloads next time
+     * @param {string?} objectId
      */
     function onDownloadFailed(objectId) {
-        window.localStorage.removeItem('realityEditor.previousDownloadInfo.' + objectId);
+        if (objectId) {
+            window.localStorage.removeItem('realityEditor.previousDownloadInfo.' + objectId);
+        }
 
         if (!isPingPending) {
             setTimeout(function () {

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -162,6 +162,7 @@ realityEditor.device.onload = function () {
 
     }).moveToDevelopMenu();
 
+    // Add a debug toggle to the develop menu that forces the targetDownloader to re-download each time instead of using the cache
     realityEditor.gui.settings.addToggle('Reset Target Cache', 'clear cache of downloaded target data', 'resetTargetCache',  '../../../svg/object.svg', false, function(newValue) {
         if (newValue) {
             realityEditor.app.targetDownloader.resetTargetDownloadCache();

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -162,6 +162,12 @@ realityEditor.device.onload = function () {
 
     }).moveToDevelopMenu();
 
+    realityEditor.gui.settings.addToggle('Reset Target Cache', 'clear cache of downloaded target data', 'resetTargetCache',  '../../../svg/object.svg', false, function(newValue) {
+        if (newValue) {
+            realityEditor.app.targetDownloader.resetTargetDownloadCache();
+        }
+    }).moveToDevelopMenu();
+
     // initialize additional services
     realityEditor.device.initService();
     realityEditor.device.touchInputs.initService();

--- a/src/gui/settings/index.js
+++ b/src/gui/settings/index.js
@@ -112,7 +112,6 @@ realityEditor.gui.settings.loadSettingsPost = function () {
         for (let key in dynamicSettings) {
 
             var settingInfo = dynamicSettings[key];
-            console.log(key, settingInfo);
 
             // add HTML element for this toggle if it doesn't exist already
             var existingElement = container.querySelector('#' + key);

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -1771,9 +1771,11 @@ realityEditor.network.onSettingPostMessage = function (msgContent) {
 
         for (let objectKey in realityEditor.objects) {
             var thisObject = realityEditor.getObject(objectKey);
+
             var isInitialized = realityEditor.app.targetDownloader.isObjectTargetInitialized(objectKey) || // either target downloaded
                                 objectKey === realityEditor.worldObjects.getLocalWorldId() || // or it's the _WORLD_local
-                                (thisObject.isWorldObject && !realityEditor.gui.settings.toggleStates.requireWorldLocalization); // or its a world and we dont require targets
+                                (thisObject.isWorldObject && !realityEditor.gui.settings.toggleStates.requireWorldLocalization); // or it's a world and we dont require targets
+
             thisObjects[objectKey] = {
                 name: thisObject.name,
                 ip: thisObject.ip,

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -1772,7 +1772,8 @@ realityEditor.network.onSettingPostMessage = function (msgContent) {
         for (let objectKey in realityEditor.objects) {
             var thisObject = realityEditor.getObject(objectKey);
             var isInitialized = realityEditor.app.targetDownloader.isObjectTargetInitialized(objectKey) || // either target downloaded
-                                objectKey === realityEditor.worldObjects.getLocalWorldId(); // or it's the _WORLD_local
+                                objectKey === realityEditor.worldObjects.getLocalWorldId() || // or it's the _WORLD_local
+                                (thisObject.isWorldObject && !realityEditor.gui.settings.toggleStates.requireWorldLocalization); // or its a world and we dont require targets
             thisObjects[objectKey] = {
                 name: thisObject.name,
                 ip: thisObject.ip,

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -343,6 +343,16 @@ realityEditor.network.addHeartbeatObject = function (beat) {
                     realityEditor.network.checkIfNewServer(beat.ip);//, objectKey);
                 }
             });
+        } else {
+            var isInitialized = realityEditor.app.targetDownloader.isObjectTargetInitialized(beat.id) || // either target downloaded
+                beat.id === realityEditor.worldObjects.getLocalWorldId() || // or it's the _WORLD_local
+                (objects[beat.id].isWorldObject && !realityEditor.gui.settings.toggleStates.requireWorldLocalization); // or it's a world and we dont require targets
+
+            if (!isInitialized && realityEditor.app.targetDownloader.isObjectReadyToRetryDownload(beat.id, beat.tcs)) {
+                setTimeout(function() {
+                    realityEditor.app.targetDownloader.downloadAvailableTargetFiles(beat);
+                }, 1000);
+            }
         }
     }
 };

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -344,6 +344,8 @@ realityEditor.network.addHeartbeatObject = function (beat) {
                 }
             });
         } else {
+            // if we receive a heartbeat of an object that has been created but it still needs targets
+            // try to re-download its target data if possible/necessary
             var isInitialized = realityEditor.app.targetDownloader.isObjectTargetInitialized(beat.id) || // either target downloaded
                 beat.id === realityEditor.worldObjects.getLocalWorldId() || // or it's the _WORLD_local
                 (objects[beat.id].isWorldObject && !realityEditor.gui.settings.toggleStates.requireWorldLocalization); // or it's a world and we dont require targets


### PR DESCRIPTION
Previous fixes were stop-gap, didn't actually keep track of which files had been previously downloaded/cached and which ones hadn't was leading to edge case bugs. This tries to fix it properly.