### PR TITLE
Better touch event handling

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -811,7 +811,7 @@ body {
     left: 0;
     top: 0;
     background: transparent;
-    pointer-events: none;
+    pointer-events: auto;
     -webkit-transform-style: preserve-3d;
     -webkit-transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 }

--- a/css/index.css
+++ b/css/index.css
@@ -811,7 +811,7 @@ body {
     left: 0;
     top: 0;
     background: transparent;
-    pointer-events: auto;
+    pointer-events: none;
     -webkit-transform-style: preserve-3d;
     -webkit-transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 }

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -21,7 +21,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let knownAnchorNodes = {};
     let threejsGroups = {};
     let isPositioningMode = false;
-    let touchEventCatcher = null;
     let isPointerDown = false;
 
     let selectedGroupKey = null;
@@ -219,12 +218,20 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         if (mouseCursorMesh) { mouseCursorMesh.visible = false; }
         if (initialCalculationMesh) { initialCalculationMesh.visible = false; }
 
+        let threejsCanvas = document.getElementById('mainThreejsCanvas');
+        if (!threejsCanvas) {
+            return;
+        }
         if (isPositioningMode && !globalStates.settingsButtonState) {
-            getTouchEventCatcher().style.display = '';
-            getTouchEventCatcher().style.pointerEvents = 'auto';
+            threejsCanvas.addEventListener('pointerdown', onPointerDown, false);
+            threejsCanvas.addEventListener('pointerup', onPointerUp, false);
+            threejsCanvas.addEventListener('pointercancel', onPointerUp, false);
+            threejsCanvas.addEventListener('pointermove', onPointerMove, false);
         } else {
-            getTouchEventCatcher().style.display = 'none';
-            getTouchEventCatcher().style.pointerEvents = 'none';
+            threejsCanvas.removeEventListener('pointerdown', onPointerDown, false);
+            threejsCanvas.removeEventListener('pointerup', onPointerUp, false);
+            threejsCanvas.removeEventListener('pointercancel', onPointerUp, false);
+            threejsCanvas.removeEventListener('pointermove', onPointerMove, false);
         }
     }
 
@@ -246,28 +253,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         if (hiddenInEnvelope) {
             group.visible = false;
         }
-    }
-
-    // ensures there's a div on top of everything that blocks touch events from reaching the tools when we're in this mode
-    function getTouchEventCatcher() {
-        if (!touchEventCatcher) {
-            touchEventCatcher = document.createElement('div');
-            touchEventCatcher.style.position = 'absolute';
-            touchEventCatcher.style.left = '0';
-            touchEventCatcher.style.top = '0';
-            touchEventCatcher.style.width = '100vw';
-            touchEventCatcher.style.height = '100vh';
-            let zIndex = 2900; // above scene elements, below pocket and menus
-            touchEventCatcher.style.zIndex = zIndex;
-            touchEventCatcher.style.transform = 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,' + zIndex + ',1)';
-            document.body.appendChild(touchEventCatcher);
-
-            touchEventCatcher.addEventListener('pointerdown', onPointerDown);
-            touchEventCatcher.addEventListener('pointerup', onPointerUp);
-            touchEventCatcher.addEventListener('pointercancel', onPointerUp);
-            touchEventCatcher.addEventListener('pointermove', onPointerMove);
-        }
-        return touchEventCatcher;
     }
 
     // hit test threeJsScene to see if we hit any of the anchor threeJsGroups

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -61,6 +61,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         realityEditor.gui.buttons.registerCallbackForButton('setting', function(_params) {
             updatePositioningMode(); // check if positioning mode needs update due to settings menu state
         });
+
+        updatePositioningMode();
     }
 
     /**

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -324,7 +324,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
             console.log('loaded gltf', pathToGltf);
 
             if (callback) {
-              callback(gltf.scene);
+              callback(gltf.scene, wireMesh);
             }
         });
     }


### PR DESCRIPTION
Paired with the latest changes on the remote operator's depth-representation branch this tries to do away with the touchEventCatcher pattern

It is a bit flaky and prone to race conditions with how convoluted the startup process is. I'm trying to improve this but if it's not working just click into and out of logic mode and the settings menu