### PR TITLE
fix reference to distance getter function that was refactored

### DIFF
--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1165,7 +1165,7 @@ realityEditor.gui.ar.draw.drawTransformed = function (visibleObjects, objectKey,
                 var distance = activeVehicle.screenZ;
                 var distanceScale = realityEditor.gui.ar.getDistanceScale(activeVehicle);
                 // multiply the default min distance by the amount this frame distance has been scaled up
-                var distanceThreshold = (distanceScale * realityEditor.device.distanceScaling.defaultDistance);
+                var distanceThreshold = (distanceScale * realityEditor.device.distanceScaling.getDefaultDistance());
                 var isDistantVehicle = distance > distanceThreshold;
                 var isAlmostDistantVehicle = distance > (distanceThreshold * 0.8);
 

--- a/src/gui/ar/grouping.js
+++ b/src/gui/ar/grouping.js
@@ -364,7 +364,7 @@ createNameSpace("realityEditor.gui.ar.grouping");
 
             forEachGroupedFrame(params.frame, function(groupedFrame) {
                 // groupedFrame.distanceScale = params.frame.distanceScale;
-                groupedFrame.distanceScale = (groupedFrame.screenZ / realityEditor.device.distanceScaling.defaultDistance) / 0.85;
+                groupedFrame.distanceScale = (groupedFrame.screenZ / realityEditor.device.distanceScaling.getDefaultDistance()) / 0.85;
             }, true);
         });
         


### PR DESCRIPTION
I broke the way tools fade away when you move farther away from them when I refactored this variable. This fixes it.