### PR TITLE
fix upside-down app to work even if orientation event triggers before…

### DIFF
--- a/src/gui/ar/index.js
+++ b/src/gui/ar/index.js
@@ -228,10 +228,17 @@ realityEditor.gui.ar.setProjectionMatrix = function(matrix) {
     
     var r = [];
 
+    var shouldMatrixBeFlipped = globalStates.realProjectionMatrix[0] !== globalStates.unflippedRealProjectionMatrix[0];
+
     globalStates.unflippedRealProjectionMatrix = realityEditor.gui.ar.utilities.copyMatrix(matrix);
     globalStates.realProjectionMatrix = realityEditor.gui.ar.utilities.copyMatrix(matrix);
     this.utilities.multiplyMatrix(scaleZ, matrix, r);
     this.utilities.multiplyMatrix(r, viewportScaling, globalStates.projectionMatrix);
+
+    // if setProjectionMatrix happens after onOrientationChanged, flip it if necessary
+    if (shouldMatrixBeFlipped) {
+        realityEditor.gui.ar.updateProjectionMatrix(true);
+    }
 };
 
 /**


### PR DESCRIPTION
… setProjectionMatrix

If you previously started the app while holding the phone upside down, the projection matrix would get initialized incorrectly.

(Reported https://forum.spatialtoolbox.vuforia.com/t/tool-does-not-attach-when-camera-is-on-the-left-side/25/7)