### PR TITLE
Hotfix hidden canvas

### DIFF
--- a/src/gui/spatial/index.js
+++ b/src/gui/spatial/index.js
@@ -342,6 +342,12 @@ realityEditor.gui.spatial.sketch = function(p) {
 
 realityEditor.gui.spatial.myp5 = new p5(realityEditor.gui.spatial.sketch.bind(realityEditor.gui.spatial), 'p5WebGL');
 
+// creating the p5 canvas somehow sets display: none on the globalCanvas
+for (let time = 100; time < 10000; time *= 2) {
+    setTimeout(function() {
+        globalCanvas.canvas.style.display = ''; // unhide the canvas getting auto-hidden by p5
+    }, time);
+}
 
 realityEditor.gui.spatial.draw.nodesP5 = function (object,p){
     

--- a/src/gui/spatial/index.js
+++ b/src/gui/spatial/index.js
@@ -8,7 +8,6 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-
 createNameSpace("realityEditor.gui.spatial");
 realityEditor.gui.spatial.worldOrigin = [
     1, 0, 0, 0,
@@ -38,42 +37,41 @@ realityEditor.gui.spatial.lineAnimationList = {};
 
 realityEditor.gui.spatial.collectSpatialList = function(worldOrigin, modelMatrix, objMatrix, objectID){
     this.worldOrigin = worldOrigin;
-    
-    if( globalStates.spatial.whereWas || globalStates.spatial.velocityOf) {
+
+    if (globalStates.spatial.whereWas || globalStates.spatial.velocityOf) {
         this.timeRecorder.initSequence(objectID, objectID, '', '');
         this.timeRecorder.addMatrix(objMatrix, objectID);
-        
+
         if (this.objects[objectID]) {
             for (let key in this.objects[objectID].frames) {
-                        let thisTool = this.objects[objectID].frames[key];
-                        let m3 = [
-                            thisTool.ar.scale, 0, 0, 0,
-                            0, thisTool.ar.scale, 0, 0,
-                            0, 0, thisTool.ar.scale, 0,
-                            thisTool.ar.x, thisTool.ar.y, 0, 1
-                        ];
-                        let m0 = [];
-                        let m1 = [];
+                let thisTool = this.objects[objectID].frames[key];
+                let m3 = [
+                    thisTool.ar.scale, 0, 0, 0,
+                    0, thisTool.ar.scale, 0, 0,
+                    0, 0, thisTool.ar.scale, 0,
+                    thisTool.ar.x, thisTool.ar.y, 0, 1
+                ];
+                let m0 = [];
+                let m1 = [];
 
-                        if (thisTool.ar.matrix.length < 13) {
-                            this.utilities.multiplyMatrix(m3, objMatrix, m0);
-                        } else {
-                            this.utilities.multiplyMatrix(thisTool.ar.matrix, objMatrix, m1);
-                            this.utilities.multiplyMatrix(m3, m1, m0);
-                        }
-                        
+                if (thisTool.ar.matrix.length < 13) {
+                    this.utilities.multiplyMatrix(m3, objMatrix, m0);
+                } else {
+                    this.utilities.multiplyMatrix(thisTool.ar.matrix, objMatrix, m1);
+                    this.utilities.multiplyMatrix(m3, m1, m0);
+                }
+
                 this.timeRecorder.initSequence(objectID+key, objectID, key, '');
                 this.timeRecorder.addMatrix(m0, objectID+key);
             }
         }
-        
     }
-    
-   // console.log(objMatrix[12],objMatrix[13],objMatrix[14]);
+
+    // console.log(objMatrix[12],objMatrix[13],objMatrix[14]);
     for(let ip in  globalStates.spatial.whereIs) {
         for(let key in  globalStates.spatial.whereIs[ip]) {
             this.loadObjectAndTool(this, globalStates.spatial.whereIs[ip][key], this.whereIsList, key, modelMatrix,objectID)
-        }  
+        }
     }
 
     for(let ip in  globalStates.spatial.whereIs) {
@@ -82,48 +80,39 @@ realityEditor.gui.spatial.collectSpatialList = function(worldOrigin, modelMatrix
         }
     }
 
-        for(let ip in  globalStates.spatial.whereIs) {
-            for (let key in globalStates.spatial.whereWas[ip]) {
-                this.loadObjectAndTool(this, globalStates.spatial.whereWas[ip][key], this.whereWasList, key, null, objectID);
-            }
+    for(let ip in  globalStates.spatial.whereIs) {
+        for (let key in globalStates.spatial.whereWas[ip]) {
+            this.loadObjectAndTool(this, globalStates.spatial.whereWas[ip][key], this.whereWasList, key, null, objectID);
         }
+    }
 
-   for(let ip in  globalStates.spatial.whereIs) {
-       for (let key in globalStates.spatial.velocityOf[ip]) {
-           this.loadObjectAndTool(this, globalStates.spatial.velocityOf[ip][key], this.velocityOfList, key, modelMatrix, objectID);
-       }
-   }
-
-
-   
-    
+    for(let ip in  globalStates.spatial.whereIs) {
+        for (let key in globalStates.spatial.velocityOf[ip]) {
+            this.loadObjectAndTool(this, globalStates.spatial.velocityOf[ip][key], this.velocityOfList, key, modelMatrix, objectID);
+        }
+    }
 };
 
 realityEditor.gui.spatial.collectNodeList = function(_objMatrix, _objectID, _nodeID){
-  // console.log(objectID, objects[objectID].internalMatrix.object);
-   /*
-   for(let key in  objects[objectID].frames){
-       if(objects[objectID].frames.hasOwnProperty(key)) {
-           realityEditor.gui.spatial.transformTools(objects[objectID].frames[key], objects[objectID], "tool");
-         //  console.log(objects[objectID].frames[key]);
-           for (let key2 in objects[objectID].frames[key].nodes) {
-                   realityEditor.gui.spatial.transformTools(objects[objectID].frames[key].nodes[key2], objects[objectID].frames[key], "node");
-             // console.log(objects[objectID].frames[key].nodes[key2]);
-              
-             realityEditor.gui.spatial.nodeList[objectID + key+key2] = {};
-               realityEditor.gui.spatial.nodeList[objectID + key+key2].object = objects[objectID].frames[key].nodes[key2];
-               realityEditor.gui.spatial.nodeList[objectID + key+key2].matrix = realityEditor.gui.spatial.nodeList[objectID + key+key2].object.internalMatrix.modelView;
-
-                   
+    // console.log(objectID, objects[objectID].internalMatrix.object);
+    /*
+    for(let key in  objects[objectID].frames){
+        if(objects[objectID].frames.hasOwnProperty(key)) {
+            realityEditor.gui.spatial.transformTools(objects[objectID].frames[key], objects[objectID], "tool");
+          //  console.log(objects[objectID].frames[key]);
+            for (let key2 in objects[objectID].frames[key].nodes) {
+                    realityEditor.gui.spatial.transformTools(objects[objectID].frames[key].nodes[key2], objects[objectID].frames[key], "node");
+              // console.log(objects[objectID].frames[key].nodes[key2]);
                
-           }
-       }
-   }
-
-  // console.log(realityEditor.gui.spatial.nodeList);
-*/
+              realityEditor.gui.spatial.nodeList[objectID + key+key2] = {};
+                realityEditor.gui.spatial.nodeList[objectID + key+key2].object = objects[objectID].frames[key].nodes[key2];
+                realityEditor.gui.spatial.nodeList[objectID + key+key2].matrix = realityEditor.gui.spatial.nodeList[objectID + key+key2].object.internalMatrix.modelView;
+            }
+        }
+    }
+   // console.log(realityEditor.gui.spatial.nodeList);
+ */
 };
-
 
 realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject, type) {
     if(!referenceObject.internalMatrix) return;
@@ -139,8 +128,6 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
         0, 0, ar.scale, 0,
         ar.x, ar.y, 0, 1
     ];
-
-  
     
     let m0 = [];
     let m1 = [];
@@ -151,15 +138,15 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
         0, 0, 1, 0,
         0, 0, 0, 1
     ];
-    
-    if(type === "node"){
+
+    if (type === "node") {
         if(ar.matrix.length < 13){
             if(referenceObject.ar.matrix.length > 13){
                 ar.matrix = referenceObject.ar.matrix;
             }
         }
 
-        if(referenceObject.location === "global") {
+        if (referenceObject.location === "global") {
             m3 = [
                 ar.scale * (referenceObject.ar.scale) , 0, 0, 0,
                 0, ar.scale * (referenceObject.ar.scale) , 0, 0,
@@ -167,8 +154,7 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
                 ar.x + referenceObject.ar.x, ar.y + referenceObject.ar.y, 0, 1
             ];
         }
-        
-        
+
         if (ar.matrix.length < 13) {
             this.utilities.multiplyMatrix(m3, referenceObject.internalMatrix.object, m5);
         } else {
@@ -177,9 +163,8 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
         }
         this.utilities.multiplyMatrix(m5, referenceObject.internalMatrix.world, m4);
 
-    }
-    else  if(type === "tool"){
-        
+    } else if (type === "tool") {
+
         if (ar.matrix.length < 13) {
             this.utilities.multiplyMatrix(m3, referenceObject.internalMatrix.object, m0);
         } else {
@@ -188,11 +173,11 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
         }
 
         let m6 = [];
-        
+
         realityEditor.gui.ar.utilities.multiplyMatrix(rotateX, m0, m6); // TODO: to really optimize, could inline/simplify the rotateX multiplication
         realityEditor.gui.ar.utilities.multiplyMatrix(m6, referenceObject.internalMatrix.world, m4);
-        
-      //  this.utilities.multiplyMatrix(m0, referenceObject.internalMatrix.world, m4);
+
+        //  this.utilities.multiplyMatrix(m0, referenceObject.internalMatrix.world, m4);
 
         //  this.utilities.multiplyMatrix(m0, referenceObject.internalMatrix.world, m4);
     }
@@ -207,10 +192,9 @@ realityEditor.gui.spatial.transformTools = function ( thisItem, referenceObject,
     };
 };
 
+realityEditor.gui.spatial.loadObjectAndTool = function(that, workObject, list, key, matrix, objectID) {
 
-realityEditor.gui.spatial.loadObjectAndTool = function(that, workObject, list, key, matrix, objectID){
-
-    if(workObject.objectID === objectID) {
+    if (workObject.objectID === objectID) {
         if (workObject.toolID === "") {
             list[objectID] = {
                 'key': objectID,
@@ -220,8 +204,7 @@ realityEditor.gui.spatial.loadObjectAndTool = function(that, workObject, list, k
         } else if (this.objects[objectID]) {
             for (let key in this.objects[objectID].frames) {
                 if (workObject.toolID === key) {
-                    if(!matrix)
-                    {
+                    if (!matrix) {
                         list[objectID + key] = {
                             'key': objectID + key,
                             'matrix': null
@@ -255,8 +238,6 @@ realityEditor.gui.spatial.loadObjectAndTool = function(that, workObject, list, k
     }
 };
 
-
-
 realityEditor.gui.spatial.myFont = null;
 realityEditor.gui.spatial.canvasThis = null;
 realityEditor.gui.spatial.saveOldMatrix = null;
@@ -267,7 +248,7 @@ realityEditor.gui.spatial.sketch = function(p) {
     p.preload = function() {
         this.myFont = p.loadFont('thirdPartyCode/fonts/BrutalType.otf');
     }.bind(this);
-  
+
     p.setup = function() {
         p.setAttributes('antialias', true);
         this.canvasThis = p.createCanvas(globalStates.height,globalStates.width, p.WEBGL);
@@ -275,42 +256,42 @@ realityEditor.gui.spatial.sketch = function(p) {
         let gl = document.getElementById('p5jsCanvas').getContext('webgl');
         gl.disable(gl.DEPTH_TEST);
         _canvasTexture = p.createGraphics(globalStates.height, globalStates.width,null, globalCanvas.canvas);
-     
-     //  p.frameRate(5);
+
+        //  p.frameRate(5);
     }.bind(this);
-    
+
     p.draw = function() {
 
         p.clear();
-     
+
         // copy normal ball connection context
 
         p.push();
         this.canvasThis.uPMatrix.set(globalStates.realProjectionMatrix);
         // console.log(p.frameRate());
-     
 
-        this.canvasThis.uMVMatrix.set([   
+
+        this.canvasThis.uMVMatrix.set([
             1, 0, 0, 0,
             0, 1, 0, 0,
             0, 0, 1, 0,
             0, 0, 0, 1]);
+
+        /*
+          p.push();
       
-      /*
-        p.push();
-    
-        p.translate(globalStates.height/2,-globalStates.width/2,-544);
-       // if(globalStates.deviceOrientationRight) {
-        p.rotateY(Math.PI);
-    //}
-    // canvasTexture.background(100);
-        p.image(canvasTexture, 0, 0);
-        p.pop();
-        */
-      /*  for(let key in this.nodeList) {
-            this.draw.nodesP5(this.nodeList[key],p);
-        }*/
-        
+          p.translate(globalStates.height/2,-globalStates.width/2,-544);
+         // if(globalStates.deviceOrientationRight) {
+          p.rotateY(Math.PI);
+      //}
+      // canvasTexture.background(100);
+          p.image(canvasTexture, 0, 0);
+          p.pop();
+          */
+        /*  for(let key in this.nodeList) {
+              this.draw.nodesP5(this.nodeList[key],p);
+          }*/
+
         for(let key in this.whereIsList) {
             this.draw.whereIsP5(this.whereIsList[key],p);
         }
@@ -325,44 +306,43 @@ realityEditor.gui.spatial.sketch = function(p) {
 
         this.canvasThis.uMVMatrix.apply(this.worldOrigin);
         //  p.translate( this.worldOrigin[12], this.worldOrigin[13], this.worldOrigin[14]);
-/*
-        p.fill('rgba(0,255,255, 1)');
-        p.stroke('rgba(0,255,255, 1)');
-        p.circle(0,0,20);
-        p.sphere(5);*/
-        
-        
+        /*
+                p.fill('rgba(0,255,255, 1)');
+                p.stroke('rgba(0,255,255, 1)');
+                p.circle(0,0,20);
+                p.sphere(5);*/
+
+
         for(let key in this.whereWasList) {
             this.draw.whereWasP5(this.whereWasList[key],p);
         }
-        
+
         p.pop();
     }.bind(this);
 };
 
 realityEditor.gui.spatial.myp5 = new p5(realityEditor.gui.spatial.sketch.bind(realityEditor.gui.spatial), 'p5WebGL');
 
-// creating the p5 canvas somehow sets display: none on the globalCanvas
-for (let time = 100; time < 10000; time *= 2) {
+// creating the p5 canvas somehow sets display:none on the globalCanvas
+// for now, fix it by repeatedly setting it back to un-hidden a few times
+for (let time = 100; time < 5000; time *= 2) {
     setTimeout(function() {
         globalCanvas.canvas.style.display = ''; // unhide the canvas getting auto-hidden by p5
     }, time);
 }
 
-realityEditor.gui.spatial.draw.nodesP5 = function (object,p){
-    
-  
+realityEditor.gui.spatial.draw.nodesP5 = function (object,p) {
     p.push();
- realityEditor.gui.spatial.canvasThis.uMVMatrix.apply(object.matrix);
+    realityEditor.gui.spatial.canvasThis.uMVMatrix.apply(object.matrix);
 //p.translate(m[12], m[13], m[14]*0.97);
- //   p.background(100);
-   p.erase();
+    //   p.background(100);
+    p.erase();
     p.fill('rgba(255,255,255, 1)');
-  p.stroke('rgba(0,255,255, 1)');
-   p.circle(0,0,250);
-   p.noErase();
-   p.blendMode(p.ADD);
-   // p.sphere(50);
+    p.stroke('rgba(0,255,255, 1)');
+    p.circle(0,0,250);
+    p.noErase();
+    p.blendMode(p.ADD);
+    // p.sphere(50);
 
     p.translate(0, -400, 0);
 
@@ -371,35 +351,30 @@ realityEditor.gui.spatial.draw.nodesP5 = function (object,p){
     p.textAlign(p.CENTER, p.CENTER);
     p.text(object.object.data.value, 0, 0);
     p.pop();
-    
-    
-    
 };
-
 
 realityEditor.gui.spatial.draw.whereWasP5 = function (workObject,p){
     p.noStroke();
     if(!(workObject.key in realityEditor.gui.spatial.timeRecorder.sequences)) return;
     let sequence = realityEditor.gui.spatial.timeRecorder.sequences[workObject.key].sequence;
 
-  if(sequence.length>2){
-      for (let i = 1; i < sequence.length; i++) {
-         // p.vertex(sequence[i].m[0], sequence[i].m[1],sequence[i].m[2]);
-        // realityEditor.gui.spatial.draw.drawLineP5(p, null, sequence[i-1].m,sequence[i].m,2, 2,[0,255,255, 1],[0,255,255, 1], "solid", 2, null);
-          realityEditor.gui.spatial.draw.drawLineP5(p, workObject, sequence[i-1].m,sequence[i].m ,2, 2,[0,255,255, 1],[0,255,255, 1], "solid", -0.1, null);
-   
-      }
-    /*  p.endShape();
-      p.pop();*/
-  }
+    if(sequence.length>2){
+        for (let i = 1; i < sequence.length; i++) {
+            // p.vertex(sequence[i].m[0], sequence[i].m[1],sequence[i].m[2]);
+            // realityEditor.gui.spatial.draw.drawLineP5(p, null, sequence[i-1].m,sequence[i].m,2, 2,[0,255,255, 1],[0,255,255, 1], "solid", 2, null);
+            realityEditor.gui.spatial.draw.drawLineP5(p, workObject, sequence[i-1].m,sequence[i].m ,2, 2,[0,255,255, 1],[0,255,255, 1], "solid", -0.1, null);
+
+        }
+        /*  p.endShape();
+          p.pop();*/
+    }
 };
-realityEditor.gui.spatial.draw.lastLocation = {
-    
-};
-    
-realityEditor.gui.spatial.draw.velocityOfP5 = function (workObject,p){
-    if(!(workObject.key in realityEditor.gui.spatial.timeRecorder.sequences)) return;
-    
+
+realityEditor.gui.spatial.draw.lastLocation = {};
+
+realityEditor.gui.spatial.draw.velocityOfP5 = function (workObject,p) {
+    if (!(workObject.key in realityEditor.gui.spatial.timeRecorder.sequences)) return;
+
     let thisSequence = realityEditor.gui.spatial.timeRecorder.sequences[workObject.key];
 
     let m1 = workObject.matrix;
@@ -420,29 +395,27 @@ realityEditor.gui.spatial.draw.velocityOfP5 = function (workObject,p){
     } else {
         p.rotateY(Math.PI);
     }
- 
+
     p.textFont(realityEditor.gui.spatial.myFont);
     p.textSize(15);
     p.textAlign(p.CENTER, p.CENTER);
-  
+
     p.text(parseInt(thisSequence.speed*10)/10 + ' m/s', 0, 0);
     p.pop();
-    
 
-        let m4 = realityEditor.gui.spatial.timeRecorder.copyArray(workObject.matrix);
+
+    let m4 = realityEditor.gui.spatial.timeRecorder.copyArray(workObject.matrix);
 
     m4[12] -= thisSequence.speedVector[0];
     m4[13] -= thisSequence.speedVector[1];
     m4[14] -= thisSequence.speedVector[2];
-    
-            realityEditor.gui.spatial.draw.drawLineP5(p, workObject, workObject.matrix, m4, 4, 2, [255, 255, 0, 1], [255, 255, 0, 1], "solid", 0, null);
 
+    realityEditor.gui.spatial.draw.drawLineP5(p, workObject, workObject.matrix, m4, 4, 2, [255, 255, 0, 1], [255, 255, 0, 1], "solid", 0, null);
 };
 
-
-realityEditor.gui.spatial.draw.whereIsP5 = function (workObject,p){
+realityEditor.gui.spatial.draw.whereIsP5 = function (workObject,p) {
     let matrix = workObject.matrix;
-    
+
     p.push();
 
     p.stroke('rgba(0,255,255, 0.8)');
@@ -450,7 +423,7 @@ realityEditor.gui.spatial.draw.whereIsP5 = function (workObject,p){
     p.fill('rgba(0,255,255, 0.8)');
 
     p.beginShape();
-    
+
     p.vertex(-5,10, -20);
     p.vertex(-5,matrix[13], matrix[14]);
     p.vertex(0,matrix[13]-5, matrix[14]);
@@ -481,15 +454,15 @@ realityEditor.gui.spatial.draw.whereIsP5 = function (workObject,p){
     p.fill('rgba(0,255,255, 1)');
     p.sphere(5);
     p.pop();
-
 };
+
 let _angle = 0;
-realityEditor.gui.spatial.draw.howFarIsP5 = function (obj,p){
+realityEditor.gui.spatial.draw.howFarIsP5 = function (obj,p) {
     let m1 = obj.matrix;
     let _worldAngle = Math.atan2(m1[13], m1[12]);
     let color;
     color = [0,255,255, 0.8];
- 
+
     p.noStroke();
 
     p.fill('rgba(0,255,255, 1)');
@@ -498,14 +471,14 @@ realityEditor.gui.spatial.draw.howFarIsP5 = function (obj,p){
     p.sphere(5);
     p.pop();
     p.fill(color);
-    for(let key in realityEditor.gui.spatial.howFarIsList){
-        if(key !== obj.key){
+    for (let key in realityEditor.gui.spatial.howFarIsList) {
+        if (key !== obj.key) {
             let m2 = realityEditor.gui.spatial.howFarIsList[key].matrix;
-            
-            if(m1[12]>m2[12]){
+
+            if (m1[12]>m2[12]) {
 
                 realityEditor.gui.spatial.draw.drawLineP5(p, obj, m1,m2,2, 2,[0,255,255, 1],[0,255,255, 1], "solid", 15, "line");
-                
+
                 // erase background
                 p.push();
                 p.translate(
@@ -518,7 +491,7 @@ realityEditor.gui.spatial.draw.howFarIsP5 = function (obj,p){
                 p.rect(-20, -10, 40, 20, 5);
                 p.noErase();
                 p.blendMode(p.ADD);
-             
+
                 // distance Number
                 p.translate(0,0,0.1);
                 if(!globalStates.deviceOrientationRight) {
@@ -548,7 +521,7 @@ realityEditor.gui.spatial.draw.mL = {
     z2 : 14
 };
 
-realityEditor.gui.spatial.draw.drawLineP5 = function (p, obj, m1,m2,startWidth, endWidth, startColor, endColor, lineType, endSpacer, endpointType){
+realityEditor.gui.spatial.draw.drawLineP5 = function (p, obj, m1,m2,startWidth, endWidth, startColor, endColor, lineType, endSpacer, endpointType) {
     let that = realityEditor.gui.spatial.draw.mL;
 
     that.x = 12;
@@ -571,7 +544,7 @@ realityEditor.gui.spatial.draw.drawLineP5 = function (p, obj, m1,m2,startWidth, 
         that.y2 = 1;
         that.z2 = 2;
     }
-     // init math
+    // init math
     that.distance = Math.sqrt(Math.pow(m1[that.x]-m2[that.x2], 2) + Math.pow(m1[that.y]-m2[that.y2], 2) + Math.pow(m1[that.z]-m2[that.z2], 2));
     that.angle = Math.atan2(m1[that.y]-m2[that.y2], m1[that.x]-m2[that.x2]);
     that.angleZ = Math.asin((m1[that.z] - m2[that.z2])/that.distance);
@@ -618,12 +591,9 @@ realityEditor.gui.spatial.draw.drawLineP5 = function (p, obj, m1,m2,startWidth, 
         p.vertex(+that.wDist, endSpacer + startWidth, 0);
         p.endShape();
         p.pop();
-        
-        
     }
     // solid line
-    if(lineType === "solid")
-    {
+    if (lineType === "solid") {
         p.push();
         p.fill("rgba("+startColor+")");
         p.beginShape();
@@ -633,7 +603,7 @@ realityEditor.gui.spatial.draw.drawLineP5 = function (p, obj, m1,m2,startWidth, 
         p.vertex(m2[that.x2]+that.endX+that.sX, m2[that.y2]+that.endY+that.sY, m2[that.z2]);
         p.endShape();
         p.pop();
-        
+
     } else if(lineType === "balls"){
         realityEditor.gui.spatial.drawLine(p, obj, m1, m2, startWidth, endWidth, startColor, endColor, null, 1, 1);
     }
@@ -645,7 +615,7 @@ realityEditor.gui.spatial.dL = {
 
 realityEditor.gui.spatial.drawLine = function(p, obj, m1, m2, startWeight, endWeight, startColor, endColor, speed, _startAplha, _endAlpha) {
     let that = realityEditor.gui.spatial;
-  startWeight = 20;
+    startWeight = 20;
     that.spacer = 5;
     if (!speed) speed = 0.5;
 
@@ -657,20 +627,20 @@ realityEditor.gui.spatial.drawLine = function(p, obj, m1, m2, startWeight, endWe
     that.vZ =  Math.tan(that.angleZ) * (startWeight + that.spacer)*-1;
     that.stepLength = Math.sqrt(Math.pow(that.vX, 2) + Math.pow(that.vY, 2) + Math.pow(that.vZ, 2));
     that.counter = that.lineVectorLength / that.stepLength-1;
-    
+
     if (!realityEditor.gui.spatial.lineAnimationList[obj.key]) realityEditor.gui.spatial.lineAnimationList[obj.key] = 0;
     if (realityEditor.gui.spatial.lineAnimationList[obj.key] >= startWeight + that.spacer)  realityEditor.gui.spatial.lineAnimationList[obj.key] = 0;
-    
+
     p.push();
-   p.fill("rgba("+startColor+")");
+    p.fill("rgba("+startColor+")");
     p.translate(m1[12], m1[13], m1[14]);
     p.translate( -Math.cos(that.angle) * realityEditor.gui.spatial.lineAnimationList[obj.key], -Math.sin(that.angle) * realityEditor.gui.spatial.lineAnimationList[obj.key], -Math.tan(that.angleZ) * realityEditor.gui.spatial.lineAnimationList[obj.key]);
     p.circle(0, 0, startWeight);
-    
+
     for (let i = 0; i < that.counter; i++) {
         p.translate(that.vX, that.vY, that.vZ);
-       p.circle(0, 0, startWeight);
-       // p.sphere(startWeight/2);
+        p.circle(0, 0, startWeight);
+        // p.sphere(startWeight/2);
     }
     p.pop();
     realityEditor.gui.spatial.lineAnimationList[obj.key] += (timeCorrection.delta)+speed;

--- a/src/gui/spatial/index.js
+++ b/src/gui/spatial/index.js
@@ -252,7 +252,7 @@ realityEditor.gui.spatial.sketch = function(p) {
     p.setup = function() {
         p.setAttributes('antialias', true);
         this.canvasThis = p.createCanvas(globalStates.height,globalStates.width, p.WEBGL);
-        this.canvasThis .id('p5jsCanvas');
+        this.canvasThis.id('p5jsCanvas');
         let gl = document.getElementById('p5jsCanvas').getContext('webgl');
         gl.disable(gl.DEPTH_TEST);
         _canvasTexture = p.createGraphics(globalStates.height, globalStates.width,null, globalCanvas.canvas);

--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,10 @@ var realityEditor = realityEditor || {
             positioning: {},
             utilities: {}
         },
-        spatial:{
-            whereIs :{},
-            draw : {},
-            timeRecorder : {},
+        spatial: {
+            whereIs: {},
+            draw: {},
+            timeRecorder: {},
         },
         crafting: {
             blockMenu: {},

--- a/src/states.js
+++ b/src/states.js
@@ -67,14 +67,14 @@ var TEMP_DISABLE_MEMORIES = false;
  **********************************************************************************************************************/
 
 var globalStates = {
-    spatial : { 
-        whereIs :{},
-        howFarIs : {},
-        whereWas : {},
-        velocityOf : {}
-        },
-    craftingMoveDelay : 400,
-    tempUuid : "0000",
+    spatial: {
+        whereIs: {},
+        howFarIs: {},
+        whereWas: {},
+        velocityOf: {}
+    },
+    craftingMoveDelay: 400,
+    tempUuid: "0000",
     debug: false,
     debugSpeechConsole: false,
     device: "",


### PR DESCRIPTION
Didn't test / notice that initializing a p5 canvas somehow sets display:none on all(?) other canvases when it finishes loading, so the links were being hidden. quick fix by setting back to visible after a timeout. (first commit)

also, added code reformat for spatial/index.js (second and third commits)