### PR TITLE
adds temporary fix for instant image targets

### DIFF
--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -211,6 +211,31 @@ createNameSpace('realityEditor.app.callbacks');
 
             });
 
+            realityEditor.forEachObject(function(object, objectKey) {
+                if (typeof visibleObjects[objectKey] !== 'undefined') {
+                    // if it's a JPG instant target, correct the size so it matches as if it were DAT
+                    if (object.isJpgTarget) {
+                        // this fixes the scale, but the tracker still thinks it is further away
+                        // than it is, because the z translation is off by a factor
+                        let jpgTargetScaleFactor = 3;
+                        let scaleMatrix = [jpgTargetScaleFactor, 0, 0, 0,
+                            0, jpgTargetScaleFactor, 0, 0,
+                            0, 0, jpgTargetScaleFactor, 0,
+                            0, 0, 0, 1];
+                        let tempScaled = [];
+                        realityEditor.gui.ar.draw.utilities.multiplyMatrix(scaleMatrix, visibleObjects[objectKey], tempScaled);
+                        visibleObjects[objectKey] = tempScaled;
+
+                        // this fixes it if the image target is at the world origin, but drifts
+                        // towards the origin as you move the object further away
+                        // let jpgTargetScaleFactor2 = 0.333;
+                        // visibleObjects[objectKey][12] *= jpgTargetScaleFactor2;
+                        // visibleObjects[objectKey][13] *= jpgTargetScaleFactor2;
+                        // visibleObjects[objectKey][14] *= jpgTargetScaleFactor2;
+                    }
+                }
+            });
+
             realityEditor.gui.ar.draw.visibleObjectsCopy = visibleObjects;
         }
 

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -228,6 +228,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             var xmlFileName = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/target/target.xml';
             realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+            realityEditor.getObject(objectID).isJpgTarget = false;
 
         } else {
             console.log('failed to download DAT file: ' + fileName);
@@ -264,6 +265,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             console.log('attempting to add target via JPG of width ' + targetWidth);
             realityEditor.app.addNewMarkerJPG(fileName, objectID, targetWidth, moduleName + '.onMarkerAdded');
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+            realityEditor.getObject(objectID).isJpgTarget = true;
         } else {
             console.log('failed to download file: ' + fileName);
             targetDownloadStates[objectID].JPG = DownloadState.FAILED;

--- a/src/gui/ar/index.js
+++ b/src/gui/ar/index.js
@@ -554,12 +554,19 @@ realityEditor.gui.ar.getClosestFrameToScreenCoordinates = function(screenX, scre
  */
 realityEditor.gui.ar.getDistanceScale = function(activeVehicle) {
     var keys = realityEditor.getKeysFromVehicle(activeVehicle);
+    // check if the object is a jpgTarget and scale the distance from which it can be seen
+    // (compensates for bug in instant tracking that hasn't been fixed yet)
+    let objectTypeScale = 1;
+    let object = realityEditor.getObject(keys.objectKey);
+    if (object.isJpgTarget) {
+        objectTypeScale = 3;
+    }
     if (keys.nodeKey) {
         // it's a node, return its parent frame's value
         var parentFrame = realityEditor.getFrame(keys.objectKey, keys.frameKey);
-        return parentFrame.distanceScale || 1.0;
+        return (parentFrame.distanceScale * objectTypeScale) || objectTypeScale;
     } else {
         // it's a frame, return its own value
-        return activeVehicle.distanceScale || 1.0;
+        return (activeVehicle.distanceScale * objectTypeScale) || objectTypeScale;
     }
 };


### PR DESCRIPTION
This fixes half of the problem.

Intercepts matrices detected by Vuforia before they get passed to visibleObjects, and multiplies those that use the instant image target API by a scale factor. Ideally instead of scaling the size by 3x we would adjust the position so that it's just 3x closer to the camera, but this is the wrong place in the pipeline to do it and I'm not sure where the right place is.

Separately adjusts the visibility distance for instant image targets to be 3x as far because they are treated as being 3x as far away. 

Thoughts?