### PR TITLE
Use memory warning API to stop area target scan before crash

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -390,6 +390,15 @@ realityEditor.app.setOrientation = function(orientationString, callBack) {
 };
 
 /**
+ * Triggers the callback whenever the app moves receives a high memory usage event
+ // * The callback has a single string argument of: "report_memory" or a warning, and an integer argument of bytesUsed
+ * @param {FunctionName} callBack
+ */
+realityEditor.app.subscribeToAppMemoryEvents = function(callBack) {
+    this.appFunctionCall('subscribeToAppMemoryEvents', null, 'realityEditor.app.callBack('+callBack+', [__ARG1__, __ARG2__, __ARG3__])');
+}
+
+/**
  **************Debugging****************
  **/
 

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -369,14 +369,6 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         }
 
         feedbackString = status + '... (' + statusInfo + ')';
-
-        // if (globalStates.debugSpeechConsole) {
-        //     let console = document.getElementById('speechConsole');
-        //     if (!console) { return; }
-        //     console.innerHTML =
-        //         'Status: ' + status + '<br>' +
-        //         'Info: ' + statusInfo;
-        // }
     }
 
     function printFeedback() {


### PR DESCRIPTION
When toggled on in the develop menu, stop the area target scan when app memory exceeds a specified percentage of total device memory (default = 33%). Also responds to native `UIApplicationDidReceiveMemoryWarningNotification` but that usually happens too late in my tested environment (around 50%) to upload without crashing. 

Native APIs already exist, no other PRs needed for this change.