### PR TITLE
"environment" refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
     <script src="src/device/videoRecording.js"></script>
     <script src="src/device/distanceScaling.js"></script>
     <script src="src/device/keyboardEvents.js"></script>
+    <script src="src/device/environment.js"></script>
 
     <script src="src/network/index.js"></script>
     <script src="src/network/realtime.js"></script>

--- a/src/device/distanceScaling.js
+++ b/src/device/distanceScaling.js
@@ -43,7 +43,7 @@ createNameSpace("realityEditor.device.distanceScaling");
     }
 
     function getDefaultDistance() {
-        return defaultDistance;
+        return defaultDistance * realityEditor.device.environment.getDistanceScaleFactor();
     }
     
     function initService() {
@@ -54,11 +54,6 @@ createNameSpace("realityEditor.device.distanceScaling");
         
         realityEditor.gui.buttons.registerCallbackForButton('distance', onDistanceEditingModeChanged);
         realityEditor.gui.buttons.registerCallbackForButton('distanceGreen', onDistanceGreenPressed);
-        
-        if (realityEditor.device.utilities.isDesktop()) {
-            console.log('adjusted default distance from ' + defaultDistance + ' (for desktop)');
-            defaultDistance = defaultDistance * 10;
-        }
     }
     
     function loop() {

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -1,0 +1,14 @@
+createNameSpace("realityEditor.device.environment");
+
+(function(exports) {
+
+    /**
+     * Public init method sets up module and registers callbacks in other modules
+     */
+    function initService() {
+
+    }
+
+    exports.initService = initService;
+
+}(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -33,6 +33,14 @@ createNameSpace("realityEditor.device.environment");
 
     exports.supportsDistanceFading = function() {
         return true; // false for desktop?
-    }
+    };
+
+    exports.getDistanceScaleFactor = function() {
+        return 1; // 10 for desktop?
+    };
+
+    exports.shouldCreateDesktopSocket = function() {
+        return false; // true for desktop
+    };
 
 }(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -1,46 +1,110 @@
 createNameSpace("realityEditor.device.environment");
 
+/**
+ * @fileOverview realityEditor.device.environment.js
+ * This provides an extensible location for defining environment variables that are used by
+ * the core application, but may be modified by add-ons to affect conditional behavior in the app.
+ *
+ * For example, an add-on can disable distance fading, if that is important for the add-on behavior,
+ * or it can change which event names the app responds to (mousedown vs touchdown), or it can scale
+ * certain UI constants, such as the link line width, by factors specific to the environment.
+ *
+ * Currently, if multiple add-ons try to set the same variable it will lead to inconsistent results
+ * based on which add-on is loaded first. There are plans to allow add-ons to register their
+ * individual requirements, which the getter functions would resolve at runtime.
+ */
 (function(exports) {
 
+    exports.initService = function() {
+        console.log('Default environment initialized');
+    };
+
+    // initialized with default variables for iPhone environment. add-ons can modify
+    let variables = {
+        // booleans
+        providesOwnUpdateLoop: false,
+        shouldBroadcastUpdateObjectMatrix: false,
+        doWorldObjectsRequireCameraTransform: false,
+        requiresMouseEvents: false,
+        supportsDistanceFading: true,
+        shouldCreateDesktopSocket: false,
+        // numbers
+        lineWidthMultiplier: 1, // 5
+        distanceScaleFactor: 1 // 10
+    };
+
+    // variables can be directly set by add-ons by using the public 'variables' property
+    exports.variables = variables;
+    // however, rather than reading these variables directly, it is preferred to use the getters:
+    // this is for compatibility with future plans which will add more logic to the variables
+
     /**
-     * Public init method sets up module and registers callbacks in other modules
+     * Whether the environment contains a service that will trigger gui.ar.draw.update
+     * If not, the editor will keep the update loop running while frozen to drive line animations.
+     * @return {boolean} - default false
      */
-    function initService() {
-
-    }
-
-    exports.initService = initService;
-
     exports.providesOwnUpdateLoop = function() {
-        return false; // true if desktop
+        return variables.providesOwnUpdateLoop;
     };
 
-    exports.getLineWidthMultiplier = function() {
-        return 1; // 5 if desktop
-    };
-
+    /**
+     * If true, and there is a localized world object in sight, looking at new objects will
+     * continuously set their ar.matrix property on the server to store their position
+     * @return {boolean} - default false
+     */
     exports.shouldBroadcastUpdateObjectMatrix = function() {
-        return false; // true if desktop
+        return variables.shouldBroadcastUpdateObjectMatrix;
     };
 
+    /**
+     * If true, multiplies world origin by the camera matrix while rendering, rather than using
+     * the visibleObjects matrix for world objects un-altered.
+     * May be required based on the camera system being used.
+     * @return {boolean} - default false
+     */
     exports.doWorldObjectsRequireCameraTransform = function() {
-        return false; // true if desktop
+        return variables.doWorldObjectsRequireCameraTransform;
     };
 
+    /**
+     * If true, replaces touch events with mouse events.
+     * @return {boolean} - default false
+     */
     exports.requiresMouseEvents = function() {
-        return false; // true if desktop
+        return variables.requiresMouseEvents;
     };
 
+    /**
+     * Whether tools and nodes should become invisible as the camera moves further away
+     * @return {boolean} - default true
+     */
     exports.supportsDistanceFading = function() {
-        return true; // false for desktop?
+        return variables.supportsDistanceFading;
     };
 
-    exports.getDistanceScaleFactor = function() {
-        return 1; // 10 for desktop?
-    };
-
+    /**
+     * Whether the application should open a socket to directly receive /update/object,
+     * /update/frame, and /update/node realtime messages
+     * @return {boolean} - default false
+     */
     exports.shouldCreateDesktopSocket = function() {
-        return false; // true for desktop
+        return variables.shouldCreateDesktopSocket;
+    };
+
+    /**
+     * How much bigger than usual each dot in a link should be rendered
+     * @return {number} - default 1
+     */
+    exports.getLineWidthMultiplier = function() {
+        return variables.lineWidthMultiplier;
+    };
+
+    /**
+     * How much further away than usual before a tool or node fades away
+     * @return {number} - default 1
+     */
+    exports.getDistanceScaleFactor = function() {
+        return variables.distanceScaleFactor;
     };
 
 }(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -28,6 +28,9 @@ createNameSpace("realityEditor.device.environment");
         requiresMouseEvents: false,
         supportsDistanceFading: true,
         shouldCreateDesktopSocket: false,
+        distanceRequiresCameraTransform: false,
+        ignoresFreezeButton: false,
+        shouldDisplayLogicMenuModally: false,
         // numbers
         lineWidthMultiplier: 1, // 5
         distanceScaleFactor: 1 // 10
@@ -89,6 +92,33 @@ createNameSpace("realityEditor.device.environment");
      */
     exports.shouldCreateDesktopSocket = function() {
         return variables.shouldCreateDesktopSocket;
+    };
+
+    /**
+     * Whether features such as unconstrained repositioning or distance scaling should continue even if the freeze
+     * button is activated.
+     * @return {boolean} - default false
+     */
+    exports.ignoresFreezeButton = function() {
+        return variables.ignoresFreezeButton;
+    };
+
+    /**
+     * Whether the logic block menu should be rendered as a popup along the right edge of the screen, rather than
+     * expanding to be fullscreen and centered.
+     * @return {boolean} - default false
+     */
+    exports.shouldDisplayLogicMenuModally = function() {
+        return variables.shouldDisplayLogicMenuModally;
+    };
+
+    /**
+     * Set to true if calculating distance of visibleObjects matrix should implicitly multiply by camera position
+     * Necessary for some camera systems.
+     * @return {boolean} - default false
+     */
+    exports.distanceRequiresCameraTransform = function() {
+        return variables.distanceRequiresCameraTransform;
     };
 
     /**

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -11,4 +11,12 @@ createNameSpace("realityEditor.device.environment");
 
     exports.initService = initService;
 
+    exports.providesOwnUpdateLoop = function() {
+        return false; // true if desktop
+    };
+
+    exports.getLineWidthMultiplier = function() {
+        return 1; // 5 if desktop
+    };
+
 }(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -31,4 +31,8 @@ createNameSpace("realityEditor.device.environment");
         return false; // true if desktop
     };
 
+    exports.supportsDistanceFading = function() {
+        return true; // false for desktop?
+    }
+
 }(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -19,4 +19,16 @@ createNameSpace("realityEditor.device.environment");
         return 1; // 5 if desktop
     };
 
+    exports.shouldBroadcastUpdateObjectMatrix = function() {
+        return false; // true if desktop
+    };
+
+    exports.doWorldObjectsRequireCameraTransform = function() {
+        return false; // true if desktop
+    };
+
+    exports.requiresMouseEvents = function() {
+        return false; // true if desktop
+    };
+
 }(realityEditor.device.environment));

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -1305,7 +1305,7 @@ realityEditor.device.checkIfFramePulledIntoUnconstrained = function(activeVehicl
 
     // many conditions to check to see if it has this feature enabled
     var ableToBePulled = !(this.editingState.unconstrained || globalStates.unconstrainedPositioning) && 
-                            (!globalStates.freezeButtonState || realityEditor.device.utilities.isDesktop()) &&
+                            (!globalStates.freezeButtonState || realityEditor.device.environment.ignoresFreezeButton()) &&
                             realityEditor.gui.ar.positioning.isVehicleUnconstrainedEditable(activeVehicle);
     
     if (ableToBePulled) {

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -363,7 +363,7 @@ realityEditor.device.addDocumentTouchListeners = function() {
     document.addEventListener('pointermove', this.onDocumentPointerMove.bind(this));
     document.addEventListener('pointerup', this.onDocumentPointerUp.bind(this));
     
-    if (realityEditor.device.utilities.isDesktop()) {
+    if (realityEditor.device.environment.requiresMouseEvents()) {
         document.addEventListener('mousedown', this.onDocumentMultiTouchStart.bind(this));
         document.addEventListener('mousemove', this.onDocumentMultiTouchMove.bind(this));
         document.addEventListener('mouseup', this.onDocumentMultiTouchEnd.bind(this));
@@ -391,7 +391,7 @@ realityEditor.device.addTouchListenersForElement = function(overlayDomElement, a
         evt.target.releasePointerCapture(evt.pointerId);
     });
 
-    if (realityEditor.device.utilities.isDesktop()) {
+    if (realityEditor.device.environment.requiresMouseEvents()) {
         // use TouchEvents for dragging because it keeps its original target even if you leave the bounds of the target
         overlayDomElement.addEventListener('mouseup', this.onElementMultiTouchEnd.bind(this));
         // overlayDomElement.addEventListener('touchcancel', this.onElementMultiTouchEnd.bind(this));
@@ -547,7 +547,7 @@ realityEditor.device.disablePinchToScale = function() {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchDown = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     var target = event.currentTarget;
     var activeVehicle = realityEditor.getVehicle(target.objectId, target.frameId, target.nodeId);
@@ -615,7 +615,7 @@ realityEditor.device.onElementTouchDown = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchMove = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     var target = event.currentTarget;
     
@@ -644,7 +644,7 @@ realityEditor.device.onElementTouchMove = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchEnter = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     var target = event.currentTarget;
     
@@ -686,7 +686,7 @@ realityEditor.device.onElementTouchEnter = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchOut = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     var target = event.currentTarget;
     if (target.type !== "ui") {
@@ -724,7 +724,7 @@ realityEditor.device.onElementTouchOut = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchUp = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     var target = event.currentTarget;
     var activeVehicle = this.getEditingVehicle();
@@ -926,7 +926,7 @@ realityEditor.device.onElementMultiTouchEnd = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerDown = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
     
     globalStates.pointerPosition = [event.clientX, event.clientY];
 
@@ -962,7 +962,7 @@ realityEditor.device.onDocumentPointerDown = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerMove = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     event.preventDefault(); //TODO: why is this here but not in other document events?
 
@@ -986,7 +986,7 @@ realityEditor.device.onDocumentPointerMove = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerUp = function(event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
 
     // add the pocket node to the closest frame
     if (realityEditor.gui.buttons.getButtonState('pocket') === 'down') {
@@ -1063,7 +1063,7 @@ realityEditor.device.onDocumentPointerUp = function(event) {
  * @param {MouseEvent} event
  */
 function modifyTouchEventIfDesktop(event) {
-    if (realityEditor.device.utilities.isDesktop()) {
+    if (realityEditor.device.environment.requiresMouseEvents()) {
         event.touches = [];
         event.touches[0] = {
             altitudeAngle: 0,
@@ -1092,7 +1092,7 @@ function modifyTouchEventIfDesktop(event) {
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchStart = function (event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchstart", realityEditor.device.touchInputs.screenTouchStart);
@@ -1149,7 +1149,7 @@ realityEditor.device.onDocumentMultiTouchStart = function (event) {
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchMove = function (event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchmove", realityEditor.device.touchInputs.screenTouchMove);
@@ -1371,7 +1371,7 @@ realityEditor.device.checkIfFramePulledIntoUnconstrained = function(activeVehicl
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchEnd = function (event) {
-    if (realityEditor.device.utilities.isDesktop() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchend", realityEditor.device.touchInputs.screenTouchEnd);

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -245,7 +245,7 @@ realityEditor.device.onload = function () {
     (function animate(time) {
         realityEditor.gui.ar.draw.frameNeedsToBeRendered = true;
         // TODO This is a hack to keep the crafting board running
-        if (globalStates.freezeButtonState && !realityEditor.device.utilities.isDesktop()) {
+        if (globalStates.freezeButtonState && !realityEditor.device.environment.providesOwnUpdateLoop()) {
             realityEditor.gui.ar.draw.update(realityEditor.gui.ar.draw.visibleObjectsCopy); 
         }
         requestAnimationFrame(animate);
@@ -258,33 +258,6 @@ realityEditor.device.onload = function () {
     
     // start the AR framework in native iOS
     realityEditor.app.getVuforiaReady('realityEditor.app.callbacks.vuforiaIsReady');
-    
-    // window.addEventListener('resize', function(event) {
-    //     console.log(window.innerWidth, window.innerHeight);
-    // });
-    
-    // this is purely for debugging purposes, can be removed in production.
-    // re-purposes the speechConsole from an old experiment into an on-screen message display for debug messages
-    // TODO: implement a clean system for logging info or debug messages to an on-screen display
-    if (!realityEditor.device.utilities.isDesktop()) {
-        if (globalStates.debugSpeechConsole) {
-            document.getElementById('speechConsole').style.display = 'inline';
-            
-            var DEBUG_SHOW_CLOSEST_OBJECT = false;
-            if (DEBUG_SHOW_CLOSEST_OBJECT) {
-                setInterval(function() {
-                    var closestObjectKey = realityEditor.gui.ar.getClosestObject()[0];
-                    if (closestObjectKey) {
-                        var mat = realityEditor.getObject(closestObjectKey).matrix; //realityEditor.gui.ar.draw.visibleObjects[closestObjectKey];
-                        if (realityEditor.gui.ar.draw.worldCorrection !== null) {
-                            console.warn('Should never get here until we fix worldCorrection');
-                            document.getElementById('speechConsole').innerText = 'object ' + closestObjectKey + ' is at (' + mat[12]/mat[15] + ', ' + mat[13]/mat[15] + ', ' + mat[14]/mat[15] + ')';
-                        }
-                    }
-                }, 500);
-            }
-        }
-    }
 
     // see if we should open the modal - defaults hidden but can be turned on from menu
     let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -181,11 +181,6 @@ realityEditor.device.onload = function () {
     realityEditor.network.frameContentAPI.initService();
     realityEditor.envelopeManager.initService();
     realityEditor.network.availableFrames.initService();
-    
-    // on desktop, the desktopAdapter adds a different update loop, but on mobile we set up the default one here
-    // if (!realityEditor.device.utilities.isDesktop()) {
-    //     realityEditor.gui.ar.draw.updateLoop();
-    // }
 
     realityEditor.app.getDeviceReady('realityEditor.app.callbacks.getDeviceReady');
 

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -169,6 +169,7 @@ realityEditor.device.onload = function () {
     realityEditor.device.initService();
     realityEditor.device.touchInputs.initService();
     realityEditor.device.videoRecording.initService();
+    realityEditor.device.environment.initService();
     realityEditor.gui.ar.frameHistoryRenderer.initService();
     realityEditor.gui.ar.grouping.initService();
     realityEditor.gui.ar.anchors.initService();

--- a/src/device/utilities.js
+++ b/src/device/utilities.js
@@ -290,16 +290,13 @@ realityEditor.device.utilities.diffArrays = function(oldArray, newArray) {
     }
 };
 
-// speeding things up by only verifying once
-realityEditor.device.utilities.isItADesktop = window.navigator.userAgent.indexOf('Mobile') <= -1 || window.navigator.userAgent.indexOf('Macintosh') > -1;
-
 /**
  * Utility function to determine if the editor is loaded on a desktop browser or within the full mobile app.
  * @todo: make more robust so that loading on a mobile safari browser is distinguisable from within the Reality Editor app
  * @return {boolean}
  */
 realityEditor.device.utilities.isDesktop = function() {
-    return realityEditor.device.utilities.isItADesktop;
+    return false;
 };
 
 /**

--- a/src/device/utilities.js
+++ b/src/device/utilities.js
@@ -291,15 +291,6 @@ realityEditor.device.utilities.diffArrays = function(oldArray, newArray) {
 };
 
 /**
- * Utility function to determine if the editor is loaded on a desktop browser or within the full mobile app.
- * @todo: make more robust so that loading on a mobile safari browser is distinguisable from within the Reality Editor app
- * @return {boolean}
- */
-realityEditor.device.utilities.isDesktop = function() {
-    return false;
-};
-
-/**
  * Helper function tells if tapped the background (and excludes edge-case: multi-touch gesture while selecting a vehicle)
  * @param {PointerEvent} event
  * @return {boolean}

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1801,16 +1801,6 @@ realityEditor.gui.ar.draw.getFinalMatrixForFrame = function(visibleObjectMatrix,
         0, 0, frameScale, 0,
         frameX, frameY, 0, 1
     ];
-    
-    if (realityEditor.device.utilities.isDesktop()) {
-        this.getMatrixValues.scale = [
-            frameScale, 0, 0, 0,
-            0, -frameScale, 0, 0,
-            0, 0, frameScale, 0,
-            frameX, frameY, 0, 1
-        ];
-    }
-
 
     // 2. multiply values
     if (frameMatrix.length === 16) {

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1187,7 +1187,8 @@ realityEditor.gui.ar.draw.drawTransformed = function (visibleObjects, objectKey,
             */
 
             // can't change while frozen so don't recalculate
-            if (realityEditor.device.environment.supportsDistanceFading() && !globalStates.freezeButtonState) {
+            if (realityEditor.device.environment.supportsDistanceFading() &&
+                (!globalStates.freezeButtonState || realityEditor.device.environment.ignoresFreezeButton())) {
                 // fade out frames and nodes when they move beyond a certain distance
                 var distance = activeVehicle.screenZ;
                 var distanceScale = realityEditor.gui.ar.getDistanceScale(activeVehicle);

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -79,13 +79,6 @@ realityEditor.gui.ar.draw.activeObjectMatrix = [];
 realityEditor.gui.ar.draw.finalMatrix = [];
 realityEditor.gui.ar.draw.rotateX = rotateX;
 
-var desktopFrameTransform = [
-    1, 0, 0, 0,
-    0, 1, 0, 0,
-    0, 0, 1, 0,
-    0, 0, 0, 1
-];
-
 /**
  * @type {{temp: number[], begin: number[], end: number[], r: number[], r2: number[], r3: number[]}}
  */

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1193,9 +1193,8 @@ realityEditor.gui.ar.draw.drawTransformed = function (visibleObjects, objectKey,
             }
             */
 
-            // frames don't fade out with distance on desktop remote renderer, but they do on the phone
-            var ENABLE_DISTANCE_FADING_ON_DESKTOP = false;
-            if ((!realityEditor.device.utilities.isDesktop() || ENABLE_DISTANCE_FADING_ON_DESKTOP) && !globalStates.freezeButtonState) { // can't change while frozen so don't recalculate
+            // can't change while frozen so don't recalculate
+            if (realityEditor.device.environment.supportsDistanceFading() && !globalStates.freezeButtonState) {
                 // fade out frames and nodes when they move beyond a certain distance
                 var distance = activeVehicle.screenZ;
                 var distanceScale = realityEditor.gui.ar.getDistanceScale(activeVehicle);
@@ -1377,13 +1376,6 @@ realityEditor.gui.ar.draw.drawTransformed = function (visibleObjects, objectKey,
                     utilities.multiplyMatrix(positionData.matrix, activeObjectMatrix, matrix.r);
                     utilities.multiplyMatrix(matrix.r3, matrix.r, finalMatrix);
                 }
-            }
-
-            // todo: this code was thrown together in a pretty haphazard way for desktop rendering. needs some cleanup and documentation.
-            // fixes rotation too late
-            if (realityEditor.device.utilities.isDesktop()) {
-                var finalMatCopy = realityEditor.gui.ar.utilities.copyMatrix(finalMatrix);
-                realityEditor.gui.ar.utilities.multiplyMatrix(desktopFrameTransform, finalMatCopy, finalMatrix);
             }
 
             if (typeof activeVehicle.attachToGroundPlane !== 'undefined') {

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -387,7 +387,7 @@ realityEditor.gui.ar.draw.update = function (visibleObjects) {
             // }
       
             // TODO: check if this needs to be fixed for desktop, now that we have a different method for worldCorrection / world origins
-            if (!realityEditor.device.utilities.isDesktop()) {
+            if (realityEditor.device.environment.shouldBroadcastUpdateObjectMatrix()) {
                 if (realityEditor.gui.ar.draw.worldCorrection !== null) {
                     console.warn('Should never get here until we fix worldCorrection');
                     if (!this.activeObject.isWorldObject) {
@@ -405,7 +405,7 @@ realityEditor.gui.ar.draw.update = function (visibleObjects) {
                     continue;
                 }
                 // on desktop, model matrix for a world object will be origin instead of camera position, so update with camera view matrix
-                if (realityEditor.device.utilities.isDesktop()) {
+                if (realityEditor.device.environment.doWorldObjectsRequireCameraTransform()) {
                     this.activeObjectMatrix = realityEditor.gui.ar.utilities.copyMatrix(this.visibleObjects[objectKey]);
                     // use rotateX?
                     var tempM = [];

--- a/src/gui/ar/index.js
+++ b/src/gui/ar/index.js
@@ -65,25 +65,6 @@ createNameSpace("realityEditor.gui.ar");
  * @param {Array.<number>} matrix - a 4x4 projection matrix
  */
 realityEditor.gui.ar.setProjectionMatrix = function(matrix) {
-    
-    // matrix[0] *= -1;
-
-    // if (realityEditor.device.utilities.isDesktop()) {
-    //     globalStates.realProjectionMatrix = matrix;
-    //     globalStates.projectionMatrix = matrix;
-    //     return;
-    // }
-    //
-    // if (realityEditor.device.utilities.isDesktop()) {
-    //     var scaleFactor = window.innerWidth/568;
-    //     matrix[0] *= scaleFactor;
-    //     matrix[5] *= scaleFactor;
-    //     matrix[10] *= scaleFactor;
-    //     globalStates.realProjectionMatrix = matrix;
-    //     globalStates.projectionMatrix = matrix;
-    //     return;
-    // }
-    //
 
     if (realityEditor.device.utilities.isDesktop()) {
         matrix[5] *= -1;
@@ -205,10 +186,6 @@ realityEditor.gui.ar.setProjectionMatrix = function(matrix) {
     ];
     
     var multiplier = -1;
-
-    // if (realityEditor.device.utilities.isDesktop()) {
-    //     multiplier = 1;
-    // }
 
     var viewportScaling = [
         globalStates.height, 0, 0, 0,

--- a/src/gui/ar/index.js
+++ b/src/gui/ar/index.js
@@ -65,11 +65,6 @@ createNameSpace("realityEditor.gui.ar");
  * @param {Array.<number>} matrix - a 4x4 projection matrix
  */
 realityEditor.gui.ar.setProjectionMatrix = function(matrix) {
-
-    if (realityEditor.device.utilities.isDesktop()) {
-        matrix[5] *= -1;
-        matrix[0] *= -1;
-    }
     
     var corX = 0;
     var corY = 0;
@@ -391,36 +386,6 @@ realityEditor.gui.ar.closestVisibleObject = function(optionalFilter) {
     return {
         objectKey: object,
         distance: distance
-    }
-};
-
-/**
- * @note: currently not used, but may be useful
- * Returns a list of every object and the distance from that to the camera 
- * @param {boolean} isDesktop
- * @return {{dist: *, key: *}[]}
- */
-realityEditor.gui.ar.utilities.getAllObjectDistances = function(isDesktop) {
-    
-    if (isDesktop) {
-        // camera behavior is different on desktop
-        return Object.keys(realityEditor.gui.ar.draw.visibleObjects).map(function(key) {
-            var mat = [];
-            realityEditor.gui.ar.utilities.multiplyMatrix(realityEditor.gui.ar.draw.visibleObjects[key], realityEditor.gui.ar.draw.correctedCameraMatrix, mat);
-            return {
-                key: key,
-                dist: realityEditor.gui.ar.utilities.distance(mat)
-            }
-        });
-
-    } else {
-        return Object.keys(realityEditor.gui.ar.draw.modelViewMatrices).map(function (key) {
-            return {
-                key: key,
-                dist: realityEditor.gui.ar.utilities.distance(realityEditor.gui.ar.draw.modelViewMatrices[key])
-            }
-        });
-
     }
 };
 

--- a/src/gui/ar/lines.js
+++ b/src/gui/ar/lines.js
@@ -413,10 +413,8 @@ realityEditor.gui.ar.lines.drawLine = function(context, lineStartPoint, lineEndP
         lineStartWeight = lineEndWeight;
     }
     
-    if (realityEditor.device.utilities.isDesktop()) {
-        lineStartWeight *= 5;
-        lineEndWeight *= 5;
-    }
+    lineStartWeight *= realityEditor.device.environment.getLineWidthMultiplier();
+    lineEndWeight *= realityEditor.device.environment.getLineWidthMultiplier();
     
     if (typeof lineAlphaStart === 'undefined') lineAlphaStart = 1.0;
     if (typeof lineAlphaEnd === 'undefined') lineAlphaEnd = 1.0;

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -1469,7 +1469,7 @@ realityEditor.gui.ar.utilities.repositionedMatrix = function (matrix, object) {
 realityEditor.gui.ar.utilities.distance = function (matrix) {
     var distance = 1000; // for now give a valid value as a fallback
     try {
-        if (realityEditor.device.utilities.isDesktop()) {
+        if (realityEditor.device.environment.distanceRequiresCameraTransform()) {
             // calculate distance to camera
             var matrixToCamera = [];
             realityEditor.gui.ar.utilities.multiplyMatrix(matrix, realityEditor.gui.ar.draw.correctedCameraMatrix, matrixToCamera);

--- a/src/gui/crafting/blockMenu.js
+++ b/src/gui/crafting/blockMenu.js
@@ -99,9 +99,8 @@ createNameSpace("realityEditor.gui.crafting.blockMenu");
         container.style.width = '506px';
         container.style.height = '320px';
         
-        // TODO: move into desktop module
         // change display for desktop programming
-        if (realityEditor.device.utilities.isDesktop()) {
+        if (realityEditor.device.environment.shouldDisplayLogicMenuModally()) {
             container.style.left = 'unset';
             craftingMenusContainer.style.background = 'rgba(0, 0, 0, 0.5)';
             craftingMenusContainer.style.backdropFilter = 'blur(3px)';
@@ -110,6 +109,8 @@ createNameSpace("realityEditor.gui.crafting.blockMenu");
             var scaleMultiplier = Math.max(logic.grid.containerHeight / logic.grid.gridHeight, logic.grid.containerWidth / logic.grid.gridWidth);
             container.style.transformOrigin = '100% 50%';
             container.style.transform = 'scale(' + scaleMultiplier + ')';
+
+            // TODO: needs some additional styling to look good on modal environments, e.g. to blockIcon
         }
 
         craftingMenusContainer.appendChild(container);
@@ -255,7 +256,7 @@ createNameSpace("realityEditor.gui.crafting.blockMenu");
     function redisplayTabSelection() {
 
         // TODO: move into desktop adapter module
-        if (realityEditor.device.utilities.isDesktop()) {
+        if (realityEditor.device.environment.shouldDisplayLogicMenuModally()) {
             document.getElementById("datacraftingCanvas").style.display = '';
             document.getElementById("blockPlaceholders").style.display = '';
             document.getElementById("blocks").style.display = '';

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -875,7 +875,13 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
                     if (globalStates.guiState === "node") {
                         
                         // we're using the same method as when we add a node from a memory, instead of using old pocket method. // TODO: make less hack of a solution
-                        let addedElement = realityEditor.gui.pocket.createLogicNode();
+                        let addedElement = null;
+                        try {
+                            addedElement = realityEditor.gui.pocket.createLogicNode();
+                        } catch (e) {
+                            console.warn('Unable to create new logic node', e);
+                            return;
+                        }
 
                         // set the name of the node by counting how many logic nodes the frame already has
                         var closestFrame = realityEditor.getFrame(addedElement.objectKey, addedElement.frameKey);

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ var realityEditor = realityEditor || {
     },
     device: {
         distanceScaling: {},
+        environment: {},
         keyboardEvents: {},
         layout: {},
         onLoad: {},

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -19,15 +19,19 @@ createNameSpace("realityEditor.network.realtime");
      */
     function initService() {
         // TODO Is this redundant code? It seems to generate the error that pops up
-        
-        if (realityEditor.device.utilities.isDesktop()) { realityEditor.gui.settings.toggleStates.realtimeEnabled = true; } // realtime is necessary for desktop to work
+
+        // realtime is necessary for some environments to work
+        if (realityEditor.device.environment.shouldCreateDesktopSocket()) {
+            realityEditor.gui.settings.toggleStates.realtimeEnabled = true;
+        }
         console.log('realityEditor.network.realtime.initService()', hasBeenInitialized, realityEditor.gui.settings.toggleStates.realtimeEnabled);
 
+        // don't initialize multiple times or if this feature is specifically turned off
         if (hasBeenInitialized || !realityEditor.gui.settings.toggleStates.realtimeEnabled) return;
         
         console.log('actually initializing realtime services');
 
-        if (realityEditor.device.utilities.isDesktop()) {
+        if (realityEditor.device.environment.shouldCreateDesktopSocket()) {
             desktopSocket = io.connect();
         }
         setupVehicleUpdateSockets();


### PR DESCRIPTION
Can I get feedback on this design change?

**Motivation**: the iPad rendering was broken because it mistakenly evaluated isDesktop to true because of changes to window.navigation.userAgent. Rather than simply change this to a more accurate check, I thought it would be better if some variables/features were explicitly enabled by the add-ons that require them (e.g. internalResearch-addon), and default to normal app behavior if the add-on is not present.

**Method**: I split up the isDesktop variable into a set of variables based on what it was being used for, and added setters/getters for those capabilities to src/device/environment.js. This means that new add-ons can selectively trigger certain behavior in the core app by toggling these environment vars. Essentially decouples the add-on from the implementations of the capabilities it requires.

Corresponding changes made to addon, e.g. https://github.com/ptcrealitylab/vuforia-spatial-internalResearch-addon/pull/2