### PR TITLE
visualizes links to/from logic node's different colors

### DIFF
--- a/src/constructors.js
+++ b/src/constructors.js
@@ -334,6 +334,9 @@ function LogicGUIState() {
 	this.menuBlockData = [ [], [], [], [], [] ]; //defaultBlockData(); //TODO: load cached blocks instead of empty
 	// dom elements for blocks in menu
 	this.menuBlockDivs = [];
+	// keeps track of which colors have links drawn to them from the outside
+    this.connectedInputColors = [false, false, false, false]; // blue, green, yellow, red
+    this.connectedOutputColors = [false, false, false, false]; // stored in array for easy conversion to coordinates
 }
 
 /**

--- a/src/gui/crafting/index.js
+++ b/src/gui/crafting/index.js
@@ -61,23 +61,6 @@ realityEditor.gui.crafting.reusableLinkObject = {
     }
 };
 
-realityEditor.gui.crafting.recalculateConnectedColors = function(logic) {
-    let connectedLinks = realityEditor.getLinksToAndFromNode(logic.uuid);
-
-    let connectedInputs = connectedLinks.linksToNode.map(function(link) {
-        return link.logicB; // the port number of the end of the link
-    });
-    let connectedOutputs = connectedLinks.linksFromNode.map(function(link) {
-        return link.logicA; // the port number of the start of the link
-    });
-
-    // 0 = blue, 1 = green, 2 = yellow, 3 = red
-    [0, 1, 2, 3].forEach(function(index) {
-        logic.guiState.connectedInputColors[index] = connectedInputs.includes(index);
-        logic.guiState.connectedOutputColors[index] = connectedOutputs.includes(index);
-    });
-};
-
 realityEditor.gui.crafting.initService = function() {
     realityEditor.gui.buttons.registerCallbackForButton('gui', hideCraftingOnButtonUp);
     realityEditor.gui.buttons.registerCallbackForButton('logic', hideCraftingOnButtonUp);
@@ -378,34 +361,28 @@ realityEditor.gui.crafting.redrawDataCrafting = function() {
         this.realityEditor.gui.ar.lines.drawSimpleLine(ctx, tempLine.start.x, tempLine.start.y, tempLine.end.x, tempLine.end.y, lineColor, 3);
     }
 
-    // draw links from top of screen for any of the connected input colors
     let connectedInputColors = globalStates.currentLogic.guiState.connectedInputColors;
     let connectedOutputColors = globalStates.currentLogic.guiState.connectedOutputColors;
-
     let numReusableUpdates = connectedInputColors.filter(function(value) { return value; }).length +
         connectedOutputColors.filter(function(value) { return value; }).length;
 
+    // draw links from top of screen for any of the connected input colors
     connectedInputColors.forEach(function(isConnected, index) {
         if (!isConnected) { return; } // only draw connected lines
-        // draw dashed line from (blue-x, top) to (blue-x, blue-input-y)
         let linkX = grid.getColumnCenterX(index * 2);
         let endY = grid.getRowCenterY(0);
         _this.reusableLinkObject.route.pointData.points = [{screenX: linkX, screenY: 0}, {screenX: linkX, screenY: endY}];
         _this.drawDataCraftingLineDashed(ctx, realityEditor.gui.crafting.reusableLinkObject, numReusableUpdates);
     });
 
-    // draw links from top of screen for any of the connected input colors
+    // draw links to bottom of screen for any of the connected input colors
     connectedOutputColors.forEach(function(isConnected, index) {
         if (!isConnected) { return; } // only draw connected lines
-        // draw dashed line from (blue-x, top) to (blue-x, blue-input-y)
         let linkX = grid.getColumnCenterX(index * 2);
         let startY = grid.getRowCenterY(6);
         _this.reusableLinkObject.route.pointData.points = [{screenX: linkX, screenY: startY}, {screenX: linkX, screenY: window.innerHeight}];
         _this.drawDataCraftingLineDashed(ctx, realityEditor.gui.crafting.reusableLinkObject, numReusableUpdates);
     });
-
-    // draw links to bottom of screen for any of the connected output colors
-    // let connectedOutputColors = globalStates.currentLogic.guiState.connectedOutputColors;
 
     var tappedContents = globalStates.currentLogic.guiState.tappedContents;
     if (tappedContents) {
@@ -857,4 +834,27 @@ realityEditor.gui.crafting.initLogicInOutBlocks = function() {
             this.grid.addBlock(x, y, blockJSON, globalId, true);
         }
     }
+};
+
+/**
+ * Updates this logic node's connectedInputColors and connectedOutputColors by looking at all links on all objects
+ * that either start or end at this logic node and seeing which color they are connected to.
+ * Resulting format is something like [true, false, false, true] - meaning blue and red are connected on outside
+ * @param {Logic} logic
+ */
+realityEditor.gui.crafting.recalculateConnectedColors = function(logic) {
+    let connectedLinks = realityEditor.getLinksToAndFromNode(logic.uuid);
+
+    let connectedInputs = connectedLinks.linksToNode.map(function(link) {
+        return link.logicB; // the port number of the end of the link
+    });
+    let connectedOutputs = connectedLinks.linksFromNode.map(function(link) {
+        return link.logicA; // the port number of the start of the link
+    });
+
+    // 0 = blue, 1 = green, 2 = yellow, 3 = red
+    [0, 1, 2, 3].forEach(function(index) {
+        logic.guiState.connectedInputColors[index] = connectedInputs.includes(index);
+        logic.guiState.connectedOutputColors[index] = connectedOutputs.includes(index);
+    });
 };

--- a/src/gui/crafting/index.js
+++ b/src/gui/crafting/index.js
@@ -435,11 +435,11 @@ realityEditor.gui.crafting.redrawDataCrafting = function() {
  * Draws a blue dashed animated line along the route specified in the linkObject
  * @param {CanvasRenderingContext2D} context
  * @param {BlockLink} linkObject - contains route with points, and ballAnimationCount for animating
- * @param {number?} numSharingThis - optional param makes animation work at correct speed if the same
+ * @param {number?} numSharingLinkObject - optional param makes animation work at correct speed if the same
  *                                   ballAnimationCount is being shared by multiple links being rendered
  */
-realityEditor.gui.crafting.drawDataCraftingLineDashed = function(context, linkObject, numSharingThis) {
-    if (typeof numSharingThis === 'undefined') { numSharingThis = 1; }
+realityEditor.gui.crafting.drawDataCraftingLineDashed = function(context, linkObject, numSharingLinkObject) {
+    if (typeof numSharingLinkObject === 'undefined') { numSharingLinkObject = 1; }
 
     // context.save();
     // start a dashed line
@@ -452,7 +452,7 @@ realityEditor.gui.crafting.drawDataCraftingLineDashed = function(context, linkOb
     context.lineWidth = 3;
 
     // animate the line
-    var numFramesForAnimationLoop = 30 * numSharingThis;
+    var numFramesForAnimationLoop = 30 * numSharingLinkObject;
     linkObject.ballAnimationCount += totalLength / numFramesForAnimationLoop;
     if (linkObject.ballAnimationCount >= totalLength) {
         linkObject.ballAnimationCount = 0;

--- a/src/gui/crafting/index.js
+++ b/src/gui/crafting/index.js
@@ -52,11 +52,13 @@ createNameSpace("realityEditor.gui.crafting");
 realityEditor.gui.crafting.blockIconCache = {};
 realityEditor.gui.crafting.menuBarWidth = 62;
 realityEditor.gui.crafting.blockColorMap = ["#00FFFF", "#00FF00", "#FFFF00", "#FF007C"];
+
+// since all the connectedColors links have the same shape, we can animate them with the same object
 realityEditor.gui.crafting.reusableLinkObject = {
     ballAnimationCount: 0,
     route: {
-        pointData: {  // list of [{screenX, screenY}]
-            points: []
+        pointData: {
+            points: [] // list of [{screenX, screenY}] will get populated in render function
         }
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -452,3 +452,29 @@ realityEditor.getKeysFromVehicle = function(vehicle) {
 realityEditor.isVehicleAFrame = function(vehicle) {
     return (vehicle.type === 'ui' || typeof vehicle.type === 'undefined');
 };
+
+realityEditor.getLinksToAndFromNode = function(nodeKey) {
+    let linksToNode = [];
+    let linksFromNode = [];
+
+    // loop through all frames
+    realityEditor.forEachFrameInAllObjects(function(thatObjectKey, thatFrameKey) {
+        var thatFrame = realityEditor.getFrame(thatObjectKey, thatFrameKey);
+
+        // loop through all links in that frame
+        for (var linkKey in thatFrame.links) {
+            var link = thatFrame.links[linkKey];
+
+            if (link.nodeA === nodeKey) {
+                linksFromNode.push(link);
+            } else if (link.nodeB === nodeKey) {
+                linksToNode.push(link);
+            }
+        }
+    });
+
+    return {
+        linksToNode: linksToNode,
+        linksFromNode: linksFromNode
+    };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -453,6 +453,11 @@ realityEditor.isVehicleAFrame = function(vehicle) {
     return (vehicle.type === 'ui' || typeof vehicle.type === 'undefined');
 };
 
+/**
+ * Helper function loops over all links on all objects to find ones starting or ending at this node
+ * @param {string} nodeKey
+ * @return {{linksToNode: Array.<Link>, linksFromNode: Array.<Link>}}
+ */
 realityEditor.getLinksToAndFromNode = function(nodeKey) {
     let linksToNode = [];
     let linksFromNode = [];


### PR DESCRIPTION
Draws links from edge of screen to the input/output blocks in those columns within the crafting board. This should help with the mental leap of tying together what's happening in AR with what's happening in the grid. Also helps with debugging, for example if you connected the wrong color on the outside you'd notice when programming it.

![IMG_0526](https://user-images.githubusercontent.com/32580292/89675202-8af2bc80-d8b7-11ea-8296-d2dcb1c1252d.PNG)
