### PR TITLE
Tool groundplane anchor repositioning mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
     <script src="src/gui/ar/grouping.js"></script>
     <script src="src/gui/ar/moveabilityOverlay.js"></script>
     <script src="src/gui/ar/frameHistoryRenderer.js"></script>
+    <script src="src/gui/ar/groundPlaneAnchors.js"></script>
     <script src="src/gui/ar/groundPlaneRenderer.js"></script>
     <script src="src/gui/ar/anchors.js"></script>
     <script src="src/gui/ar/areaTargetScanner.js"></script>

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -225,6 +225,7 @@ realityEditor.device.onload = function () {
     realityEditor.gui.ar.frameHistoryRenderer.initService();
     realityEditor.gui.ar.grouping.initService();
     realityEditor.gui.ar.anchors.initService();
+    realityEditor.gui.ar.groundPlaneAnchors.initService();
     realityEditor.gui.ar.groundPlaneRenderer.initService();
     realityEditor.gui.ar.areaTargetScanner.initService();
     realityEditor.device.touchPropagation.initService();

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1277,7 +1277,7 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
             if (activeType === "ui") {
                 let sendMatrices = activeVehicle.sendMatrices;
                 if (activeVehicle.sendMatrix || activeVehicle.sendAcceleration || activeVehicle.sendScreenPosition || activeVehicle.sendPositionInWorld || activeVehicle.sendDeviceDistance ||
-                    sendMatrices && (sendMatrices.devicePose || sendMatrices.groundPlane || sendMatrices.allObjects || sendMatrices.model || sendMatrices.view)) {
+                    sendMatrices && (sendMatrices.devicePose || sendMatrices.groundPlane || sendMatrices.anchoredModelView || sendMatrices.allObjects || sendMatrices.model || sendMatrices.view)) {
 
                     var thisMsg = {};
 
@@ -1300,6 +1300,10 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
 
                     if (sendMatrices.groundPlane === true) {
                         thisMsg.groundPlaneMatrix = realityEditor.sceneGraph.getGroundPlaneModelViewMatrix();
+                    }
+
+                    if (sendMatrices.anchoredModelView === true) {
+                        thisMsg.anchoredModelView = realityEditor.gui.ar.groundPlaneAnchors.getMatrix(activeVehicle.uuid);
                     }
 
                     if (sendMatrices.allObjects === true) {

--- a/src/gui/ar/groundPlaneRenderer.js
+++ b/src/gui/ar/groundPlaneRenderer.js
@@ -106,8 +106,18 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
             const colorCenterLine = new THREE.Color(0, 0.3, 0.3);
             const colorGrid = new THREE.Color(0, 1, 1);
             gridHelper = new THREE.GridHelper( size, divisions, colorCenterLine, colorGrid );
+            gridHelper.name = 'groundPlaneVisualizer';
             // threejsContainerObj.add( gridHelper );
             realityEditor.gui.threejsScene.addToScene(gridHelper, {occluded: true});
+
+            // const THREE = realityEditor.gui.threejsScene.THREE;
+            // const geometry = new THREE.PlaneGeometry( 1000 * 5, 1000 * 5);
+            // const material = new THREE.MeshBasicMaterial( {color: 0x00ffff, side: THREE.DoubleSide} );
+            // const plane = new THREE.Mesh( geometry, material );
+            // plane.rotateX(Math.PI/2);
+            // realityEditor.gui.threejsScene.addToScene(plane, {occluded: true});
+            // plane.name = 'groundPlaneVisualizer';
+            
         }
 
         // add/activate the update loop

--- a/src/gui/ar/groundPlaneRenderer.js
+++ b/src/gui/ar/groundPlaneRenderer.js
@@ -107,17 +107,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
             const colorGrid = new THREE.Color(0, 1, 1);
             gridHelper = new THREE.GridHelper( size, divisions, colorCenterLine, colorGrid );
             gridHelper.name = 'groundPlaneVisualizer';
-            // threejsContainerObj.add( gridHelper );
             realityEditor.gui.threejsScene.addToScene(gridHelper, {occluded: true});
-
-            // const THREE = realityEditor.gui.threejsScene.THREE;
-            // const geometry = new THREE.PlaneGeometry( 1000 * 5, 1000 * 5);
-            // const material = new THREE.MeshBasicMaterial( {color: 0x00ffff, side: THREE.DoubleSide} );
-            // const plane = new THREE.Mesh( geometry, material );
-            // plane.rotateX(Math.PI/2);
-            // realityEditor.gui.threejsScene.addToScene(plane, {occluded: true});
-            // plane.name = 'groundPlaneVisualizer';
-            
         }
 
         // add/activate the update loop

--- a/src/gui/ar/groundplaneAnchors.js
+++ b/src/gui/ar/groundplaneAnchors.js
@@ -16,7 +16,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let isPositioningMode = false;
     let touchEventCatcher = null;
     let isPointerDown = false;
-    
+
     let selectedGroupKey = null;
     let selectedMeshName = null;
     let constrainToX = false;
@@ -28,7 +28,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let selectionColor = 0xffff00;
     let mouseCursorColor = 0xff00ff;
     let mouseCursorMesh = null;
-    
+
     function initService() {
         // Note that, currently, positioningMode blocks touch events from reaching anything else, so it should be toggled off when not in use
         realityEditor.gui.settings.addToggle('Reposition Ground Anchors', 'surface anchors can be dragged to move tools', 'repositionGroundAnchors',  '../../../svg/move.svg', false, function(newValue) {
@@ -36,7 +36,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
                 togglePositioningMode();
             }
         });
-        
+
         realityEditor.gui.ar.draw.addUpdateListener(function(visibleObjects) {
             try {
                 update(visibleObjects);
@@ -58,12 +58,12 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         }
         return null;
     }
-    
+
     function update(visibleObjects) {
         for (let objectKey in visibleObjects) {
             let object = realityEditor.getObject(objectKey);
             if (!object) { continue; }
-            
+
             for (let frameKey in object.frames) {
                 let frame = realityEditor.getFrame(objectKey, frameKey);
                 if (!frame) { continue; }
@@ -71,16 +71,16 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             }
         }
     }
-    
+
     function updateFrame(frameKey) {
         if (!knownAnchorNodes[frameKey]) { return; }
         if (!threejsGroups[frameKey]) { return; }
-        
+
         // get world matrix of frame
         let frameNode = realityEditor.sceneGraph.getSceneNodeById(frameKey);
         // get world matrix of ground plane
         let groundPlaneNode = realityEditor.sceneGraph.getSceneNodeById('GROUNDPLANE');
-        
+
         // calculate frame relative to ground plane
         let relativeMatrix = frameNode.getMatrixRelativeTo(groundPlaneNode);
         let anchoredMatrix = [
@@ -89,7 +89,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             0, 0, 1, 0,
             relativeMatrix[12], 0, relativeMatrix[14], 1
         ];
-            
+
         // set the anchor matrix by taking the x, z position
         knownAnchorNodes[frameKey].setLocalMatrix(anchoredMatrix);
 
@@ -105,15 +105,15 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         // let linkedDataObject = thisFrame;
         let parentNode = realityEditor.sceneGraph.getSceneNodeById('GROUNDPLANE');
         let sceneNodeId = realityEditor.sceneGraph.addVisualElement(elementName, parentNode); //, linkedDataObject);
-        
+
         knownAnchorNodes[frameKey] = realityEditor.sceneGraph.getSceneNodeById(sceneNodeId);
-        
+
         // add an element to the three.js scene
         let group = createAnchorGroup(frameKey);
         realityEditor.gui.threejsScene.addToScene(group); // this adds it to the ground plane group by default
         threejsGroups[frameKey] = group;
     }
-    
+
     function getMouseCursorMesh() {
         if (!mouseCursorMesh) {
             const THREE = realityEditor.gui.threejsScene.THREE;
@@ -126,7 +126,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         }
         return mouseCursorMesh;
     }
-    
+
     function createAnchorGroup(frameKey) {
         const THREE = realityEditor.gui.threejsScene.THREE;
         const group = new THREE.Group();
@@ -151,11 +151,11 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         originBox.add(zBox);
         return group;
     }
-    
+
     function getElementName(frameKey) {
         return frameKey + '_groundPlaneAnchor';
     }
-    
+
     // show and hide the anchors as well as the touch event catcher
     function togglePositioningMode() {
         isPositioningMode = !isPositioningMode;
@@ -170,7 +170,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             getTouchEventCatcher().style.pointerEvents = 'none';
         }
     }
-    
+
     // ensures there's a div on top of everything that blocks touch events from reaching the tools when we're in this mode
     function getTouchEventCatcher() {
         if (!touchEventCatcher) {
@@ -184,7 +184,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             touchEventCatcher.style.zIndex = zIndex + 'px';
             touchEventCatcher.style.transform = 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,' + zIndex + ',1)';
             document.body.appendChild(touchEventCatcher);
-            
+
             touchEventCatcher.addEventListener('pointerdown', onPointerDown);
             touchEventCatcher.addEventListener('pointerup', onPointerUp);
             touchEventCatcher.addEventListener('pointercancel', onPointerUp);
@@ -200,10 +200,10 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         isPointerDown = true;
 
         let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-        
+
         intersects.forEach(function(intersect) {
             if (selectedGroupKey) { return; }
-            
+
             let meshName = intersect.object.name;
             let matchingKey = Object.keys(threejsGroups).find(function(key) {
                 return meshName.includes(key);
@@ -212,17 +212,17 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
 
             constrainToX = meshName.includes('_xBox');
             constrainToZ = meshName.includes('_zBox');
-            
+
             selectedMeshName = meshName;
             selectedGroupKey = matchingKey;
-            
+
             intersect.object.material.color.setHex(selectionColor);
-            
+
             // TODO: use this to update the position in realtime rather than waiting for pointerup
             // initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
         });
     }
-    
+
     function getPositionXZ(threeJsObject) {
         if (!threeJsObject || typeof threeJsObject.matrix === 'undefined') { return null; }
         return {
@@ -230,12 +230,12 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             z: threeJsObject.matrix.elements[14]
         };
     }
-    
+
     // when we touch up, move the selected anchor's tool to match the movement of the mouse cursor mesh relative to its anchor
     function onPointerUp(e) {
         e.stopPropagation();
         isPointerDown = false;
-        
+
         // reset mesh color
         if (selectedGroupKey && threejsGroups[selectedGroupKey]) {
             let group = threejsGroups[selectedGroupKey];
@@ -249,27 +249,27 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
                     mesh.material.color.setHex(originColor);
                 }
             }
-            
+
             // move tool to correct position
             let oldAnchorLocalPosition = getPositionXZ(group);
             let newAnchorLocalPosition = getPositionXZ(getMouseCursorMesh());
-            
+
             let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
             let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
-            
+
             let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
             let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix);
             localMatrix[12] += dx;
             localMatrix[14] += dz;
             frameSceneNode.setLocalMatrix(localMatrix);
         }
-        
+
         // reset any editing state
         selectedGroupKey = null;
         selectedMeshName = null;
         constrainToX = false;
         constrainToZ = false;
-        
+
         getMouseCursorMesh().visible = false;
     }
 
@@ -278,15 +278,15 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         e.stopPropagation();
         if (!isPointerDown) { return; }
         if (!selectedGroupKey) { return; }
-        
+
         let thisGroup = threejsGroups[selectedGroupKey];
         let thisAnchorNode = knownAnchorNodes[selectedGroupKey];
         if (!thisGroup || !thisAnchorNode) { return; }
-        
+
         let mesh = getMouseCursorMesh();
-        
+
         let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-        
+
         let areaTargetIntersect = null;
         intersects.forEach(function(intersect) {
             if (areaTargetIntersect) { return; }
@@ -295,9 +295,9 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
                 areaTargetIntersect = intersect;
             }
         });
-        
+
         if (!areaTargetIntersect) { return; }
-        
+
         let result = realityEditor.gui.threejsScene.getPointAtDistanceFromCamera(e.clientX, e.clientY, areaTargetIntersect.distance);
 
         let relativePosition = thisGroup.worldToLocal(result);
@@ -309,7 +309,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         mesh.position.set(newX, 0, newZ);
         mesh.visible = true;
     }
-    
+
     exports.initService = initService;
     exports.getMatrix = getMatrix;
     exports.sceneNodeAdded = sceneNodeAdded;

--- a/src/gui/ar/groundplaneAnchors.js
+++ b/src/gui/ar/groundplaneAnchors.js
@@ -29,6 +29,12 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let xBoxColor = 0xff0000;
     let zBoxColor = 0x0000ff;
     let selectionColor = 0xffff00;
+    let mouseCursorColor = 0xff00ff;
+    
+    let initialAnchorPosition = null;
+    
+    let mouseCursorMesh = null;
+    var planeZ;
     
     function initService() {
         console.log("init ground plane anchors");
@@ -108,6 +114,19 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         threejsGroups[frameKey] = group;
     }
     
+    function getMouseCursorMesh() {
+        if (!mouseCursorMesh) {
+            const THREE = realityEditor.gui.threejsScene.THREE;
+            let size = 100;
+            mouseCursorMesh = new THREE.Mesh(new THREE.BoxGeometry(size, size, size),new THREE.MeshBasicMaterial({color: mouseCursorColor}));
+            mouseCursorMesh.name = 'mouseCursorMesh';
+            // mouseCursorMesh.matrixAutoUpdate = false; // this is needed to position it directly with matrices
+            mouseCursorMesh.visible = isPositioningMode;
+            realityEditor.gui.threejsScene.addToScene(mouseCursorMesh); // this adds it to the ground plane group by default
+        }
+        return mouseCursorMesh;
+    }
+    
     function createAnchorGroup(frameKey) {
         const THREE = realityEditor.gui.threejsScene.THREE;
         const group = new THREE.Group();
@@ -115,7 +134,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         group.matrixAutoUpdate = false; // this is needed to position it directly with matrices
         group.visible = isPositioningMode;
         let originSize = 100, axisSize = 50;
-        const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize),new THREE.MeshBasicMaterial({color:0xffffff}));
+        const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize),new THREE.MeshBasicMaterial({color: originColor}));
         originBox.name = getElementName(frameKey) + '_originBox';
         const xBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: xBoxColor}));
         xBox.name = getElementName(frameKey) + '_xBox';
@@ -143,7 +162,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
      */
     function getMatrix(vehicleId) {
         if (knownAnchorNodes[vehicleId]) {
-            return knownAnchorNodes[vehicleId].worldMatrix;
+            // return knownAnchorNodes[vehicleId].worldMatrix;
+            return realityEditor.sceneGraph.getModelViewMatrix(knownAnchorNodes[vehicleId].id);
         }
         return null;
     }
@@ -211,6 +231,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             selectedGroupKey = matchingKey;
             
             intersect.object.material.color.setHex(selectionColor);
+            
+            initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
         });
         
         if (selectedGroupKey) {
@@ -220,6 +242,15 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             console.log('selected: ' + selectedGroupKey);
         }
     }
+    
+    function getPositionXZ(threeJsObject) {
+        if (!threeJsObject || typeof threeJsObject.matrix === 'undefined') { return null; }
+        return {
+            x: threeJsObject.matrix.elements[12],
+            z: threeJsObject.matrix.elements[14]
+        };
+    }
+    
     
     function onPointerUp(e) {
         e.stopPropagation();
@@ -239,6 +270,19 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
                     mesh.material.color.setHex(originColor);
                 }
             }
+            
+            // move tool to correct position
+            let oldAnchorLocalPosition = getPositionXZ(group);
+            let newAnchorLocalPosition = getPositionXZ(getMouseCursorMesh());
+            
+            let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
+            let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
+            
+            let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+            let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix);
+            localMatrix[12] += dx;
+            localMatrix[14] += dz;
+            frameSceneNode.setLocalMatrix(localMatrix);
         }
         
         // reset any editing state
@@ -246,32 +290,127 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         selectedMeshName = null;
         constrainToX = false;
         constrainToZ = false;
+        
+        getMouseCursorMesh().visible = false;
+    }
+    
+    function getPlaneZ() {
+        const THREE = realityEditor.gui.threejsScene.THREE;
+        if (!planeZ) {
+            planeZ = new THREE.Plane(new THREE.Vector3(1, 0, 0), 0);
+        }
+        let groundPlaneModelView = realityEditor.sceneGraph.getGroundPlaneModelViewMatrix();
+        if (groundPlaneModelView) {
+            planeZ.constant = -1000; //groundPlaneModelView[13];
+        }
+        return planeZ;
     }
     
     function onPointerMove(e) {
         e.stopPropagation();
         if (!isPointerDown) { return; }
         
-        // if we touched down on anything, move it
+        // if we touched down on anything...
+        // move getSceneNodeById(frameKey).localMatrix so that the anchorNode.worldMatrix will line up with mouse position
+
         if (!selectedGroupKey) { return; }
+        let thisGroup = threejsGroups[selectedGroupKey];
+        let thisAnchorNode = knownAnchorNodes[selectedGroupKey];
+        
+        if (!thisGroup || !thisAnchorNode) { return; }
+        
+        let mesh = getMouseCursorMesh();
+        // console.log(mesh);
+        
+        let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
+        // console.log(intersects);
+        
+        let areaTargetIntersect = null;
+        intersects.forEach(function(intersect) {
+            if (areaTargetIntersect) { return; }
+            if (intersect.object.name === 'mesh_0') {
+                areaTargetIntersect = intersect;
+            }
+            
+            // console.log(intersect.object.name);
+            // console.log('checking intersect');
+            // console.log(intersect);
+            // let obj = JSON.parse(JSON.stringify(intersect.object));
+            // while (obj && obj.name) {
+            //     if ()
+            //     obj = obj.parent;
+            // }
+            // let meshName = intersect.object.name;
+            // let matchingKey = Object.keys(threejsGroups).find(function(key) {
+            //     return meshName.includes(key);
+            // });
+            // if (!matchingKey) { return; }
+        });
+        
+        if (!areaTargetIntersect) { return; }
+        
+        // let planeIntersect = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY, getPlaneZ());
+        // console.log('planeIntersect', planeIntersect);
+        //
+        // let worldIntersectionPoint = areaTargetIntersect.object.localToWorld(areaTargetIntersect.point);
+        // console.log('pt', worldIntersectionPoint);
+        // let groundPlaneVisualizer = realityEditor.gui.threejsScene.getObjectByName('groundPlaneVisualizer');
+        // if (!groundPlaneVisualizer) { return; }
+        // let groundPlaneIntersect = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY, groundPlaneVisualizer);
+        // console.log('groundPlaneIntersect', groundPlaneIntersect);
+        //
+        // let groundPlanePosition = groundPlaneVisualizer.worldToLocal(worldIntersectionPoint);
+        // console.log(groundPlanePosition);
 
-        console.log('catcher pointer move');
+        // this is the best one
+        // let anchorStartPosition = thisGroup.localToWorld(new realityEditor.gui.threejsScene.THREE.Vector3(0,0,0));
+
+        let result = realityEditor.gui.threejsScene.getGroundPlaneRaycast(e.clientX, e.clientY, areaTargetIntersect.distance);
+        // console.log('result', result);
+        
+        // let difference = result.sub(anchorStartPosition);
+
+        let relativePosition = thisGroup.worldToLocal(result); //thisGroup.worldToLocal(result);
+        // console.log(relativePosition);
+        
+        let anchorLocalPosition = getPositionXZ(thisGroup);
+
+        let newX = constrainToZ ? anchorLocalPosition.x : relativePosition.x + anchorLocalPosition.x;
+        let newZ = constrainToX ? anchorLocalPosition.z : relativePosition.z + anchorLocalPosition.z;
+
+        mesh.position.set(newX, 0, newZ);
+        mesh.visible = true;
+
+        // var planeZ = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+        // var mv = new THREE.Vector3(
+        //     (clientX / window.innerWidth) * 2 - 1,
+        //     -(clientY / window.innerHeight) * 2 + 1,
+        //     0.5 );
+        // var raycaster = projector.pickingRay(mv, camera);
+        // var pos = raycaster.ray.intersectPlane(planeZ);
+        // console.log("x: " + pos.x + ", y: " + pos.y);
+
+        // // get world matrix of frame
+        // let frameNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey)
+        //
+        // // get world matrix of ground plane
+        // let groundPlaneNode = realityEditor.sceneGraph.getSceneNodeById('GROUNDPLANE');
+        //
+        // // calculate frame relative to ground plane
+        // let relativeMatrix = frameNode.getMatrixRelativeTo(groundPlaneNode);
+        // let anchoredMatrix = [
+        //     1, 0, 0, 0,
+        //     0, 1, 0, 0,
+        //     0, 0, 1, 0,
+        //     relativeMatrix[12], 0, relativeMatrix[14], 1
+        // ];
+        //
+        // // set the anchor matrix by taking the x, z position
+        // knownAnchorNodes[selectedGroupKey].setLocalMatrix(anchoredMatrix);
+        //
+        // // we use localMatrix, not world matrix, because mesh is already a child of the ground plane
+        // realityEditor.gui.threejsScene.setMatrixFromArray(threejsGroups[selectedGroupKey].matrix, knownAnchorNodes[selectedGroupKey].localMatrix);
     }
-
-    // function touchDecider(eventData) {
-    //     //1. sets the mouse position with a coordinate system where the center
-    //     //   of the screen is the origin
-    //     mouseVector.x = ( eventData.x / window.innerWidth ) * 2 - 1;
-    //     mouseVector.y = - ( eventData.y / window.innerHeight ) * 2 + 1;
-    //
-    //     //2. set the picking ray from the camera position and mouse coordinates
-    //     raycaster.setFromCamera( mouseVector, camera );
-    //
-    //     //3. compute intersections
-    //     var intersects = raycaster.intersectObjects( scene.children, true );
-    //
-    //     return intersects.length > 0;
-    // }
     
     exports.initService = initService;
     exports.getMatrix = getMatrix;

--- a/src/gui/ar/groundplaneAnchors.js
+++ b/src/gui/ar/groundplaneAnchors.js
@@ -1,0 +1,280 @@
+/*
+* Created by Ben Reynolds on 10/08/20.
+*
+* Copyright (c) 2020 PTC Inc
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
+
+(function(exports) {
+    let knownAnchorNodes = {};
+    let threejsGroups = {};
+    let isPositioningMode = false;
+    let touchEventCatcher = null;
+    let isPointerDown = false;
+
+    // let raycaster;// = new THREE.Raycaster();
+    // let mouseVector;// = new THREE.Vector2();
+    
+    let selectedGroupKey = null;
+    let selectedMeshName = null;
+    let constrainToX = false;
+    let constrainToZ = false;
+
+    let originColor = 0xffffff;
+    let xBoxColor = 0xff0000;
+    let zBoxColor = 0x0000ff;
+    let selectionColor = 0xffff00;
+    
+    function initService() {
+        console.log("init ground plane anchors");
+        
+        realityEditor.gui.ar.draw.addUpdateListener(function(visibleObjects) {
+            try {
+                update(visibleObjects);
+            } catch (e) {
+                console.warn(e);
+            }
+        });
+
+        realityEditor.gui.settings.addToggle('Reposition Ground Anchors', '', 'repositionGroundAnchors',  '../../../svg/move.svg', false, function(newValue) {
+            // only draw frame ghosts while in programming mode if we're not in power-save mode
+            if (isPositioningMode !== newValue) {
+                togglePositioningMode();
+            }
+        });
+
+        // const THREE = realityEditor.gui.threejsScene.THREE;
+        // raycaster = new THREE.Raycaster();
+        // mouseVector = new THREE.Vector2();
+    }
+    
+    function update(visibleObjects) {
+        for (let objectKey in visibleObjects) {
+            let object = realityEditor.getObject(objectKey);
+            if (!object) { continue; }
+            
+            for (let frameKey in object.frames) {
+                let frame = realityEditor.getFrame(objectKey, frameKey);
+                if (!frame) { continue; }
+                updateFrame(frameKey);
+            }
+        }
+    }
+    
+    function updateFrame(frameKey) {
+        if (!knownAnchorNodes[frameKey]) { return; }
+        if (!threejsGroups[frameKey]) { return; }
+        
+        // get world matrix of frame
+        let frameNode = realityEditor.sceneGraph.getSceneNodeById(frameKey);
+        // get world matrix of ground plane
+        let groundPlaneNode = realityEditor.sceneGraph.getSceneNodeById('GROUNDPLANE');
+        
+        // calculate frame relative to ground plane
+        let relativeMatrix = frameNode.getMatrixRelativeTo(groundPlaneNode);
+        let anchoredMatrix = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            relativeMatrix[12], 0, relativeMatrix[14], 1
+        ];
+            
+        // set the anchor matrix by taking the x, z position
+        knownAnchorNodes[frameKey].setLocalMatrix(anchoredMatrix);
+
+        // we use localMatrix, not world matrix, because mesh is already a child of the ground plane
+        realityEditor.gui.threejsScene.setMatrixFromArray(threejsGroups[frameKey].matrix, knownAnchorNodes[frameKey].localMatrix);
+    }
+
+    // when we add a sceneNode for a tool, also add one to the groundplane that is associated with it
+    function sceneNodeAdded(objectKey, frameKey, _thisFrame, _matrix) {
+
+        // elementName, optionalParent, linkedDataObject, initialLocalMatrix
+        let elementName = getElementName(frameKey);
+        // let linkedDataObject = thisFrame;
+        let parentNode = realityEditor.sceneGraph.getSceneNodeById('GROUNDPLANE');
+        let sceneNodeId = realityEditor.sceneGraph.addVisualElement(elementName, parentNode); //, linkedDataObject);
+        
+        knownAnchorNodes[frameKey] = realityEditor.sceneGraph.getSceneNodeById(sceneNodeId);
+        
+        // add an element to the three.js scene
+        let group = createAnchorGroup(frameKey);
+        realityEditor.gui.threejsScene.addToScene(group); // this adds it to the ground plane group by default
+        threejsGroups[frameKey] = group;
+    }
+    
+    function createAnchorGroup(frameKey) {
+        const THREE = realityEditor.gui.threejsScene.THREE;
+        const group = new THREE.Group();
+        group.name = getElementName(frameKey) + '_group';
+        group.matrixAutoUpdate = false; // this is needed to position it directly with matrices
+        group.visible = isPositioningMode;
+        let originSize = 100, axisSize = 50;
+        const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize),new THREE.MeshBasicMaterial({color:0xffffff}));
+        originBox.name = getElementName(frameKey) + '_originBox';
+        const xBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: xBoxColor}));
+        xBox.name = getElementName(frameKey) + '_xBox';
+        // const yBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color:0x00ff00}));
+        // yBox.name = getElementName(frameKey) + '_yBox';
+        const zBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: zBoxColor}));
+        zBox.name = getElementName(frameKey) + '_zBox';
+        xBox.position.x = 150;
+        // yBox.position.y = 15;
+        zBox.position.z = 150;
+        group.add(originBox);
+        originBox.add(xBox);
+        // originBox.add(yBox);
+        originBox.add(zBox);
+        return group;
+    }
+    
+    function getElementName(frameKey) {
+        return frameKey + '_groundPlaneAnchor';
+    }
+
+    /**
+     * @param {string} vehicleId
+     * @returns {Array.<number>}
+     */
+    function getMatrix(vehicleId) {
+        if (knownAnchorNodes[vehicleId]) {
+            return knownAnchorNodes[vehicleId].worldMatrix;
+        }
+        return null;
+    }
+    
+    function togglePositioningMode() {
+        isPositioningMode = !isPositioningMode;
+        for (let key in threejsGroups) {
+            threejsGroups[key].visible = isPositioningMode;
+        }
+        if (isPositioningMode) {
+            getTouchEventCatcher().style.display = '';
+            getTouchEventCatcher().style.pointerEvents = 'auto';
+        } else {
+            getTouchEventCatcher().style.display = 'none';
+            getTouchEventCatcher().style.pointerEvents = 'none';
+        }
+    }
+    
+    function getTouchEventCatcher() {
+        if (!touchEventCatcher) {
+            touchEventCatcher = document.createElement('div');
+            touchEventCatcher.style.position = 'absolute';
+            touchEventCatcher.style.left = '0';
+            touchEventCatcher.style.top = '0';
+            touchEventCatcher.style.width = '100vw';
+            touchEventCatcher.style.height = '100vh';
+            let zIndex = 8000;
+            touchEventCatcher.style.zIndex = zIndex + 'px';
+            touchEventCatcher.style.transform = 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,' + zIndex + ',1)';
+            document.body.appendChild(touchEventCatcher);
+            
+            touchEventCatcher.addEventListener('pointerdown', onPointerDown);
+            touchEventCatcher.addEventListener('pointerup', onPointerUp);
+            touchEventCatcher.addEventListener('pointercancel', onPointerUp);
+            touchEventCatcher.addEventListener('pointermove', onPointerMove);
+        }
+        return touchEventCatcher;
+    }
+    
+    function onPointerDown(e) {
+        e.stopPropagation();
+        console.log('catcher pointer down');
+        isPointerDown = true;
+        
+        // hit test threeJsScene to see if we hit any of the threeJsGroups
+        // if we are, keep track of it and so we can move it on pointermove
+
+        let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
+        // console.log(intersects);
+        
+        // let intersectedMesh = null;
+        intersects.forEach(function(intersect) {
+            if (selectedGroupKey) { return; }
+            
+            let meshName = intersect.object.name;
+            let matchingKey = Object.keys(threejsGroups).find(function(key) {
+                return meshName.includes(key);
+            });
+            if (!matchingKey) { return; }
+
+            constrainToX = meshName.includes('_xBox');
+            constrainToZ = meshName.includes('_zBox');
+            
+            selectedMeshName = meshName;
+            selectedGroupKey = matchingKey;
+            
+            intersect.object.material.color.setHex(selectionColor);
+        });
+        
+        if (selectedGroupKey) {
+            // threejsGroups[selectedGroupKey].children.forEach(function(child) {
+            //     child.material.color.setHex(0xffff00);
+            // });
+            console.log('selected: ' + selectedGroupKey);
+        }
+    }
+    
+    function onPointerUp(e) {
+        e.stopPropagation();
+        console.log('catcher pointer up');
+        isPointerDown = false;
+        
+        // reset mesh color
+        if (selectedGroupKey && threejsGroups[selectedGroupKey]) {
+            let group = threejsGroups[selectedGroupKey];
+            let mesh = group.getObjectByName(selectedMeshName);
+            if (mesh) {
+                if (constrainToX) {
+                    mesh.material.color.setHex(xBoxColor);
+                } else if (constrainToZ) {
+                    mesh.material.color.setHex(zBoxColor);
+                } else {
+                    mesh.material.color.setHex(originColor);
+                }
+            }
+        }
+        
+        // reset any editing state
+        selectedGroupKey = null;
+        selectedMeshName = null;
+        constrainToX = false;
+        constrainToZ = false;
+    }
+    
+    function onPointerMove(e) {
+        e.stopPropagation();
+        if (!isPointerDown) { return; }
+        
+        // if we touched down on anything, move it
+        if (!selectedGroupKey) { return; }
+
+        console.log('catcher pointer move');
+    }
+
+    // function touchDecider(eventData) {
+    //     //1. sets the mouse position with a coordinate system where the center
+    //     //   of the screen is the origin
+    //     mouseVector.x = ( eventData.x / window.innerWidth ) * 2 - 1;
+    //     mouseVector.y = - ( eventData.y / window.innerHeight ) * 2 + 1;
+    //
+    //     //2. set the picking ray from the camera position and mouse coordinates
+    //     raycaster.setFromCamera( mouseVector, camera );
+    //
+    //     //3. compute intersections
+    //     var intersects = raycaster.intersectObjects( scene.children, true );
+    //
+    //     return intersects.length > 0;
+    // }
+    
+    exports.initService = initService;
+    exports.getMatrix = getMatrix;
+    exports.sceneNodeAdded = sceneNodeAdded;
+    exports.togglePositioningMode = togglePositioningMode;
+}(realityEditor.gui.ar.groundPlaneAnchors));

--- a/src/gui/glRenderer.js
+++ b/src/gui/glRenderer.js
@@ -327,7 +327,7 @@ createNameSpace("realityEditor.gui.glRenderer");
         for (let i = 0; i < proxiesToBeRenderedThisFrame.length; i++) {
             let proxy = proxiesToBeRenderedThisFrame[i];
             if (!res[i]) {
-                console.warn('miscreant detected', proxy);
+                // console.warn('miscreant detected', proxy);
                 continue;
             }
             proxy.executeFrameCommands();

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -808,6 +808,7 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
             realityEditor.network.toBeInitialized[frameID] = true;
 
             realityEditor.sceneGraph.addFrame(frame.objectId, frameID, frame, frame.ar.matrix);
+            realityEditor.gui.ar.groundPlaneAnchors.sceneNodeAdded(frame.objectId, frameID, frame, frame.ar.matrix);
 
             console.log(frame);
             // send it to the server

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -17,6 +17,8 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     const worldOcclusionObjects = {}; // Keeps track of initialized occlusion objects per world object
     let raycaster;
     let mouse;
+    let distanceRaycastVector = new THREE.Vector3();
+    let distanceRaycastResultPosition = new THREE.Vector3();
 
     const DISPLAY_ORIGIN_BOX = false;
 
@@ -336,40 +338,23 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         return raycaster.intersectObjects( objectsToCheck || scene.children, true );
     }
 
-    let groundPlaneRaycastVector = new THREE.Vector3();
-    let groundPlaneRaycastPosition = new THREE.Vector3();
-
-    function getGroundPlaneRaycast(clientX, clientY, targetZ) {
-        // groundPlaneRaycastVector.set(
-        //     ( clientX / window.innerWidth ) * 2 - 1,
-        //     - ( clientY / window.innerHeight ) * 2 + 1,
-        //     0.5
-        // );
-        // groundPlaneRaycastVector.unproject(camera);
-        // groundPlaneRaycastVector.sub(camera.position).normalize();
-        // let distance = ( targetZ - camera.position.z ) / groundPlaneRaycastVector.z;
-        // groundPlaneRaycastPosition.copy(camera.position).add(groundPlaneRaycastVector.multiplyScalar(distance));
-        // return {
-        //     x: groundPlaneRaycastPosition.x,
-        //     y: groundPlaneRaycastPosition.y,
-        //     z: groundPlaneRaycastPosition.z
-        // };
-
-        groundPlaneRaycastVector.set(
+    /**
+     * Returns the 3D coordinate which is [distance] mm in front of the screen pixel coordinates [clientX, clientY]
+     * @param {number} clientX - in screen pixels
+     * @param {number} clientY - in screen pixels
+     * @param {number} distance - in millimeters
+     * @returns {Vector3} - position relative to camera
+     */
+    function getPointAtDistanceFromCamera(clientX, clientY, distance) {
+        distanceRaycastVector.set(
             ( clientX / window.innerWidth ) * 2 - 1,
             - ( clientY / window.innerHeight ) * 2 + 1,
             0
         );
-        groundPlaneRaycastVector.unproject(camera);
-        groundPlaneRaycastVector.normalize();
-        let distance = targetZ;
-        groundPlaneRaycastPosition.set(0, 0, 0).add(groundPlaneRaycastVector.multiplyScalar(distance));
-        // return {
-        //     x: groundPlaneRaycastPosition.x,
-        //     y: groundPlaneRaycastPosition.y,
-        //     z: groundPlaneRaycastPosition.z
-        // };
-        return groundPlaneRaycastPosition;
+        distanceRaycastVector.unproject(camera);
+        distanceRaycastVector.normalize();
+        distanceRaycastResultPosition.set(0, 0, 0).add(distanceRaycastVector.multiplyScalar(distance));
+        return distanceRaycastResultPosition;
     }
 
     function getObjectByName(name) {
@@ -487,7 +472,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     exports.addToScene = addToScene;
     exports.removeFromScene = removeFromScene;
     exports.getRaycastIntersects = getRaycastIntersects;
-    exports.getGroundPlaneRaycast = getGroundPlaneRaycast;
+    exports.getPointAtDistanceFromCamera = getPointAtDistanceFromCamera;
     exports.getObjectByName = getObjectByName;
     exports.setMatrixFromArray = setMatrixFromArray;
     exports.THREE = THREE;

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -18,7 +18,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     let raycaster;
     let mouse;
 
-    const DISPLAY_ORIGIN_BOX = true;
+    const DISPLAY_ORIGIN_BOX = false;
 
     let customMaterials;
 

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -20,7 +20,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     let distanceRaycastVector = new THREE.Vector3();
     let distanceRaycastResultPosition = new THREE.Vector3();
 
-    const DISPLAY_ORIGIN_BOX = false;
+    const DISPLAY_ORIGIN_BOX = true;
 
     let customMaterials;
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ var realityEditor = realityEditor || {
             areaTargetScanner: {},
             draw: {},
             frameHistoryRenderer: {},
+            groundPlaneAnchors: {},
             groundPlaneRenderer: {},
             grouping: {},
             lines: {},

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -268,6 +268,7 @@ realityEditor.network.onNewObjectAdded = function(objectKey) {
         modelView : false,
         devicePose : false,
         groundPlane : false,
+        anchoredModelView: false,
         allObjects : false
     };
     thisObject.sendScreenPosition = false;
@@ -335,6 +336,7 @@ realityEditor.network.initializeDownloadedFrame = function(objectKey, frameKey, 
         modelView : false,
         devicePose : false,
         groundPlane : false,
+        anchoredModelView: false,
         allObjects : false
     };
     thisFrame.sendScreenPosition = false;
@@ -354,6 +356,7 @@ realityEditor.network.initializeDownloadedFrame = function(objectKey, frameKey, 
     }
 
     realityEditor.sceneGraph.addFrame(objectKey, frameKey, thisFrame, positionData.matrix);
+    realityEditor.gui.ar.groundPlaneAnchors.sceneNodeAdded(objectKey, frameKey, thisFrame, positionData.matrix);
 
     for (let nodeKey in thisFrame.nodes) {
         var thisNode = thisFrame.nodes[nodeKey];
@@ -1001,6 +1004,7 @@ realityEditor.network.onAction = function (action) {
                 modelView : false,
                 devicePose : false,
                 groundPlane : false,
+                anchoredModelView: false,
                 allObjects : false
             };
             frame.sendScreenPosition = false;
@@ -1264,6 +1268,17 @@ realityEditor.network.onInternalPostMessage = function (e) {
             if (tempThisObject.integerVersion >= 32) {
                if(!tempThisObject.sendMatrices) tempThisObject.sendMatrices = {};
                 tempThisObject.sendMatrices.groundPlane = true;
+                let activeKey = msgContent.node ? msgContent.node : msgContent.frame;
+                if (activeKey === msgContent.frame) {
+                    globalDOMCache["iframe" + activeKey].contentWindow.postMessage(
+                        '{"projectionMatrix":' + JSON.stringify(globalStates.realProjectionMatrix) + "}", '*');
+                }
+            }
+        }
+        if (msgContent.sendMatrices.anchoredModelView === true) {
+            if (tempThisObject.integerVersion >= 32) {
+                if(!tempThisObject.sendMatrices) tempThisObject.sendMatrices = {};
+                tempThisObject.sendMatrices.anchoredModelView = true;
                 let activeKey = msgContent.node ? msgContent.node : msgContent.frame;
                 if (activeKey === msgContent.frame) {
                     globalDOMCache["iframe" + activeKey].contentWindow.postMessage(


### PR DESCRIPTION
Toggling on this mode (in the settings menu or with "P" key on remote operator) shows threejs icons anchored to groundplane underneath each tool. Dragging the anchors moves the tools along that plane. Also adds API for tools to subscribe directly to the anchor modelView.

NOTE: this currently only works on remote operator because it's reliant on raycasting against the area target mesh. I will update soon to work in AR with the ground plane.