### PR TITLE
fixes groundplane orientation by not snapping to WORLD_local

### DIFF
--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -308,7 +308,7 @@ createNameSpace('realityEditor.app.callbacks');
             let worldObject = realityEditor.worldObjects.getBestWorldObject();
 
             // snap groundplane to world origin, if available
-            if (worldObject) {
+            if (worldObject && worldObject.uuid !== realityEditor.worldObjects.getLocalWorldId()) {
                 let origin = realityEditor.worldObjects.getOrigin(worldObject.uuid);
                 if (origin) {
                     let tempMatrix = [];


### PR DESCRIPTION
It appears that the ground plane bug wasn't actually that it was rotated 90 degrees, but actually that the ground plane was snapping to the orientation/position that the phone was held at when it opened. This is because I forgot to exclude the WORLD_local from the world origins that the ground plane snaps to.

I tried on my own object and it seemed to work. Can someone else verify that this works?