### PR TITLE
Ben anchor updates

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1527,7 +1527,6 @@ Logic Interface CSS
     text-align: center;
     vertical-align: bottom;
     right: 1%;
-    width: 35%;
     top: 52%;
     height: 9%;
 }

--- a/src/gui/ar/anchors.js
+++ b/src/gui/ar/anchors.js
@@ -7,15 +7,56 @@ createNameSpace("realityEditor.gui.ar.anchors");
 (function(exports) {
 
     let anchorObjects = {};
-    let objectsWithAnchorElements = {};
     let utilities = realityEditor.gui.ar.utilities;
     let fullscreenAnchor = null;
+    const anchorContentSize = 300;
 
     function initService() {
         realityEditor.gui.ar.draw.addVisibleObjectModifier(modifyVisibleObjects);
         realityEditor.gui.ar.draw.addUpdateListener(onUpdate);
     }
 
+    /**
+     * Anchor objects are uniquely defined by a heartbeat with checksum=0 and the isAnchor property
+     * @param heartbeat
+     * @return {boolean|*}
+     */
+    function isAnchorHeartbeat(heartbeat) {
+        let checksumIsZero = heartbeat.tcs === 0;
+        let jsonIsAnchor = realityEditor.getObject(heartbeat.id).isAnchor;
+        return checksumIsZero && jsonIsAnchor;
+    }
+
+    /**
+     * Helper function to register this heartbeat as a recognized anchor
+     * @param heartbeat
+     */
+    function createAnchorFromHeartbeat(heartbeat) {
+        if (typeof anchorObjects[heartbeat.id] !== 'undefined') {
+            return;
+        }
+        anchorObjects[heartbeat.id] = heartbeat;
+    }
+
+    /**
+     * Helper function returns whether this object ID is an anchor (and thus has no target data)
+     * @param objectId
+     * @return {boolean}
+     */
+    function isAnchorObject(objectId) {
+        return anchorObjects.hasOwnProperty(objectId);
+    }
+
+
+    /**
+     * This gets triggered at the beginning of gui.ar.draw.update
+     * We use this function to inject anchor objects' model matrices into the visibleObjects in the
+     * gui.ar.draw.update function
+     * @param visibleObjects
+     * @todo: store which world they are relative to, rather than finding closest world each time
+     * (e.g. even if the closest world to the camera changes, the anchor should stay relative to
+     * its world)
+     */
     function modifyVisibleObjects(visibleObjects) {
         // if there's no visible world object other than the world_local, ignore all this code
         if (realityEditor.worldObjects.getBestWorldObject().objectId === realityEditor.worldObjects.getLocalWorldId()) {
@@ -31,69 +72,36 @@ createNameSpace("realityEditor.gui.ar.anchors");
             return;
         }
 
-        // console.log('need to render', anchorObjectIds);
         anchorObjectIds.forEach(function(objectKey) {
-            // visibleObjects[objectKey] = realityEditor.getObject(objectKey).matrix || utilities.newIdentityMatrix();
-            
-            let objectMatrix = realityEditor.getObject(objectKey).matrix || utilities.newIdentityMatrix();
-            
-            // object.matrix is its position relative to the world.. put that relative to screen
+            // object.matrix is its position relative to the world..
             // e.g. if object.matrix is identity, its visibleObjects matrix should be equal to
             // the visibleObjects matrix of its world
-            
+            let objectMatrix = realityEditor.getObject(objectKey).matrix || utilities.newIdentityMatrix();
             let visibleObjectMatrix = [];
-            // let worldModelViewMatrix = getWorldModelViewMatrix();
-            // utilities.multiplyMatrix(objectMatrix, worldModelViewMatrix, visibleObjectMatrix);
-
-            // let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-            // let worldMatrix = visibleObjects[closestWorld.uuid];
-
             let closestWorld = realityEditor.worldObjects.getBestWorldObject();
             let worldModelMatrix = realityEditor.worldObjects.getOrigin(closestWorld.uuid);
-
             utilities.multiplyMatrix(objectMatrix, worldModelMatrix, visibleObjectMatrix);
 
             visibleObjects[objectKey] = visibleObjectMatrix;
         });
     }
 
-    function isAnchorHeartbeat(heartbeat) {
-        let checksumIsZero = heartbeat.tcs === 0;
-        let jsonIsAnchor = realityEditor.getObject(heartbeat.id).isAnchor;
-        return checksumIsZero && jsonIsAnchor;
-    }
-
-    function createAnchorFromHeartbeat(heartbeat) {
-        if (typeof anchorObjects[heartbeat.id] !== 'undefined') {
-            return;
-        }
-
-        console.log('create anchor!', heartbeat);
-
-        anchorObjects[heartbeat.id] = heartbeat;
-    }
-
-    function isAnchorObject(objectId) {
-        return anchorObjects.hasOwnProperty(objectId);
-    }
-
+    /**
+     * This gets triggered at the end of gui.ar.draw.update
+     * @param modelViewMatrices
+     */
     function onUpdate(modelViewMatrices) {
         for (var objectKey in modelViewMatrices) {
             if (!modelViewMatrices.hasOwnProperty(objectKey)) continue;
             if (!isAnchorObject(objectKey)) continue;
 
-            let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-            let worldId = closestWorld.uuid;
-
-            // actually render the outline as a DOM element
-            // renderAnchor(objectKey, modelViewMatrices[objectKey], worldId, modelViewMatrices[worldId]);
-
+            // create the DOM element and render with the correct transformation
             if (!globalDOMCache['anchor' + objectKey]) {
                 createAnchorElement(objectKey);
             }
 
+            // render it fullscreen and skip 3d rendering early if it is being "carried"
             if (fullscreenAnchor === objectKey) {
-                // render it fullscreen and return early
                 let zIndex = 5000; // defaults to front of screen
                 globalDOMCache['anchor' + objectKey].style.transform =
                     'matrix3d(1, 0, 0, 0,' +
@@ -102,47 +110,15 @@ createNameSpace("realityEditor.gui.ar.anchors");
                     '0, 0, ' + zIndex + ', 1)';
                 continue;
             }
-            
-            // let activeObjectMatrix = [];
-
-            // let worldMatrix = realityEditor.worldObjects.getOrigin(worldId);
-            // utilities.multiplyMatrix(rotateX, worldMatrix, temp1);
-            // utilities.multiplyMatrix(temp1, realityEditor.gui.ar.draw.correctedCameraMatrix, temp2);
-
-            // utilities.multiplyMatrix(worldMatrix, realityEditor.gui.ar.draw.correctedCameraMatrix, temp2);
 
             let worldModelView = getWorldModelViewMatrix();
             let worldModelViewProjection = [];
             utilities.multiplyMatrix(worldModelView, globalStates.projectionMatrix, worldModelViewProjection);
-            
-            // let scale = [
-            //     3, 0, 0, 0,
-            //     0, 3, 0, 0,
-            //     0, 0, 3, 0,
-            //     0, 0, 0, 1
-            // ];
 
-            // utilities.multiplyMatrix(transform, worldModelViewProjection, activeObjectMatrix);
-            
-            // let positionData = {
-            //     x: -3.1,
-            //     y: -2.5,
-            //     scale: 0.5,
-            //     matrix: utilities.newIdentityMatrix()
-            // };
-            //
-            // let r3 = [
-            //     0.25, 0, 0, 0,
-            //     0, 0.25, 0, 0,
-            //     0, 0, 0.25, 0,
-            //     -3.1, -2.5, 0, 1
-            // ];
-            //
-            // let r = [];
             let anchorObject = realityEditor.getObject(objectKey);
             let transformedAnchorMatrix = [];
 
-            let scale = 0.5;
+            let scale = 0.5; // we can adjust how big it looks using this. empirically determined.
             let transform = [
                 scale, 0, 0, 0,
                 0, scale, 0, 0,
@@ -151,154 +127,48 @@ createNameSpace("realityEditor.gui.ar.anchors");
             ];
             utilities.multiplyMatrix(transform, anchorObject.matrix, transformedAnchorMatrix);
 
+            // multiply the final position of the world by the position of the anchor relative
+            // to the world to calculate its final 3d transformation
             let finalMatrix = [];
             utilities.multiplyMatrix(transformedAnchorMatrix, worldModelViewProjection, finalMatrix);
-            
-            // utilities.multiplyMatrix(r3, r, finalMatrix);
-            //
-            // var projectedPoint = realityEditor.gui.ar.utilities.multiplyMatrix4([0, 0, 0, 1], activeObjectMatrix);
-            // finalMatrix[14] = 200 + 1000000 / Math.max(10, projectedPoint[2]);
 
             globalDOMCache['anchor' + objectKey].style.transform = 'matrix3d(' + finalMatrix.toString() + ')';
-            // globalDOMCache['anchor' + objectKey].style.transform = 'matrix3d(' + activeObjectMatrix.toString() + ')';
-
-            // let worldMatrix = modelViewMatrices[worldId];
-            // let modelView = [];
-            // let modelViewProjection = [];
-            // utilities.multiplyMatrix(realityEditor.gui.ar.draw.visibleObjects[worldId])
-
-            // var origin = realityEditor.worldObjects.getOrigin(worldId);
-            // if (origin) {
-            //     let tempMatrix = [];
-            //     realityEditor.gui.ar.utilities.multiplyMatrix(origin, realityEditor.gui.ar.draw.correctedCameraMatrix, tempMatrix);
-            //
-            //     utilities.multiplyMatrix(tempMatrix, globalStates.projectionMatrix, modelViewProjection);
-            //     globalDOMCache['anchor' + objectKey].style.transform = 'matrix3d(' + modelViewProjection.toString() + ')';
-            //    
-            // }
-
-            // realityEditor.gui.ar.utilities.multiplyMatrix(origin, realityEditor.gui.ar.draw.correctedCameraMatrix, tempMatrix);
-
-            // utilities.multiplyMatrix(realityEditor.gui.ar.draw.visibleObjects[worldId], globalStates.projectionMatrix, modelViewProjection);
-            // globalDOMCache['anchor' + objectKey].style.transform = 'matrix3d(' + modelViewProjection.toString() + ')';
-
         }
     }
 
     /**
-     * Renders a specific object DOM element by calculating its CSS3D transformation
-     * @param {string} objectKey
-     * @param {Array.<number>} modelViewMatrix - the visibleObjects[objectKey] matrix
+     * Gets the model view matrix of the closest world by multiplying its origin by the camera view
+     * @return {Array.<number>}
      */
-    function renderAnchor(objectKey, modelViewMatrix, closestWorldId, worldMatrix) {
-        // create div for ghost if needed
-        if (!globalDOMCache['anchor' + objectKey]) {
-            createAnchorElement(objectKey);
-        }
-
-        if (fullscreenAnchor === objectKey) {
-            // render it fullscreen and return early
-            let zIndex = 5000; // defaults to front of screen
-            globalDOMCache['anchor' + objectKey].style.transform =
-                'matrix3d(1, 0, 0, 0,' +
-                '0, 1, 0, 0,' +
-                '0, 0, 1, 0,' +
-                '0, 0, ' + zIndex + ', 1)';
-            return;
-        }
-
-        let worldOrigin = realityEditor.worldObjects.getOrigin(closestWorldId);
-
-        // multiply (marker modelview) * (projection) * (screen rotation) * (vehicle.matrix) * (transformation)
-        let tempObjectMatrix = [];
-        let finalMatrix = [];
-
-        // utilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, tempObjectMatrix);
-
-        // utilities.multiplyMatrix(worldOrigin, globalStates.projectionMatrix, tempObjectMatrix);
-        utilities.multiplyMatrix(worldMatrix, globalStates.projectionMatrix, tempObjectMatrix);
-
-        let anchorMatrix = realityEditor.getObject(objectKey).matrix;
-        let tempResMatrix = [];
-
-        utilities.multiplyMatrix(anchorMatrix, tempObjectMatrix, tempResMatrix);
-
-        let transformMatrix = [
-            0.25, 0, 0, 0,
-            0, 0.25, 0, 0,
-            0, 0, 0.25, 0,
-            // positionData.x, positionData.y, 0, 1
-            0, 0, 0, 1
-        ];
-
-        utilities.multiplyMatrix(transformMatrix, tempResMatrix, finalMatrix);
-
-        // utilities.multiplyMatrix(modelViewMatrix, tempObjectMatrix, finalMatrix);
-
-        // let tempResMatrix = [];
-        // if (typeof anchorPosition.matrix !== 'undefined' && anchorPosition.matrix.length === 16) {
-        //     utilities.multiplyMatrix(anchorPosition.matrix, tempObjectMatrix, tempResMatrix);
-        //     utilities.multiplyMatrix(transformationMatrix, tempResMatrix, finalMatrix);
-        // } else {
-        //     utilities.multiplyMatrix(transformationMatrix, tempObjectMatrix, finalMatrix);
-        // }
-
-        // adjust Z-index so it gets rendered behind all the real frames/nodes
-        // calculate center Z of frame to know if it is mostly in front or behind the marker plane
-        var projectedPoint = realityEditor.gui.ar.utilities.multiplyMatrix4([0, 0, 0, 1], finalMatrix);
-        finalMatrix[14] = 1000000 / Math.max(10, projectedPoint[2]); // (don't add extra 200) so it goes behind real
-
-        // actually adjust the CSS to draw it with the correct transformation
-        globalDOMCache['anchor' + objectKey].style.transform = 'matrix3d(' + finalMatrix.toString() + ')';
-
-        // store the screenX and screenY within the anchor to help us later draw lines to the and
-        // var anchorCenterPosition = getDomElementCenterPosition(globalDOMCache['anchor' + objectKey]);
-        // anchorCenterPosition.screenX = anchorCenterPosition.x;
-        // anchorCenterPosition.screenY = anchorCenterPosition.y;
+    function getWorldModelViewMatrix() {
+        let closestWorld = realityEditor.worldObjects.getBestWorldObject();
+        let worldModelMatrix = realityEditor.worldObjects.getOrigin(closestWorld.uuid);
+        let modelViewMatrix = [];
+        utilities.multiplyMatrix(worldModelMatrix, realityEditor.gui.ar.draw.correctedCameraMatrix, modelViewMatrix);
+        return modelViewMatrix;
     }
 
-    // /**
-    //  * Instantly moves the frame to the pocketBegin matrix, so it's floating right in front of the camera
-    //  * @param objectKey
-    //  * @param frameKey
-    //  */
-    // funciton moveAnchorToCamera = function(objectKey, frameKey) {
-    //
-    //     var frame = realityEditor.getFrame(objectKey, frameKey);
-    //
-    //     // recompute frame.temp for the new object
-    //     realityEditor.gui.ar.utilities.multiplyMatrix(realityEditor.gui.ar.draw.modelViewMatrices[objectKey], globalStates.projectionMatrix, frame.temp);
-    //
-    //     console.log('temp', frame.temp);
-    //     frame.begin = realityEditor.gui.ar.utilities.copyMatrix(pocketBegin);
-    //
-    //     // compute frame.matrix based on new object
-    //     var resultMatrix = [];
-    //     realityEditor.gui.ar.utilities.multiplyMatrix(frame.begin, realityEditor.gui.ar.utilities.invertMatrix(frame.temp), resultMatrix);
-    //     realityEditor.gui.ar.positioning.setPositionDataMatrix(frame, resultMatrix); // TODO: fix this somehow, make it more understandable
-    //
-    //     // reset frame.begin
-    //     frame.begin = realityEditor.gui.ar.utilities.newIdentityMatrix();
-    //
-    // };
-
     /**
-    /**
-     * Creates a DOM element for the given object
+     * Creates a DOM element for the given object.
+     * Element must be constructed in a certain way to render correctly in 3d space.
      * @param {string} objectKey
      */
     function createAnchorElement(objectKey) {
         let anchorContainer = document.createElement('div');
         anchorContainer.id = 'anchor' + objectKey;
         anchorContainer.classList.add('anchorContainer', 'ignorePointerEvents', 'main', 'visibleFrameContainer');
+        // IMPORTANT NOTE: the container size MUST be the size of the screen for the 3d math to work
+        // This is the same size as the containers that frames get added to.
+        // If size differs, rendering will be inconsistent between frames and anchors.
         anchorContainer.style.width = globalStates.height + 'px';
         anchorContainer.style.height = globalStates.width + 'px';
 
+        // the contents are a different size than the screen, so we add another div and center it
         let anchorContents = document.createElement('div');
         anchorContents.id = 'anchorContents' + objectKey;
         anchorContents.classList.add('anchorContents', 'usePointerEvents');
-        anchorContents.style.left = (globalStates.height/2 - 300/2) + 'px';
-        anchorContents.style.top = (globalStates.width/2 - 300/2) + 'px';
+        anchorContents.style.left = (globalStates.height/2 - anchorContentSize/2) + 'px';
+        anchorContents.style.top = (globalStates.width/2 - anchorContentSize/2) + 'px';
         
         anchorContainer.appendChild(anchorContents);
         document.getElementById('GUI').appendChild(anchorContainer);
@@ -308,187 +178,149 @@ createNameSpace("realityEditor.gui.ar.anchors");
 
         updateAnchorGraphics(objectKey, true);
 
-        // maintain a list so that we can remove them all on demand
-        objectsWithAnchorElements[objectKey] = true;
-
         // attach event listeners
         anchorContents.addEventListener('pointerup', function(_e) {
             onAnchorTapped(objectKey);
         });
     }
 
+    /**
+     * Toggle between fullscreen and 3d modes when an anchor is tapped
+     * @todo: maybe only allow this in repositioning mode so it doesn't happen accidentally?
+     * @param {string} objectKey
+     */
     function onAnchorTapped(objectKey) {
-        console.log('anchor tapped for object ' + objectKey);
-        console.log(realityEditor.gui.ar.draw.visibleObjects[realityEditor.worldObjects.getBestWorldObject().uuid]);
-        
         if (!fullscreenAnchor) {
+            // setting fullscreenAnchor to the object ID is all that is necessary
             fullscreenAnchor = objectKey;
         } else {
+            // tapping on the fullscreen anchor requires more calculations to drop the anchor at the
+            // phone's exact position, because we need to calculate that position relative to world
             if (fullscreenAnchor === objectKey) {
-                console.log('drop anchor here');
-
-                // let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-
-                /*     this sorta almost doesnt work     */
-                /* ------------------------------------- */
-                // // compute new object.matrix for this object based on the camera matrix
-                // let cameraMatrix = utilities.invertMatrix(realityEditor.gui.ar.draw.correctedCameraMatrix);
-                //
-                // let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-                // let worldId = closestWorld.uuid;
-                // let worldMatrix = realityEditor.worldObjects.getOrigin(worldId);
-                //
-                // let cameraRelativeToWorld = [];
-                // // utilities.multiplyMatrix(utilities.invertMatrix(worldMatrix), cameraMatrix, cameraRelativeToWorld);
-                // utilities.multiplyMatrix(worldMatrix, cameraMatrix, cameraRelativeToWorld);
-                //
-                // let anchorObject = realityEditor.getObject(objectKey);
-                // // anchorObject.matrix = cameraMatrix;
-                // anchorObject.matrix = cameraRelativeToWorld;
-                /* ------------------------------------- */
-
-                // get the world relative to the camera
-                // invert it - that will give the camera relative to the world
-                // placing the element at that position, when multiplied relative to the world
-                // position, should yield an identity matrix -> what we want
-                
                 let worldModelView = getWorldModelViewMatrix();
-                // let worldModelViewProjection = [];
-                // utilities.multiplyMatrix(worldModelView, globalStates.projectionMatrix, worldModelViewProjection);
-
                 let inverseWorld = utilities.invertMatrix(worldModelView);
-                // let inverseWorld = utilities.invertMatrix(worldModelViewProjection);
                 
                 // flip it so it faces towards the camera instead of away from the camera
                 let q = realityEditor.gui.ar.utilities.getQuaternionFromPitchRollYaw(0, Math.PI, Math.PI);
                 let rotationMatrix = utilities.getMatrixFromQuaternion(q);
-                
                 let finalMatrix = [];
                 utilities.multiplyMatrix(rotationMatrix, inverseWorld, finalMatrix);
 
+                // store the new relative position of the anchor to the world
                 let anchorObject = realityEditor.getObject(objectKey);
                 anchorObject.matrix = finalMatrix;
 
-                // let anchorMatrix = getMatrixForAnchor(objectKey, closestWorld.uuid);
-                
-                // // compute new object.matrix for this object based on the camera matrix
-                // let cameraMatrix = utilities.invertMatrix(realityEditor.gui.ar.draw.correctedCameraMatrix);
-                //
-                // let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-                // let worldId = closestWorld.uuid;
-                // let worldMatrix = realityEditor.worldObjects.getOrigin(worldId);
-                //
-                // let cameraRelativeToWorld = [];
-                // // utilities.multiplyMatrix(utilities.invertMatrix(worldMatrix), cameraMatrix, cameraRelativeToWorld);
-                // utilities.multiplyMatrix(worldMatrix, cameraMatrix, cameraRelativeToWorld);
-                //
-                // let anchorObject = realityEditor.getObject(objectKey);
-                // // anchorObject.matrix = cameraMatrix;
-                // anchorObject.matrix = cameraRelativeToWorld;
-
+                // upload to the server for persistence
                 realityEditor.network.postObjectPosition(anchorObject.ip, objectKey, anchorObject.matrix);
 
                 fullscreenAnchor = null;
             }
-
-            // if (fullscreenAnchor !== objectKey) {
-            //     fullscreenAnchor = objectKey;
-            // } else {
-            //     fullscreenAnchor = null;
-            // }
         }
 
+        // update the HTML of the anchor based on whether it is now fullscreen or not
         updateAnchorGraphics(objectKey);
     }
-    
+
+    /**
+     * Swaps the contents of the anchor's HTML container to be either a small icon in space with
+     * the object name, or a fullscreen element that expands to fill the screen and has 4
+     * corners and a center crosshair with the object name.
+     * @param {string} objectKey
+     * @param {boolean} forceCreation - tries to be efficient and not recreate inner graphics
+     *  every time, but pass in true the first time it is created to ensure this happens at
+     *  least onc
+     */
     function updateAnchorGraphics(objectKey, forceCreation) {
         let element = globalDOMCache['anchorContents' + objectKey];
-        if (fullscreenAnchor === objectKey) {
-            if (!element.classList.contains('anchorContentsFullscreen') || forceCreation) {
-                
-                // first, hide the sidebar buttons
-                document.querySelector('#UIButtons').classList.add('hiddenButtons');
-                
-                element.classList.add('anchorContentsFullscreen');
+        if (fullscreenAnchor === objectKey && (!element.classList.contains('anchorContentsFullscreen') || forceCreation)) {
 
-                element.style.left = 0;
-                element.style.top = 0;
+            // first, hide the sidebar buttons
+            document.querySelector('#UIButtons').classList.add('hiddenButtons');
 
-                element.innerHTML = '';
-                
-                let margin = 5;
+            // fill the width and height of the screen
+            element.classList.add('anchorContentsFullscreen');
 
-                let topLeft = document.createElement('img');
-                topLeft.src = '../../../svg/anchorTopLeft.svg';
-                topLeft.classList.add('anchorCorner');
-                topLeft.style.left = margin + 'px';
-                topLeft.style.top = margin + 'px';
+            // some style needs to be applied with js to override other runtime calculated properties
+            element.style.left = 0;
+            element.style.top = 0;
 
-                let topRight = document.createElement('img');
-                topRight.src = '../../../svg/anchorTopRight.svg';
-                topRight.classList.add('anchorCorner');
-                topRight.style.right = margin + 'px';
-                topRight.style.top = margin + 'px';
+            // rebuild the SVG at correct size to fill the screen's corners
+            element.innerHTML = '';
 
-                let bottomLeft = document.createElement('img');
-                bottomLeft.src = '../../../svg/anchorBottomLeft.svg';
-                bottomLeft.classList.add('anchorCorner');
-                bottomLeft.style.left = margin + 'px';
-                bottomLeft.style.bottom = margin + 'px';
+            let margin = 5;
 
-                let bottomRight = document.createElement('img');
-                bottomRight.src = '../../../svg/anchorBottomRight.svg';
-                bottomRight.classList.add('anchorCorner');
-                bottomRight.style.right = margin + 'px';
-                bottomRight.style.bottom = margin + 'px';
+            let topLeft = document.createElement('img');
+            topLeft.src = '../../../svg/anchorTopLeft.svg';
+            topLeft.classList.add('anchorCorner');
+            topLeft.style.left = margin + 'px';
+            topLeft.style.top = margin + 'px';
 
-                let centerContainer = document.createElement('div');
-                centerContainer.classList.add('anchorCenter');
-                let size = (0.6 * globalStates.width);
-                centerContainer.style.left = (globalStates.height/2 - size/2) + 'px';
-                centerContainer.style.top = (globalStates.width/2 - size/2) + 'px';
+            let topRight = document.createElement('img');
+            topRight.src = '../../../svg/anchorTopRight.svg';
+            topRight.classList.add('anchorCorner');
+            topRight.style.right = margin + 'px';
+            topRight.style.top = margin + 'px';
 
-                let centerSvg = document.createElement('img');
-                centerSvg.src = '../../../svg/anchorCenter.svg';
-                centerContainer.appendChild(centerSvg);
+            let bottomLeft = document.createElement('img');
+            bottomLeft.src = '../../../svg/anchorBottomLeft.svg';
+            bottomLeft.classList.add('anchorCorner');
+            bottomLeft.style.left = margin + 'px';
+            bottomLeft.style.bottom = margin + 'px';
 
-                let textfield = document.createElement('div');
-                textfield.classList.add('anchorTextField');
-                textfield.innerText = realityEditor.getObject(objectKey).name;
-                centerContainer.appendChild(textfield);
+            let bottomRight = document.createElement('img');
+            bottomRight.src = '../../../svg/anchorBottomRight.svg';
+            bottomRight.classList.add('anchorCorner');
+            bottomRight.style.right = margin + 'px';
+            bottomRight.style.bottom = margin + 'px';
 
-                element.appendChild(topLeft);
-                element.appendChild(topRight);
-                element.appendChild(bottomLeft);
-                element.appendChild(bottomRight);
-                element.appendChild(centerContainer);
+            let centerContainer = document.createElement('div');
+            centerContainer.classList.add('anchorCenter');
+            let size = (0.6 * globalStates.width);
+            centerContainer.style.left = (globalStates.height/2 - size/2) + 'px';
+            centerContainer.style.top = (globalStates.width/2 - size/2) + 'px';
 
-                resizeAnchorText(objectKey);
-            }
-        } else {
-            if (element.classList.contains('anchorContentsFullscreen') || forceCreation) {
-                
-                // first show the sidebar buttons
-                document.querySelector('#UIButtons').classList.remove('hiddenButtons');
+            let centerSvg = document.createElement('img');
+            centerSvg.src = '../../../svg/anchorCenter.svg';
+            centerContainer.appendChild(centerSvg);
 
-                element.classList.remove('anchorContentsFullscreen');
+            // add a textfield with the object name
+            let textfield = document.createElement('div');
+            textfield.classList.add('anchorTextField');
+            textfield.innerText = realityEditor.getObject(objectKey).name;
+            centerContainer.appendChild(textfield);
 
-                element.style.left = (globalStates.height/2 - 300/2) + 'px';
-                element.style.top = (globalStates.width/2 - 300/2) + 'px';
+            element.appendChild(topLeft);
+            element.appendChild(topRight);
+            element.appendChild(bottomLeft);
+            element.appendChild(bottomRight);
+            element.appendChild(centerContainer);
 
-                element.innerHTML = '';
-                let anchorContentsPlaced = document.createElement('img');
-                anchorContentsPlaced.src = '../../../svg/anchor.svg';
-                anchorContentsPlaced.classList.add('anchorContentsPlaced');
-                element.appendChild(anchorContentsPlaced);
+            // this needs to happen after elements have been added to the DOM
+            resizeAnchorText(objectKey);
+        } else if (element.classList.contains('anchorContentsFullscreen') || forceCreation) {
 
-                let textfield = document.createElement('div');
-                textfield.classList.add('anchorTextField');
-                textfield.innerText = realityEditor.getObject(objectKey).name;
-                element.appendChild(textfield);
+            // first show the sidebar buttons
+            document.querySelector('#UIButtons').classList.remove('hiddenButtons');
 
-                resizeAnchorText(objectKey);
-            }
+            // resize it to be a small centered icon in its container
+            element.classList.remove('anchorContentsFullscreen');
+            element.style.left = (globalStates.height/2 - anchorContentSize/2) + 'px';
+            element.style.top = (globalStates.width/2 - anchorContentSize/2) + 'px';
+
+            // rebuild the HTML with an SVG icon
+            element.innerHTML = '';
+            let anchorContentsPlaced = document.createElement('img');
+            anchorContentsPlaced.src = '../../../svg/anchor.svg';
+            anchorContentsPlaced.classList.add('anchorContentsPlaced');
+            element.appendChild(anchorContentsPlaced);
+
+            // create the text field again
+            let textfield = document.createElement('div');
+            textfield.classList.add('anchorTextField');
+            textfield.innerText = realityEditor.getObject(objectKey).name;
+            element.appendChild(textfield);
+
+            resizeAnchorText(objectKey);
         }
     }
 
@@ -525,26 +357,6 @@ createNameSpace("realityEditor.gui.ar.anchors");
             textfield.style.lineHeight = realHeight + 'px';
         });
     }
-    
-    function getWorldModelViewMatrix() {
-        let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-        let worldModelMatrix = realityEditor.worldObjects.getOrigin(closestWorld.uuid);
-        let modelViewMatrix = [];
-        utilities.multiplyMatrix(worldModelMatrix, realityEditor.gui.ar.draw.correctedCameraMatrix, modelViewMatrix);
-        return modelViewMatrix;
-    }
-    
-    // function getMatrixForAnchor(objectKey, worldKey) {
-    //     let worldMatrix = realityEditor.worldObjects.getOrigin(worldKey);
-    //     let temp1 = [];
-    //     utilities.multiplyMatrix(worldMatrix, realityEditor.gui.ar.draw.correctedCameraMatrix, temp1);
-    //     let activeObjectMatrix = [];
-    //     utilities.multiplyMatrix(temp1, globalStates.projectionMatrix, activeObjectMatrix);
-    //     let anchorObject = realityEditor.getObject(objectKey);
-    //     let finalMatrix = [];
-    //     utilities.multiplyMatrix(anchorObject.matrix, activeObjectMatrix, finalMatrix);
-    //     return finalMatrix;
-    // }
 
     exports.initService = initService;
     exports.isAnchorHeartbeat = isAnchorHeartbeat;

--- a/src/gui/ar/anchors.js
+++ b/src/gui/ar/anchors.js
@@ -9,7 +9,6 @@ createNameSpace("realityEditor.gui.ar.anchors");
     let anchorObjects = {};
     let objectsWithAnchorElements = {};
     let utilities = realityEditor.gui.ar.utilities;
-
     let fullscreenAnchor = null;
 
     function initService() {
@@ -101,7 +100,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
                     '0, 1, 0, 0,' +
                     '0, 0, 1, 0,' +
                     '0, 0, ' + zIndex + ', 1)';
-                return;
+                continue;
             }
             
             // let activeObjectMatrix = [];
@@ -456,7 +455,6 @@ createNameSpace("realityEditor.gui.ar.anchors");
                 let textfield = document.createElement('div');
                 textfield.classList.add('anchorTextField');
                 textfield.innerText = realityEditor.getObject(objectKey).name;
-                // textfield.style.right = (globalStates.height/2 - size/2) + 'px';
                 centerContainer.appendChild(textfield);
 
                 element.appendChild(topLeft);
@@ -465,6 +463,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
                 element.appendChild(bottomRight);
                 element.appendChild(centerContainer);
 
+                resizeAnchorText(objectKey);
             }
         } else {
             if (element.classList.contains('anchorContentsFullscreen') || forceCreation) {
@@ -487,8 +486,44 @@ createNameSpace("realityEditor.gui.ar.anchors");
                 textfield.classList.add('anchorTextField');
                 textfield.innerText = realityEditor.getObject(objectKey).name;
                 element.appendChild(textfield);
+
+                resizeAnchorText(objectKey);
             }
         }
+    }
+
+    /**
+     * Re-sizes the object name inside the anchor to fit the text box background
+     * @param {string} objectKey
+     */
+    function resizeAnchorText(objectKey) {
+        let anchorElement = globalDOMCache['anchorContents' + objectKey];
+        let textfield = anchorElement.querySelector('.anchorTextField');
+
+        const maxFontSize = 18;
+
+        // prep by resetting so we can compute size with default params
+        textfield.style.width = '';
+        textfield.style.fontSize = maxFontSize + 'px';
+
+        // resize text to fit after it renders once
+        requestAnimationFrame(function() {
+            let desiredWidth = anchorElement.clientWidth * 0.35;
+            let anchorCenter = anchorElement.querySelector('.anchorCenter');
+            if (anchorCenter) {
+                desiredWidth = anchorCenter.clientWidth * 0.35;
+            }
+            let realWidth = parseFloat(getComputedStyle(textfield).width);
+
+            let percent = desiredWidth / realWidth;
+            let newFontSize = Math.min(maxFontSize, maxFontSize * percent);
+            textfield.style.fontSize = newFontSize + 'px';
+
+            // update with set width/height after calculating so text is centered
+            textfield.style.width = desiredWidth + 'px';
+            let realHeight = parseFloat(getComputedStyle(textfield).height);
+            textfield.style.lineHeight = realHeight + 'px';
+        });
     }
     
     function getWorldModelViewMatrix() {

--- a/src/gui/ar/anchors.js
+++ b/src/gui/ar/anchors.js
@@ -142,7 +142,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
             let anchorObject = realityEditor.getObject(objectKey);
             let transformedAnchorMatrix = [];
 
-            let scale = 0.25;
+            let scale = 0.5;
             let transform = [
                 scale, 0, 0, 0,
                 0, scale, 0, 0,

--- a/src/gui/ar/index.js
+++ b/src/gui/ar/index.js
@@ -401,7 +401,7 @@ realityEditor.gui.ar.closestVisibleObject = function(optionalFilter) {
             }
         }
 
-        distance = this.utilities.distance(realityEditor.gui.ar.draw.visibleObjects[objectKey]);
+        distance = this.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[objectKey]);
 
         if (distance < closest) {
             object = objectKey;
@@ -435,10 +435,10 @@ realityEditor.gui.ar.utilities.getAllObjectDistances = function(isDesktop) {
         });
 
     } else {
-        return Object.keys(realityEditor.gui.ar.draw.visibleObjects).map(function (key) {
+        return Object.keys(realityEditor.gui.ar.draw.modelViewMatrices).map(function (key) {
             return {
                 key: key,
-                dist: realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.visibleObjects[key])
+                dist: realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[key])
             }
         });
 
@@ -466,7 +466,7 @@ realityEditor.gui.ar.getClosestFrame = function (filterFunction) {
                 if (!filterFunction(this.objects[objectKey].frames[frameKey])) continue;
             }
             
-            distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.visibleObjects[objectKey], this.objects[objectKey].frames[frameKey]));
+            distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.modelViewMatrices[objectKey], this.objects[objectKey].frames[frameKey]));
             if (distance < closest) {
                 object = objectKey;
                 frame = frameKey;
@@ -499,7 +499,7 @@ realityEditor.gui.ar.getClosestNode = function () {
                     break;
                 }
                 
-                distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.visibleObjects[objectKey], this.objects[objectKey].frames[frameKey].nodes[nodeKey]));
+                distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.modelViewMatrices[objectKey], this.objects[objectKey].frames[frameKey].nodes[nodeKey]));
                 if (distance < closest) {
                     object = objectKey;
                     frame = frameKey;
@@ -527,7 +527,7 @@ realityEditor.gui.ar.getClosestFrameToScreenCoordinates = function(screenX, scre
 
     for (var objectKey in realityEditor.gui.ar.draw.visibleObjects) {
         for(var frameKey in this.objects[objectKey].frames) {
-            distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.visibleObjects[objectKey], this.objects[objectKey].frames[frameKey]));
+            distance = this.utilities.distance(this.utilities.repositionedMatrix(realityEditor.gui.ar.draw.modelViewMatrices[objectKey], this.objects[objectKey].frames[frameKey]));
             
             var thisFrame = realityEditor.getFrame(objectKey, frameKey);
             var dx = screenX - thisFrame.screenX;

--- a/src/gui/screenExtension.js
+++ b/src/gui/screenExtension.js
@@ -346,7 +346,7 @@ realityEditor.gui.screenExtension.calculatePushPop = function() {
             // calculate distance to frame
             // var screenFrameMatrix = realityEditor.gui.ar.utilities.repositionedMatrix(realityEditor.gui.ar.draw.visibleObjects[this.screenObject.object], screenFrame);
             // var distanceToFrame = realityEditor.gui.ar.utilities.distance(screenFrameMatrix);
-            var distanceToObject = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.visibleObjects[this.screenObject.object]);
+            var distanceToObject = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[this.screenObject.object]);
 
             // console.log('distance to object, frame: ' + distanceToObject + ', ' + distanceToFrame);
             // console.log('distance to object: ' + distanceToFrame);

--- a/src/gui/spatial/index.js
+++ b/src/gui/spatial/index.js
@@ -17,7 +17,7 @@ realityEditor.gui.spatial.screenLocation = {x:-1,y:-1};
 realityEditor.gui.spatial.utilities = realityEditor.gui.ar.utilities;
 realityEditor.gui.spatial.draw = {};
 
-realityEditor.gui.spatial.whereIs = function(matrix, objectID,toolID,nodeID){
+realityEditor.gui.spatial.whereIs = function(matrix, objectID,toolID,_nodeID){
  
     if(objectID in globalStates.spatial.whereIs){
         this.draw.whereIs(matrix);

--- a/src/network/availableFrames.js
+++ b/src/network/availableFrames.js
@@ -150,7 +150,7 @@ createNameSpace("realityEditor.network.availableFrames");
         });
         
         return validObjectKeys.map( function(objectKey) {
-            var distance = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.visibleObjects[objectKey]);
+            var distance = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[objectKey]);
             var isWorldObject = false;
             var object = realityEditor.getObject(objectKey);
             if (object && object.isWorldObject) {

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -336,7 +336,7 @@ createNameSpace("realityEditor.worldObjects");
         for (var objectKey in realityEditor.gui.ar.draw.visibleObjects) {
             var object = realityEditor.getObject(objectKey);
             if (object.isWorldObject) {
-                var thisDistance = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.visibleObjects[objectKey]);
+                var thisDistance = realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[objectKey]);
                 distances[objectKey] = thisDistance;
             }
         }


### PR DESCRIPTION
Here are the updates for anchors which can be merged back into your code.

- The object name textfield on the anchor scales down so that the name always fits in the box.
- I updated how we calculate the closest object/frame/node to use the `modelViewMatrices` instead of the `visibleObjects` matrices because for regular objects these are equal, but for anchor objects the `modelViewMatrices` are more correct.
- You can now attach tools from the pocket to the closest anchor, and when you move the anchor around the tools move with it!