### PR TITLE
Allow server from different ports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         "globalScaleAdjustment": "writable",
         "globalStates": "writable",
         "httpPort": "writable",
+        "defaultPort": "writable",
         "hull": "writable",
         "io": "writable",
         "newNodeScaleFactor": "writable",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
         "globalScaleAdjustment": "writable",
         "globalStates": "writable",
         "httpPort": "writable",
-        "defaultPort": "writable",
+        "defaultHttpPort": "writable",
         "hull": "writable",
         "io": "writable",
         "newNodeScaleFactor": "writable",

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -124,8 +124,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             JPG: DownloadState.NOT_STARTED,
             MARKER_ADDED: DownloadState.NOT_STARTED
         };
-
-        var xmlAddress = 'http://' + objectHeartbeat.ip + ':' + httpPort + '/obj/' + objectName + '/target/target.xml';
+        var xmlAddress = 'http://' + objectHeartbeat.ip + ':' + realityEditor.network.getPort(objectHeartbeat) + '/obj/' + objectName + '/target/target.xml';
 
         // don't download XML again if already stored the same checksum version - effectively a way to cache the targets
         if (isAlreadyDownloaded(objectID, 'XML')) {
@@ -188,7 +187,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             console.log('successfully downloaded XML file: ' + fileName);
             targetDownloadStates[objectID].XML = DownloadState.SUCCEEDED;
 
-            var datAddress = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/target/target.dat';
+            var datAddress = 'http://' + object.ip + ':' + realityEditor.network.getPort(object) + '/obj/' + object.name + '/target/target.dat';
 
             // don't download again if already stored the same checksum version
             if (isAlreadyDownloaded(objectID, 'DAT')) {
@@ -218,14 +217,14 @@ createNameSpace("realityEditor.app.targetDownloader");
         var objectID = getObjectIDFromFilename(fileName);
         var object = realityEditor.getObject(objectID);
 
-        const jpgAddress = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/target/target.jpg';
+      const jpgAddress = 'http://' + object.ip + ':' + realityEditor.network.getPort(object) + '/obj/' + object.name + '/target/target.jpg';
 
         if (success) {
 
             console.log('successfully downloaded DAT file: ' + fileName);
             targetDownloadStates[objectID].DAT = DownloadState.SUCCEEDED;
 
-            var xmlFileName = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/target/target.xml';
+            var xmlFileName = 'http://' + object.ip + ':' + realityEditor.network.getPort(object) + '/obj/' + object.name + '/target/target.xml';
             realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
             realityEditor.getObject(objectID).isJpgTarget = false;
@@ -475,8 +474,8 @@ createNameSpace("realityEditor.app.targetDownloader");
             console.log('new checksum is ' + newChecksum);
             if (newChecksum === storedChecksum) {
                 // check that the files still exist in the app's temporary storage
-                var xmlFileName = 'http://' + objectHeartbeat.ip + ':' + httpPort + '/obj/' + objectName + '/target/target.xml';
-                var datFileName = 'http://' + objectHeartbeat.ip + ':' + httpPort + '/obj/' + objectName + '/target/target.dat';
+   var xmlFileName = 'http://' + objectHeartbeat.ip + ':' + realityEditor.network.getPort(objectHeartbeat) + '/obj/' + objectName + '/target/target.xml';
+                var datFileName = 'http://' + objectHeartbeat.ip + ':' + realityEditor.network.getPort(objectHeartbeat) + '/obj/' + objectName + '/target/target.dat';
 
                 realityEditor.app.getFilesExist([xmlFileName, datFileName], moduleName + '.doTargetFilesExist');
                 return;
@@ -506,14 +505,14 @@ createNameSpace("realityEditor.app.targetDownloader");
 
         // downloads the vuforia target.xml file if it doesn't have it yet
         if (needsXML) {
-            var xmlAddress = 'http://' + objectHeartbeat.ip + ':' + httpPort + '/obj/' + objectName + '/target/target.xml';
+            var xmlAddress = 'http://' + objectHeartbeat.ip + ':' + realityEditor.network.getPort(objectHeartbeat) + '/obj/' + objectName + '/target/target.xml';
             realityEditor.app.downloadFile(xmlAddress, moduleName + '.onTargetFileDownloaded');
             targetDownloadStates[objectID].XML = DownloadState.STARTED;
         }
 
         // downloads the vuforia target.dat file it it doesn't have it yet
         if (needsDAT) {
-            var datAddress = 'http://' + objectHeartbeat.ip + ':' + httpPort + '/obj/' + objectName + '/target/target.dat';
+            var datAddress = 'http://' + objectHeartbeat.ip + ':' + realityEditor.network.getPort(objectHeartbeat) + '/obj/' + objectName + '/target/target.dat';
             realityEditor.app.downloadFile(datAddress, moduleName + '.onTargetFileDownloaded');
             targetDownloadStates[objectID].DAT = DownloadState.STARTED;
         }

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -302,7 +302,8 @@ realityEditor.device.onload = function () {
     // see if we should open the modal
     let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';
 
-    if (shouldShowIntroModal) {
+    // if (shouldShowIntroModal) {
+    if (false) {
         let modalBody = "The Vuforia Spatial Toolbox is an open source research platform for exploring Augmented Reality and Spatial Computing.<br>" +
             "<ul>" +
             "</li>1. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/using-the-app'>Learn how to use the Spatial Toolbox</a><br><br></li>" +

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -300,10 +300,10 @@ realityEditor.device.onload = function () {
     }
 
     // see if we should open the modal
-    let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';
+    // let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';
 
     // if (shouldShowIntroModal) {
-    if (false) {
+    if (false) { // eslint-disable-line
         let modalBody = "The Vuforia Spatial Toolbox is an open source research platform for exploring Augmented Reality and Spatial Computing.<br>" +
             "<ul>" +
             "</li>1. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/using-the-app'>Learn how to use the Spatial Toolbox</a><br><br></li>" +

--- a/src/device/videoRecording.js
+++ b/src/device/videoRecording.js
@@ -151,8 +151,7 @@ createNameSpace("realityEditor.device.videoRecording");
         frame.integerVersion = 300;
 
         // add each node with a non-empty name
-
-        var videoPath = 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/videos/' + videoId + '.mp4';
+        var videoPath = 'http://' + object.ip + ':' + realityEditor.network.getPort(object) + '/obj/' + object.name + '/videos/' + videoId + '.mp4';
 
         var nodes = [
             {name: 'play', type: 'node', x: 40, y: 0},
@@ -269,7 +268,7 @@ createNameSpace("realityEditor.device.videoRecording");
         realityEditor.app.stopVideoRecording(videoId);
         var object = realityEditor.getObject(objectKey);
         var thisMsg = {
-            videoFilePath: 'http://' + object.ip + ':' + httpPort + '/obj/' + object.name + '/videos/' + videoId + '.mp4'
+            videoFilePath: 'http://' + object.ip + ':' + realityEditor.network.getPort(object) + '/obj/' + object.name + '/videos/' + videoId + '.mp4'
         };
         globalDOMCache["iframe" + frameKey].contentWindow.postMessage(JSON.stringify(thisMsg), '*');
     }

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -439,7 +439,7 @@ realityEditor.gui.ar.draw.update = function (visibleObjects) {
                 if (globalStates.guiState === 'ui' && !continueUpdate) { return; }
 
                 // if a DOM element hasn't been added for this frame yet, add it and load the correct src into an iframe
-                var frameUrl = "http://" + this.activeObject.ip + ":" + httpPort + "/obj/" + this.activeObject.name + "/frames/" + this.activeFrame.name + "/";
+                var frameUrl = "http://" + this.activeObject.ip + ":" + realityEditor.network.getPortByIp(this.activeObject.ip) + "/obj/" + this.activeObject.name + "/frames/" + this.activeFrame.name + "/";
                 this.addElement(frameUrl, objectKey, frameKey, null, this.activeType, this.activeVehicle);
                 
                 // if we're not viewing frames (e.g. should be viewing nodes instead), hide the frame

--- a/src/gui/ar/grouping.js
+++ b/src/gui/ar/grouping.js
@@ -212,8 +212,8 @@ createNameSpace("realityEditor.gui.ar.grouping");
                     memberContent.matrix = memberPositionData.matrix;
                 }
                 memberContent.lastEditor = globalStates.tempUuid;
-
-                var memberUrlEndpoint = 'http://' + objects[frame.objectId].ip + ':' + httpPort + '/object/' + frame.objectId + "/frame/" + frame.uuid + "/node/null/size";
+                
+                var memberUrlEndpoint = 'http://' + objects[frame.objectId].ip + ':' +  realityEditor.network.getPort(objects[frame.objectId]) + '/object/' + frame.objectId + "/frame/" + frame.uuid + "/node/null/size";
                 // + "/node/" + this.editingState.node + routeSuffix;
                 realityEditor.network.postData(memberUrlEndpoint, memberContent);
             }, false);

--- a/src/gui/crafting/blockMenu.js
+++ b/src/gui/crafting/blockMenu.js
@@ -229,7 +229,6 @@ createNameSpace("realityEditor.gui.crafting.blockMenu");
         var keys = this.crafting.eventHelper.getServerObjectLogicKeys(globalStates.currentLogic); // TODO: move to realityEditor.network module
         
         var urlEndpoint = 'http://' + keys.ip + ':' + keys.port + '/availableLogicBlocks';
-        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, req) {
             console.log("did get available blocks", req);
             callback(req);

--- a/src/gui/crafting/blockMenu.js
+++ b/src/gui/crafting/blockMenu.js
@@ -228,7 +228,8 @@ createNameSpace("realityEditor.gui.crafting.blockMenu");
     function menuLoadBlocks(callback) {
         var keys = this.crafting.eventHelper.getServerObjectLogicKeys(globalStates.currentLogic); // TODO: move to realityEditor.network module
         
-        var urlEndpoint = 'http://' + keys.ip + ':' + httpPort + '/availableLogicBlocks';
+        var urlEndpoint = 'http://' + keys.ip + ':' + keys.port + '/availableLogicBlocks';
+        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, req) {
             console.log("did get available blocks", req);
             callback(req);

--- a/src/gui/crafting/eventHelper.js
+++ b/src/gui/crafting/eventHelper.js
@@ -380,6 +380,7 @@ realityEditor.gui.crafting.eventHelper.getServerObjectLogicKeys = function(logic
             if (objects[objectKey].frames[frameKey].nodes.hasOwnProperty(logic.uuid)) {
                 var keys = {
                     ip: objects[objectKey].ip,
+                    port: realityEditor.network.getPort(objects[objectKey]),
                     objectKey: objectKey,
                     frameKey: frameKey,
                     logicKey: logic.uuid
@@ -792,7 +793,7 @@ realityEditor.gui.crafting.eventHelper.openBlockSettings = function(block) {
     this.changeDatacraftingDisplayForMenu('none');
     
     var keys = this.getServerObjectLogicKeys(globalStates.currentLogic, block);
-    var settingsUrl = 'http://' + keys.ip + ':' + httpPort + '/logicBlock/' + block.type + "/index.html";
+    var settingsUrl = 'http://' + keys.ip + ':' + keys.port + '/logicBlock/' + block.type + "/index.html";
     var craftingMenusContainer = document.getElementById('craftingMenusContainer');
     var blockSettingsContainer = document.createElement('iframe');
     blockSettingsContainer.setAttribute('id', 'blockSettingsContainer');
@@ -867,7 +868,8 @@ realityEditor.gui.crafting.eventHelper.openNodeSettings = function() {
             
             version: realityEditor.getObject(keys.objectKey).integerVersion,
             ip: keys.ip,
-            httpPort: httpPort,
+            httpPort: keys.port,
+            port:keys.port,
             
             objectKey: keys.objectKey,
             frameKey: keys.frameKey,

--- a/src/gui/crafting/index.js
+++ b/src/gui/crafting/index.js
@@ -244,11 +244,11 @@ realityEditor.gui.crafting.getBlockIcon = function(logic, blockName, labelSwitch
     // download icon to cache if not already there
     if (realityEditor.gui.crafting.blockIconCache[keys.logicKey][blockName] === undefined) {
         var icon = new Image();
-        icon.src = 'http://' + keys.ip + ':' + httpPort + '/logicBlock/' + blockName + "/icon.svg";
+        icon.src = 'http://' + keys.ip + ':' + keys.port + '/logicBlock/' + blockName + "/icon.svg";
         realityEditor.gui.crafting.blockIconCache[keys.logicKey][blockName] = icon;
 
         var label = new Image();
-        label.src = 'http://' + keys.ip + ':' + httpPort + '/logicBlock/' + blockName + "/label.svg";
+        label.src = 'http://' + keys.ip + ':' + keys.port + '/logicBlock/' + blockName + "/label.svg";
         realityEditor.gui.crafting.blockIconCache[keys.logicKey][blockName+"label"] = label;
     }
 
@@ -268,7 +268,7 @@ realityEditor.gui.crafting.getSrcForCustomIcon = function(logic) {
     }
     var keys = realityEditor.gui.crafting.eventHelper.getServerObjectLogicKeys(logic);
     if (keys) {
-        return 'http://' + keys.ip + ':' + httpPort + '/logicNodeIcon/' + realityEditor.getObject(keys.objectKey).name + "/" + keys.logicKey + ".jpg";
+        return 'http://' + keys.ip + ':' + keys.port + '/logicNodeIcon/' + realityEditor.getObject(keys.objectKey).name + "/" + keys.logicKey + ".jpg";
 
     }
 };

--- a/src/gui/memory/index.js
+++ b/src/gui/memory/index.js
@@ -102,7 +102,7 @@ function MemoryContainer(element) {
 
 MemoryContainer.prototype.set = function(obj) {
     this.obj = obj;
-    var urlBase = 'http://' + obj.ip + ':8080/obj/' + obj.name + '/memory/';
+    var urlBase = 'http://' + obj.ip + ':'+realityEditor.network.getPortByIp(obj.ip)+'/obj/' + obj.name + '/memory/';
     var image = urlBase + 'memory.jpg';
 
     this.backgroundImage = document.createElement('img');
@@ -632,7 +632,7 @@ function uploadImageToServer() {
     // Set up the request.
     var xhr = new XMLHttpRequest();
 
-    var postUrl = 'http://' + objects[currentMemory.id].ip + ':' + httpPort + '/object/' + currentMemory.id + "/memory";
+    var postUrl = 'http://' + objects[currentMemory.id].ip + ':' + realityEditor.network.getPort(objects[currentMemory.id]) + '/object/' + currentMemory.id + "/memory";
 
     // Open the connection.
     xhr.open('POST', postUrl, true);

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -482,9 +482,9 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
                 container.dataset.src = '_PLACEHOLDER_';
             } else {
                 // var thisUrl = 'frames/' + element.name + '.html';
-                var thisUrl = 'http://' + realityElements[i].proxyIP + ':' + httpPort + '/frames/' + element.name + '/index.html';
+                var thisUrl = 'http://' + realityElements[i].proxyIP + ':' + realityEditor.network.getPortByIp(realityElements[i].proxyIP) + '/frames/' + element.name + '/index.html';
                 // var gifUrl = 'frames/pocketAnimations/' + element.name + '.gif';
-                var gifUrl = 'http://' + realityElements[i].proxyIP + ':' + httpPort + '/frames/' + element.name + '/icon.gif';
+                var gifUrl = 'http://' + realityElements[i].proxyIP + ':' + realityEditor.network.getPortByIp(realityElements[i].proxyIP) + '/frames/' + element.name + '/icon.gif';
                 container.dataset.src = thisUrl;
 
                 container.dataset.name = element.name;

--- a/src/network/availableFrames.js
+++ b/src/network/availableFrames.js
@@ -45,8 +45,8 @@ createNameSpace("realityEditor.network.availableFrames");
      */
     function onNewServerDetected(serverIP) {
         console.log('availableFrames discovered server: ' + serverIP);
-        var urlEndpoint = 'http://' + serverIP + ':' + httpPort + '/availableFrames/';
-
+        var urlEndpoint = 'http://' + serverIP + ':' + realityEditor.network.getPortByIp(serverIP) + '/availableFrames/';
+        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (_nullObj, _nullFrame, _nullNode, response) {
             framesPerServer[serverIP] = response;
             console.log(framesPerServer);
@@ -279,7 +279,7 @@ createNameSpace("realityEditor.network.availableFrames");
      * @return {string} - image src path
      */
     function getFrameIconSrcByIP(serverIP, frameName) {
-        return 'http://' + serverIP + ':' + httpPort + '/frames/' + frameName + '/icon.gif';
+        return 'http://' + serverIP + ':' + realityEditor.network.getPortByIp(serverIP) + '/frames/' + frameName + '/icon.gif';
     }
 
     /**
@@ -290,7 +290,7 @@ createNameSpace("realityEditor.network.availableFrames");
      */
     function getFrameSrc(objectKey, frameName) {
         var serverIP = getServerIPForObjectFrames(objectKey);
-        return 'http://' + serverIP + ':' + httpPort + '/frames/' + frameName + '/index.html';
+        return 'http://' + serverIP + ':' + realityEditor.network.getPort(objects[objectKey]) + '/frames/' + frameName + '/index.html';
     }
     
     var serverFrameInfoUpdatedCallbacks = [];

--- a/src/network/availableFrames.js
+++ b/src/network/availableFrames.js
@@ -46,7 +46,6 @@ createNameSpace("realityEditor.network.availableFrames");
     function onNewServerDetected(serverIP) {
         console.log('availableFrames discovered server: ' + serverIP);
         var urlEndpoint = 'http://' + serverIP + ':' + realityEditor.network.getPortByIp(serverIP) + '/availableFrames/';
-        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (_nullObj, _nullFrame, _nullNode, response) {
             framesPerServer[serverIP] = response;
             console.log(framesPerServer);

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -68,14 +68,14 @@ realityEditor.network.addPostMessageHandler = function(messageName, callback) {
 };
 
 realityEditor.network.getPort = function(object) {
-    let serverPort = defaultPort;
+    let serverPort = defaultHttpPort;
     if (object.hasOwnProperty("port")) {
         serverPort = object.port;
     }
     return serverPort;
 };
 realityEditor.network.getPortByIp = function(ip) {
-    let serverPort = defaultPort;
+    let serverPort = defaultHttpPort;
     
     let thisObject = null
     for(let key in objects){

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -351,7 +351,6 @@ realityEditor.network.addHeartbeatObject = function (beat) {
     if (beat.id) {
         if (!objects[beat.id]) {
             // download the object data from its server
-            
             this.getData(beat.id, null, null, 'http://' + beat.ip + ':' + realityEditor.network.getPort(beat) + '/object/' + beat.id, function (objectKey, frameKey, nodeKey, msg) {
                 if (msg && objectKey) {
                     // add the object
@@ -762,7 +761,6 @@ realityEditor.network.onAction = function (action) {
         if (thisFrame) {
 
             let urlEndpoint = 'http://' + objects[thisAction.reloadFrame.object].ip + ':' + realityEditor.network.getPort(objects[thisAction.reloadFrame.object]) + '/object/' + thisAction.reloadFrame.object + '/frame/' + thisAction.reloadFrame.frame;
-            
             this.getData(thisAction.reloadFrame.object, thisAction.reloadFrame.frame, thisAction.reloadFrame.node, urlEndpoint, function(objectKey, frameKey, nodeKey, res) {
                 console.log('got frame');
                 
@@ -848,7 +846,6 @@ realityEditor.network.onAction = function (action) {
     if (thisAction.loadMemory) {
         var id = thisAction.loadMemory.object;
         let urlEndpoint = 'http://' + thisAction.loadMemory.ip + ':' + realityEditor.network.getPort(objects[id]) + '/object/' + id;
-
         this.getData(id, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
 
             // this.getData(url, id, function (req, thisKey) {
@@ -1878,7 +1875,6 @@ realityEditor.network.onSettingPostMessage = function (msgContent) {
 realityEditor.network.discoverObjectsFromServer = function(serverUrl) {
     var prefix = (serverUrl.indexOf('http://') === -1) ? ('http://') : ('');
     var url = prefix + serverUrl + '/allObjects/';
-    console.log("++++++++++++++++++++++++++",url);
     realityEditor.network.getData(null, null, null, url, function(_nullObj, _nullFrame, _nullNode, msg) {
         console.log('got all objects');
         console.log(msg);
@@ -2100,7 +2096,6 @@ realityEditor.network.updateNodeBlocksSettingsData = function(ip, objectKey, fra
  * @param {function<string, string, string, object>} callback
  */
 realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback) {
-    console.log("++++++++++++++++++++++++++",url);
     if (!nodeKey) nodeKey = null;
     if (!frameKey) frameKey = null;
     var _this = this;

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -71,7 +71,7 @@ realityEditor.network.getPort = function(object) {
     let serverPort = defaultPort;
     if (object.hasOwnProperty("port")) {
         serverPort = object.port;
-    };
+    }
     return serverPort;
 };
 realityEditor.network.getPortByIp = function(ip) {
@@ -87,8 +87,8 @@ realityEditor.network.getPortByIp = function(ip) {
     if(thisObject !== null) {
         if (thisObject.hasOwnProperty("port")) {
             serverPort = thisObject.port;
-        };
-    };
+        }
+    }
     return serverPort;
 };
 

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -67,6 +67,34 @@ realityEditor.network.addPostMessageHandler = function(messageName, callback) {
     });
 };
 
+realityEditor.network.getPort = function(object) {
+    let serverPort = defaultPort;
+    if (object.hasOwnProperty("port")) {
+        serverPort = object.port;
+    };
+    return serverPort;
+};
+realityEditor.network.getPortByIp = function(ip) {
+    let serverPort = defaultPort;
+    
+    let thisObject = null
+    for(let key in objects){
+        if(ip === objects[key].ip) {
+            thisObject = objects[key];
+            break;
+        }
+    }
+    if(thisObject !== null) {
+        if (thisObject.hasOwnProperty("port")) {
+            serverPort = thisObject.port;
+        };
+    };
+    return serverPort;
+};
+
+
+
+
 /**
  * @type {Array.<{messageName: string, callback: function}>}
  */
@@ -323,7 +351,8 @@ realityEditor.network.addHeartbeatObject = function (beat) {
     if (beat.id) {
         if (!objects[beat.id]) {
             // download the object data from its server
-            this.getData(beat.id, null, null, 'http://' + beat.ip + ':' + httpPort + '/object/' + beat.id, function (objectKey, frameKey, nodeKey, msg) {
+            
+            this.getData(beat.id, null, null, 'http://' + beat.ip + ':' + realityEditor.network.getPort(beat) + '/object/' + beat.id, function (objectKey, frameKey, nodeKey, msg) {
                 if (msg && objectKey) {
                     // add the object
                     objects[objectKey] = msg;
@@ -645,7 +674,7 @@ realityEditor.network.onAction = function (action) {
         }
 
         if (thisAction.reloadLink.object in objects) {
-            let urlEndpoint = 'http://' + objects[thisAction.reloadLink.object].ip + ':' + httpPort + '/object/' + thisAction.reloadLink.object + '/frame/' +thisAction.reloadLink.frame;
+            let urlEndpoint = 'http://' + objects[thisAction.reloadLink.object].ip + ':' + realityEditor.network.getPort(objects[thisAction.reloadLink.object]) + '/object/' + thisAction.reloadLink.object + '/frame/' +thisAction.reloadLink.frame;
             this.getData(thisAction.reloadLink.object, thisAction.reloadLink.frame, null, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
                 
             // });
@@ -699,7 +728,7 @@ realityEditor.network.onAction = function (action) {
 
         if (thisAction.reloadObject.object in objects) {
 
-            let urlEndpoint = 'http://' + objects[thisAction.reloadObject.object].ip + ':' + httpPort + '/object/' + thisAction.reloadObject.object;
+            let urlEndpoint = 'http://' + objects[thisAction.reloadObject.object].ip + ':' + realityEditor.network.getPort(objects[thisAction.reloadObject.object]) + '/object/' + thisAction.reloadObject.object;
             this.getData(thisAction.reloadObject.object, thisAction.reloadObject.frame, null, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
 
                 if (objects[objectKey].integerVersion < 170) {
@@ -732,7 +761,7 @@ realityEditor.network.onAction = function (action) {
         
         if (thisFrame) {
 
-            let urlEndpoint = 'http://' + objects[thisAction.reloadFrame.object].ip + ':' + httpPort + '/object/' + thisAction.reloadFrame.object + '/frame/' + thisAction.reloadFrame.frame;
+            let urlEndpoint = 'http://' + objects[thisAction.reloadFrame.object].ip + ':' + realityEditor.network.getPort(objects[thisAction.reloadFrame.object]) + '/object/' + thisAction.reloadFrame.object + '/frame/' + thisAction.reloadFrame.frame;
             
             this.getData(thisAction.reloadFrame.object, thisAction.reloadFrame.frame, thisAction.reloadFrame.node, urlEndpoint, function(objectKey, frameKey, nodeKey, res) {
                 console.log('got frame');
@@ -793,7 +822,7 @@ realityEditor.network.onAction = function (action) {
         if (thisFrame !== null) {
             // TODO: getData         webServer.get('/object/*/') ... instead of /object/node
 
-            let urlEndpoint = 'http://' + objects[thisAction.reloadNode.object].ip + ':' + httpPort + '/object/' + thisAction.reloadNode.object + '/frame/' + thisAction.reloadNode.frame + '/node/' + thisAction.reloadNode.node + '/';
+            let urlEndpoint = 'http://' + objects[thisAction.reloadNode.object].ip + ':' + realityEditor.network.getPort(objects[thisAction.reloadNode.object]) + '/object/' + thisAction.reloadNode.object + '/frame/' + thisAction.reloadNode.frame + '/node/' + thisAction.reloadNode.node + '/';
             this.getData(thisAction.reloadObject.object, thisAction.reloadObject.frame, thisAction.reloadObject.node, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
 
             // this.getData(
@@ -818,7 +847,7 @@ realityEditor.network.onAction = function (action) {
     
     if (thisAction.loadMemory) {
         var id = thisAction.loadMemory.object;
-        let urlEndpoint = 'http://' + thisAction.loadMemory.ip + ':' + httpPort + '/object/' + id;
+        let urlEndpoint = 'http://' + thisAction.loadMemory.ip + ':' + realityEditor.network.getPort(objects[id]) + '/object/' + id;
 
         this.getData(id, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
 
@@ -1458,7 +1487,7 @@ realityEditor.network.onInternalPostMessage = function (e) {
             content.scale = positionData.scale;
 
             content.lastEditor = globalStates.tempUuid;
-            let urlEndpoint = 'http://' + objects[objectKey].ip + ':' + httpPort + '/object/' + msgContent.object + "/frame/" + msgContent.frame + "/node/" + node.uuid + "/nodeSize/";
+            let urlEndpoint = 'http://' + objects[objectKey].ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + msgContent.object + "/frame/" + msgContent.frame + "/node/" + node.uuid + "/nodeSize/";
             realityEditor.network.postData(urlEndpoint, content);
         });
     }
@@ -1741,7 +1770,7 @@ realityEditor.network.postNewNodeName = function(ip, objectKey, frameKey, nodeKe
         lastEditor: globalStates.tempUuid
     };
 
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" +  frameKey + "/node/" + nodeKey + "/rename/", contents);
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" +  frameKey + "/node/" + nodeKey + "/rename/", contents);
 };
 
 /**
@@ -1791,6 +1820,7 @@ realityEditor.network.onSettingPostMessage = function (msgContent) {
             thisObjects[objectKey] = {
                 name: thisObject.name,
                 ip: thisObject.ip,
+                port: realityEditor.network.getPort(thisObject),
                 version: thisObject.version,
                 frames: {},
                 initialized: isInitialized
@@ -1848,6 +1878,7 @@ realityEditor.network.onSettingPostMessage = function (msgContent) {
 realityEditor.network.discoverObjectsFromServer = function(serverUrl) {
     var prefix = (serverUrl.indexOf('http://') === -1) ? ('http://') : ('');
     var url = prefix + serverUrl + '/allObjects/';
+    console.log("++++++++++++++++++++++++++",url);
     realityEditor.network.getData(null, null, null, url, function(_nullObj, _nullFrame, _nullNode, msg) {
         console.log('got all objects');
         console.log(msg);
@@ -1915,7 +1946,7 @@ realityEditor.network.deleteFrameFromObject = function(ip, objectKey, frameKey) 
         console.log('cant tell if local or global... frame has already been deleted on editor');
     }
     var contents = {lastEditor: globalStates.tempUuid};
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frames/" + frameKey, contents);
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frames/" + frameKey, contents);
 };
 
 /**
@@ -1928,7 +1959,7 @@ realityEditor.network.deleteFrameFromObject = function(ip, objectKey, frameKey) 
 realityEditor.network.postNewFrame = function(ip, objectKey, contents, callback) {
     this.cout("I am adding a frame: " + ip);
     contents.lastEditor = globalStates.tempUuid;
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/addFrame/", contents, callback);
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/addFrame/", contents, callback);
 };
 
 /**
@@ -1952,7 +1983,7 @@ realityEditor.network.createCopyOfFrame = function(ip, objectKey, frameKey, cont
         matrix: oldFrame.ar.matrix
     };
     
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frames/" + frameKey  + "/copyFrame/", contents, function(err, response) {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frames/" + frameKey  + "/copyFrame/", contents, function(err, response) {
         console.log(err);
         console.log(response);
         
@@ -1990,9 +2021,9 @@ realityEditor.network.deleteLinkFromObject = function (ip, objectKey, frameKey, 
     this.cout("I am deleting a link: " + ip);
 
     if (this.testVersion(objectKey) > 162) {
-        this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/editor/" + globalStates.tempUuid + "/deleteLink/");
+        this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/editor/" + globalStates.tempUuid + "/deleteLink/");
     } else {
-        this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/link/" + linkKey);
+        this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/link/" + linkKey);
     }
 };
 
@@ -2006,7 +2037,7 @@ realityEditor.network.deleteLinkFromObject = function (ip, objectKey, frameKey, 
 realityEditor.network.deleteNodeFromObject = function (ip, objectKey, frameKey, nodeKey) {
     // generate action for all links to be reloaded after upload
     this.cout("I am deleting a node: " + ip);
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/editor/" + globalStates.tempUuid + "/deleteLogicNode/");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/editor/" + globalStates.tempUuid + "/deleteLogicNode/");
 };
 
 /**
@@ -2021,7 +2052,7 @@ realityEditor.network.deleteBlockFromObject = function (ip, objectKey, frameKey,
     // generate action for all links to be reloaded after upload
     this.cout("I am deleting a block: " + ip);
     // /logic/*/*/block/*/
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/block/" + blockKey + "/editor/" + globalStates.tempUuid + "/deleteBlock/");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/block/" + blockKey + "/editor/" + globalStates.tempUuid + "/deleteBlock/");
 };
 
 /**
@@ -2036,7 +2067,7 @@ realityEditor.network.deleteBlockLinkFromObject = function (ip, objectKey, frame
     // generate action for all links to be reloaded after upload
     this.cout("I am deleting a block link: " + ip);
     // /logic/*/*/link/*/
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/link/" + linkKey + "/editor/" + globalStates.tempUuid + "/deleteBlockLink/");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/link/" + linkKey + "/editor/" + globalStates.tempUuid + "/deleteBlockLink/");
 };
 
 /**
@@ -2047,7 +2078,7 @@ realityEditor.network.deleteBlockLinkFromObject = function (ip, objectKey, frame
  * @param {string} nodeKey
  */
 realityEditor.network.updateNodeBlocksSettingsData = function(ip, objectKey, frameKey, nodeKey) {
-    var urlEndpoint = 'http://' + ip + ':' + httpPort + '/object/' + objectKey + "/node/" + nodeKey;
+    var urlEndpoint = 'http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/node/" + nodeKey;
     this.getData(objectKey, frameKey, nodeKey, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
         for (var blockKey in res.blocks) {
             if (!res.blocks.hasOwnProperty(blockKey)) continue;
@@ -2069,6 +2100,7 @@ realityEditor.network.updateNodeBlocksSettingsData = function(ip, objectKey, fra
  * @param {function<string, string, string, object>} callback
  */
 realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback) {
+    console.log("++++++++++++++++++++++++++",url);
     if (!nodeKey) nodeKey = null;
     if (!frameKey) frameKey = null;
     var _this = this;
@@ -2242,7 +2274,7 @@ realityEditor.network.postNewLink = function (ip, objectKey, frameKey, linkKey, 
     // generate action for all links to be reloaded after upload
     thisLink.lastEditor = globalStates.tempUuid;
     this.cout("sending Link");
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + '/addLink/', thisLink, function (err, response) {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + '/addLink/', thisLink, function (err, response) {
         console.log(response);
     });
 };
@@ -2257,7 +2289,7 @@ realityEditor.network.postNewLink = function (ip, objectKey, frameKey, linkKey, 
  */
 realityEditor.network.postNewNode = function (ip, objectKey, frameKey, nodeKey, thisNode) {
     thisNode.lastEditor = globalStates.tempUuid;
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + '/frame/' + frameKey + '/node/' + nodeKey + '/addNode', thisNode, function (err) {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + '/frame/' + frameKey + '/node/' + nodeKey + '/addNode', thisNode, function (err) {
         if (err) {
             console.log('postNewNode error:', err);
         }
@@ -2279,7 +2311,7 @@ realityEditor.network.postNewBlockLink = function (ip, objectKey, frameKey, node
     var linkMessage = this.realityEditor.gui.crafting.utilities.convertBlockLinkToServerFormat(thisLink);
     linkMessage.lastEditor = globalStates.tempUuid;
     // /logic/*/*/link/*/
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/link/" + linkKey + "/addBlockLink/", linkMessage, function () {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/link/" + linkKey + "/addBlockLink/", linkMessage, function () {
     });
 };
 
@@ -2297,7 +2329,7 @@ realityEditor.network.postNewLogicNode = function (ip, objectKey, frameKey, node
 
     var simpleLogic = this.realityEditor.gui.crafting.utilities.convertLogicToServerFormat(logic);
     simpleLogic.lastEditor = globalStates.tempUuid;
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/addLogicNode/", simpleLogic, function () {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/addLogicNode/", simpleLogic, function () {
     });
 };
 
@@ -2318,7 +2350,7 @@ realityEditor.network.postNewBlockPosition = function (ip, objectKey, frameKey, 
     
     content.lastEditor = globalStates.tempUuid;
     if (typeof content.x === "number" && typeof content.y === "number") {
-        this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + logicKey + "/block/" + blockKey + "/blockPosition/", content, function () {
+        this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + logicKey + "/block/" + blockKey + "/blockPosition/", content, function () {
         });
     }
 };
@@ -2337,7 +2369,7 @@ realityEditor.network.postNewBlock = function (ip, objectKey, frameKey, nodeKey,
     // /logic/*/*/block/*/
     block.lastEditor = globalStates.tempUuid;
 
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/block/" + blockKey + "/addBlock/", block, function () {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/block/" + blockKey + "/addBlock/", block, function () {
     });
 };
 
@@ -2446,9 +2478,9 @@ realityEditor.network.sendResetContent = function (objectKey, frameKey, nodeKey,
         realityEditor.gui.ar.utilities.setAverageScale(objects[objectKey]);
         var urlEndpoint;
         if (type !== 'ui') {
-            urlEndpoint = 'http://' + objects[objectKey].ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/nodeSize/";
+            urlEndpoint = 'http://' + objects[objectKey].ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/nodeSize/";
         } else {
-            urlEndpoint = 'http://' + objects[objectKey].ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/size/";
+            urlEndpoint = 'http://' + objects[objectKey].ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/size/";
         }
         console.log('url endpoint = ' + urlEndpoint);
         this.postData(urlEndpoint, content);
@@ -2461,7 +2493,7 @@ realityEditor.network.sendResetContent = function (objectKey, frameKey, nodeKey,
  * @param {string} objectKey
  */
 realityEditor.network.sendSaveCommit = function (objectKey) {
-   var urlEndpoint = 'http://' + objects[objectKey].ip + ':' + httpPort + '/object/' + objectKey + "/saveCommit/";
+   var urlEndpoint = 'http://' + objects[objectKey].ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/saveCommit/";
    var content = {};
    this.postData(urlEndpoint, content, function(){});
 };
@@ -2472,7 +2504,7 @@ realityEditor.network.sendSaveCommit = function (objectKey) {
  * @param {string} objectKey
  */
 realityEditor.network.sendResetToLastCommit = function (objectKey) {
-    var urlEndpoint = 'http://' + objects[objectKey].ip + ':' + httpPort + '/object/' + objectKey + "/resetToLastCommit/";
+    var urlEndpoint = 'http://' + objects[objectKey].ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/resetToLastCommit/";
     var content = {};
     this.postData(urlEndpoint, content, function(){});
 };
@@ -2514,6 +2546,7 @@ realityEditor.network.onElementLoad = function (objectKey, frameKey, nodeKey) {
         objectData: {},
         node: nodeKey,
         nodes: simpleNodes,
+        port: realityEditor.network.getPort(object),
         interface: globalStates.interface
     };
 
@@ -2523,7 +2556,8 @@ realityEditor.network.onElementLoad = function (objectKey, frameKey, nodeKey) {
 
     if (object && object.ip) {
         newStyle.objectData = {
-            ip: object.ip
+            ip: object.ip,
+            port: realityEditor.network.getPort(object)
         };
     }
     let activeKey = nodeKey || frameKey;
@@ -2582,7 +2616,7 @@ realityEditor.network.onElementLoad = function (objectKey, frameKey, nodeKey) {
  */
 realityEditor.network.postNewLockToNode = function (ip, objectKey, frameKey, nodeKey, content) {
     console.log("sending node lock (" + content.lockType + ")");
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/addLock/", content, function () {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/addLock/", content, function () {
     });
 };
 
@@ -2599,7 +2633,7 @@ realityEditor.network.deleteLockFromNode = function (ip, objectKey, frameKey, no
 // generate action for all links to be reloaded after upload
     console.log("I am deleting a lock: " + ip);
     console.log("password is " + password);
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/password/" + password + "/deleteLock/");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/node/" + nodeKey + "/password/" + password + "/deleteLock/");
     //console.log("deleteLockFromObject");
 };
 
@@ -2615,7 +2649,7 @@ realityEditor.network.postNewLockToLink = function (ip, objectKey, frameKey, lin
 
 // generate action for all links to be reloaded after upload
     console.log("sending link lock (" + content.lockType + ")");
-    this.postData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/addLock/", content, function () {
+    this.postData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/addLock/", content, function () {
     });
     // postData('http://' +ip+ ':' + httpPort+"/", content);
     //console.log('post --- ' + 'http://' + ip + ':' + httpPort + '/object/' + thisObjectKey + "/link/lock/" + thisLinkKey);
@@ -2634,7 +2668,7 @@ realityEditor.network.deleteLockFromLink = function (ip, objectKey, frameKey, li
 // generate action for all links to be reloaded after upload
     console.log("I am deleting a link lock: " + ip);
     console.log("lockPassword is " + password);
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/password/" + password + "/deleteLock/");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/link/" + linkKey + "/password/" + password + "/deleteLock/");
     //console.log('delete --- ' + 'http://' + ip + ':' + httpPort + '/object/' + thisObjectKey + "/link/lock/" + thisLinkKey + "/password/" + authenticatedUser);
 };
 
@@ -2649,7 +2683,7 @@ realityEditor.network.deleteLockFromLink = function (ip, objectKey, frameKey, li
  */
 realityEditor.network.updateFrameVisualization = function(ip, objectKey, frameKey, newVisualization, oldVisualizationPositionData) {
 
-    var urlEndpoint = 'http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/visualization/";
+    var urlEndpoint = 'http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/visualization/";
     var content = {
         visualization: newVisualization,
         oldVisualizationPositionData: oldVisualizationPositionData
@@ -2668,7 +2702,7 @@ realityEditor.network.updateFrameVisualization = function(ip, objectKey, frameKe
  * @param {string} frameKey
  */
 realityEditor.network.deletePublicData = function(ip, objectKey, frameKey) {
-    this.deleteData('http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/publicData");
+    this.deleteData('http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/publicData");
 };
 
 /**
@@ -2681,7 +2715,7 @@ realityEditor.network.deletePublicData = function(ip, objectKey, frameKey) {
  */
 realityEditor.network.postPublicData = function(ip, objectKey, frameKey, publicData) {
 
-    var urlEndpoint = 'http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/publicData";
+    var urlEndpoint = 'http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/publicData";
     var content = {
         publicData: publicData,
         lastEditor: globalStates.tempUuid
@@ -2713,7 +2747,7 @@ realityEditor.network.postMessageIntoFrame = function(frameKey, message) {
  * @param {string|null} newGroupID - either groupId or null for none
  */
 realityEditor.network.updateGroupings = function(ip, objectKey, frameKey, newGroupID) {
-    var urlEndpoint = 'http://' + ip + ':' + httpPort + '/object/' + objectKey + "/frame/" + frameKey + "/group/";
+    var urlEndpoint = 'http://' + ip + ':' + realityEditor.network.getPort(objects[objectKey]) + '/object/' + objectKey + "/frame/" + frameKey + "/group/";
     var content = {
         group: newGroupID,
         lastEditor: globalStates.tempUuid
@@ -2743,7 +2777,7 @@ realityEditor.network.postVehiclePosition = function(activeVehicle, ignoreMatrix
 
         var endpointSuffix = realityEditor.isVehicleAFrame(activeVehicle) ? "/size/" : "/nodeSize/";
         var keys = realityEditor.getKeysFromVehicle(activeVehicle);
-        var urlEndpoint = 'http://' + realityEditor.getObject(keys.objectKey).ip + ':' + httpPort + '/object/' + keys.objectKey + "/frame/" + keys.frameKey + "/node/" + keys.nodeKey + endpointSuffix;
+        var urlEndpoint = 'http://' + realityEditor.getObject(keys.objectKey).ip + ':' + realityEditor.network.getPort(realityEditor.getObject(keys.objectKey)) + '/object/' + keys.objectKey + "/frame/" + keys.frameKey + "/node/" + keys.nodeKey + endpointSuffix;
         realityEditor.network.postData(urlEndpoint, content);
     }
 };

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -151,7 +151,6 @@ createNameSpace("realityEditor.network.realtime");
      * connection with, adds a new 'realityServers' socket connection
      */
     function setupServerSockets() {
-        var serverPort = 8080;
         var ipList = [];
         realityEditor.forEachObject(function(object, _objectKey) {
             if (ipList.indexOf(object.ip) === -1) {

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -60,8 +60,7 @@ createNameSpace("realityEditor.network.realtime");
         
         if (object.ip === '127.0.0.1') { return; } // ignore localhost, no need for realtime because only one client
 
-        var serverPort = 8080;
-        var serverAddress = 'http://' + object.ip + ':' + serverPort;
+        var serverAddress = 'http://' + object.ip + ':' + realityEditor.network.getPort(object);
         var socketsIps = realityEditor.network.realtime.getSocketIPsForSet('realityServers');
         if (socketsIps.indexOf(serverAddress) < 0) {
             // if we haven't already created a socket connection to that IP, create a new one,
@@ -160,7 +159,7 @@ createNameSpace("realityEditor.network.realtime");
             }
         });
         ipList.forEach(function(ip) {
-            var serverAddress = 'http://' + ip + ':' + serverPort;
+            var serverAddress = 'http://' + ip + ':' + realityEditor.network.getPortByIp(ip);
             var socketsIps = realityEditor.network.realtime.getSocketIPsForSet('realityServers');
             if (socketsIps.indexOf(serverAddress) < 0) {
                 // if we haven't already created a socket connection to that IP, create a new one,

--- a/src/states.js
+++ b/src/states.js
@@ -54,6 +54,7 @@
  **********************************************************************************************************************/
 
 var httpPort = 8080;
+var defaultPort = '8080';
 var timeForContentLoaded = 100; // temporary set to 10000 with the UI Recording mode for video recording
 var timeCorrection = {delta: 0, now: 0, then: 0};
 var boundListeners = {};

--- a/src/states.js
+++ b/src/states.js
@@ -47,7 +47,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/* exported httpPort, timeForContentLoaded, timeCorrection, boundListeners, TEMP_DISABLE_MEMORIES, globalStates, globalCanvas, publicDataCache, pocketItemId, globalScaleAdjustment, pocketFrame, pocketNode, globalDOMCache, shadowObjects, globalProgram, rotateX, rotationXMatrix, editingAnimationsMatrix, pocketDropAnimation, pocketBegin, visibleObjectTapInterval, visibleObjectTapDelay, overlayDiv, CRAFTING_GRID_WIDTH, CRAFTING_GRID_HEIGHT, DEBUG_DATACRAFTING */
+/* exported httpPort, defaultPort, timeForContentLoaded, timeCorrection, boundListeners, TEMP_DISABLE_MEMORIES, globalStates, globalCanvas, publicDataCache, pocketItemId, globalScaleAdjustment, pocketFrame, pocketNode, globalDOMCache, shadowObjects, globalProgram, rotateX, rotationXMatrix, editingAnimationsMatrix, pocketDropAnimation, pocketBegin, visibleObjectTapInterval, visibleObjectTapDelay, overlayDiv, CRAFTING_GRID_WIDTH, CRAFTING_GRID_HEIGHT, DEBUG_DATACRAFTING */
 
 /**********************************************************************************************************************
  ******************************************** constant settings *******************************************************

--- a/src/states.js
+++ b/src/states.js
@@ -54,7 +54,7 @@
  **********************************************************************************************************************/
 
 var httpPort = 8080;
-var defaultPort = '8080';
+var defaultHttpPort = '8080';
 var timeForContentLoaded = 100; // temporary set to 10000 with the UI Recording mode for video recording
 var timeCorrection = {delta: 0, now: 0, then: 0};
 var boundListeners = {};

--- a/src/states.js
+++ b/src/states.js
@@ -47,7 +47,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/* exported httpPort, defaultPort, timeForContentLoaded, timeCorrection, boundListeners, TEMP_DISABLE_MEMORIES, globalStates, globalCanvas, publicDataCache, pocketItemId, globalScaleAdjustment, pocketFrame, pocketNode, globalDOMCache, shadowObjects, globalProgram, rotateX, rotationXMatrix, editingAnimationsMatrix, pocketDropAnimation, pocketBegin, visibleObjectTapInterval, visibleObjectTapDelay, overlayDiv, CRAFTING_GRID_WIDTH, CRAFTING_GRID_HEIGHT, DEBUG_DATACRAFTING */
+/* exported httpPort, defaultHttpPort, timeForContentLoaded, timeCorrection, boundListeners, TEMP_DISABLE_MEMORIES, globalStates, globalCanvas, publicDataCache, pocketItemId, globalScaleAdjustment, pocketFrame, pocketNode, globalDOMCache, shadowObjects, globalProgram, rotateX, rotationXMatrix, editingAnimationsMatrix, pocketDropAnimation, pocketBegin, visibleObjectTapInterval, visibleObjectTapDelay, overlayDiv, CRAFTING_GRID_WIDTH, CRAFTING_GRID_HEIGHT, DEBUG_DATACRAFTING */
 
 /**********************************************************************************************************************
  ******************************************** constant settings *******************************************************

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -69,6 +69,7 @@ createNameSpace("realityEditor.worldObjects");
         // this is a way to manually detect and create a world object from the local Node.js server running on the phone
         var worldObject = { id: '_WORLD_local',
             ip: "127.0.0.1", //'127.0.0.1',
+            port: 49369,
             vn: 320,
             pr: 'R2',
             tcs: null,
@@ -132,7 +133,8 @@ createNameSpace("realityEditor.worldObjects");
         }
         
         // REST endpoint for for downloading the world object for that server
-        var urlEndpoint = 'http://' + serverIP + ':' + httpPort + '/worldObject/';
+        var urlEndpoint = 'http://' + serverIP + ':' + realityEditor.network.getPortByIp(serverIP) + '/worldObject/';
+        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, msg) {
             console.log("did get world object for server: " + serverIP);
 

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -134,7 +134,6 @@ createNameSpace("realityEditor.worldObjects");
         
         // REST endpoint for for downloading the world object for that server
         var urlEndpoint = 'http://' + serverIP + ':' + realityEditor.network.getPortByIp(serverIP) + '/worldObject/';
-        console.log("++++++++++++++++++++++++++",urlEndpoint);
         realityEditor.network.getData(null, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, msg) {
             console.log("did get world object for server: " + serverIP);
 


### PR DESCRIPTION
This is a critical update to allow servers with different ports.
It is required to improve stability on iOS devices.

Why?
Its possible that multiple server run in the background on an ios device. 
Using common ports like 80, 8080 or 8888 can increase the potential for application crashes.
Therefore the server is moved to a new port. That needs to be reflected in:
ios app
user interface
server