### PR TITLE
adjusts process to load local world object so that it keeps trying until successful

### DIFF
--- a/src/gui/ar/anchors.js
+++ b/src/gui/ar/anchors.js
@@ -62,7 +62,8 @@ createNameSpace("realityEditor.gui.ar.anchors");
      */
     function modifyVisibleObjects(visibleObjects) {
         // if there's no visible world object other than the world_local, ignore all this code
-        if (realityEditor.worldObjects.getBestWorldObject().objectId === realityEditor.worldObjects.getLocalWorldId()) {
+        let bestWorldObject = realityEditor.worldObjects.getBestWorldObject();
+        if (!bestWorldObject || bestWorldObject.objectId === realityEditor.worldObjects.getLocalWorldId()) {
             return;
         }
 
@@ -81,8 +82,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
             // the visibleObjects matrix of its world
             let objectMatrix = realityEditor.getObject(objectKey).matrix || utilities.newIdentityMatrix();
             let visibleObjectMatrix = [];
-            let closestWorld = realityEditor.worldObjects.getBestWorldObject();
-            let worldModelMatrix = realityEditor.worldObjects.getOrigin(closestWorld.uuid);
+            let worldModelMatrix = realityEditor.worldObjects.getOrigin(bestWorldObject.uuid); // closest world
             utilities.multiplyMatrix(objectMatrix, worldModelMatrix, visibleObjectMatrix);
 
             // pre-compute matrices that will be used in multiple places per update
@@ -263,6 +263,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
      */
     function getWorldModelViewMatrix() {
         let closestWorld = realityEditor.worldObjects.getBestWorldObject();
+        if (!closestWorld) { return realityEditor.gui.ar.utilities.newIdentityMatrix(); }
         let worldModelMatrix = realityEditor.worldObjects.getOrigin(closestWorld.uuid);
         let modelViewMatrix = [];
         utilities.multiplyMatrix(worldModelMatrix, realityEditor.gui.ar.draw.correctedCameraMatrix, modelViewMatrix);
@@ -492,7 +493,9 @@ createNameSpace("realityEditor.gui.ar.anchors");
     // TODO: associate each anchor with a world, and only return true if that particular world has been seen
     // for now, returns true if any world other than world_local has been seen
     function isAnchorObjectDetected(_objectKey) {
-        return realityEditor.worldObjects.getBestWorldObject().objectId !== realityEditor.worldObjects.getLocalWorldId();
+        let bestWorldObject = realityEditor.worldObjects.getBestWorldObject();
+        if (!bestWorldObject) { return false; }
+        return bestWorldObject.objectId !== realityEditor.worldObjects.getLocalWorldId();
     }
 
     exports.initService = initService;


### PR DESCRIPTION
Fixes the bug where the pocket could be empty if the server didn't initialize the local world object in time, by not giving up on loading the local world after several attempts. also includes better error handling if local world object isn't loaded yet.

Tested this on an app where the local edge-server delayed initializing its local world object by 10 seconds, e.g:
```
if (globalVariables.worldObject) {
    setTimeout(function() {
        loadWorldObject();
    }, 10000);
}
```

@hobinjk-ptc can you check that this fixes it for you?