### PR TITLE
ProjectedZ PointerEvents API

### DIFF
--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -91,10 +91,11 @@ createNameSpace("realityEditor.app.targetDownloader");
         const objectID = evt.data.objectID;
         window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
 
-        // Occlusion removed in favor of distance-based fading, but could be re-enabled in the future
-        // let object = realityEditor.getObject(objectID);
-        // let gltfPath = 'http://' + object.ip + ':' + realityEditor.network.getPort(objectID) + '/obj/' + object.name + '/target/target.glb';
-        // realityEditor.gui.threejsScene.addOcclusionGltf(gltfPath, objectID);
+        if (realityEditor.device.environment.variables.addOcclusionGltf) {
+            let object = realityEditor.getObject(objectID);
+            let gltfPath = 'http://' + object.ip + ':' + realityEditor.network.getPort(objectID) + '/obj/' + object.name + '/target/target.glb';
+            realityEditor.gui.threejsScene.addOcclusionGltf(gltfPath, objectID);
+        }
 
         // realityEditor.gui.threejsScene.addGltfToScene(gltfPath);
         // let floorOffset = -1.55 * 1000;

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -47,7 +47,8 @@ createNameSpace("realityEditor.device.environment");
         // matrices
         initialPocketToolRotation: null,
         supportsAreaTargetCapture: true,
-        hideOriginCube: false // explicitly don't show the 3d cubes at the world origin
+        hideOriginCube: false, // explicitly don't show the 3d cubes at the world origin
+        addOcclusionGltf: true // by default loads the occlusion mesh, but a VR viewer can disable this
     };
 
     // variables can be directly set by add-ons by using the public 'variables' property

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -310,7 +310,7 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
         let projectedZ;
         let worldObject = realityEditor.worldObjects.getBestWorldObject();
         if (worldObject) {
-            let occlusionObject = realityEditor.gui.threejsScene.getOcclusionObject(worldObject.objectId);
+            let occlusionObject = realityEditor.gui.threejsScene.getObjectForWorldRaycasts(worldObject.objectId);
             if (occlusionObject) {
                 let raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(event.pageX, event.pageY, [occlusionObject]);
                 if (raycastIntersects.length > 0) {

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -313,21 +313,44 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
         if (worldObject) {
             let occlusionObject = realityEditor.gui.threejsScene.getObjectForWorldRaycasts(worldObject.objectId);
             if (occlusionObject) {
+                occlusionObject.updateMatrixWorld();
+                occlusionObject.children[0].geometry.computeFaceNormals()
+                occlusionObject.children[0].geometry.computeVertexNormals()
+
                 let raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(event.pageX, event.pageY, [occlusionObject]);
                 if (raycastIntersects.length > 0) {
                     projectedZ = raycastIntersects[0].distance;
+                    
+                    // NOTE: to transform a normal, you must multiply by the transpose of the inverse of the model-view matrix
 
+                    let normalMatrix = new realityEditor.gui.threejsScene.THREE.Matrix3().getNormalMatrix( occlusionObject.matrixWorld );
+                    let newNormal = raycastIntersects[0].face.normal.clone().applyMatrix3( normalMatrix ).normalize();
+
+                    // raycastIntersects[0].rayDirection.multiplyScalar(100);
+                    // raycastIntersects[0].point.add(raycastIntersects[0].rayDirection.negate());
+                    // raycastIntersects[0].point.add(raycastIntersects[0].face.normal.multiplyScalar(500));
+                    
                     // multiply intersect, which is in ROOT coordinates, by the relative world matrix (ground plane) to ROOT
                     let inverseGroundPlaneMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
                     realityEditor.gui.threejsScene.setMatrixFromArray(inverseGroundPlaneMatrix, realityEditor.sceneGraph.getGroundPlaneModelViewMatrix())
                     inverseGroundPlaneMatrix.invert();
                     raycastIntersects[0].point.applyMatrix4(inverseGroundPlaneMatrix);
 
+                    // raycastIntersects[0].face.normal.applyMatrix4(inverseGroundPlaneMatrix).normalize(); //.multiplyScalar(200);
+                    // raycastIntersects[0].point.add(raycastIntersects[0].face.normal);
+
+                    // newNormal.applyMatrix4(inverseGroundPlaneMatrix).normalize(); //.multiplyScalar(200);
+                    
+                    // transpose of the inverse of the ground-plane model-view matrix
+                    let trInvGroundPlaneMat = inverseGroundPlaneMatrix.clone().transpose();
+
                     worldIntersectPoint = {
                         x: raycastIntersects[0].point.x,
                         y: raycastIntersects[0].point.y,
-                        z: raycastIntersects[0].point.z
-                    }
+                        z: raycastIntersects[0].point.z,
+                        rayDirection: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize() // raycastIntersects[0].face.normal //raycastIntersects[0].rayDirection
+                        // rayDirection: newNormal.applyMatrix4(trInvGroundPlaneMat).normalize() // raycastIntersects[0].face.normal //raycastIntersects[0].rayDirection
+                    };
                 }
             }
         }

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -320,27 +320,13 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
                 let raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(event.pageX, event.pageY, [occlusionObject]);
                 if (raycastIntersects.length > 0) {
                     projectedZ = raycastIntersects[0].distance;
-                    
-                    // NOTE: to transform a normal, you must multiply by the transpose of the inverse of the model-view matrix
 
-                    let normalMatrix = new realityEditor.gui.threejsScene.THREE.Matrix3().getNormalMatrix( occlusionObject.matrixWorld );
-                    let newNormal = raycastIntersects[0].face.normal.clone().applyMatrix3( normalMatrix ).normalize();
-
-                    // raycastIntersects[0].rayDirection.multiplyScalar(100);
-                    // raycastIntersects[0].point.add(raycastIntersects[0].rayDirection.negate());
-                    // raycastIntersects[0].point.add(raycastIntersects[0].face.normal.multiplyScalar(500));
-                    
                     // multiply intersect, which is in ROOT coordinates, by the relative world matrix (ground plane) to ROOT
                     let inverseGroundPlaneMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
                     realityEditor.gui.threejsScene.setMatrixFromArray(inverseGroundPlaneMatrix, realityEditor.sceneGraph.getGroundPlaneModelViewMatrix())
                     inverseGroundPlaneMatrix.invert();
                     raycastIntersects[0].point.applyMatrix4(inverseGroundPlaneMatrix);
 
-                    // raycastIntersects[0].face.normal.applyMatrix4(inverseGroundPlaneMatrix).normalize(); //.multiplyScalar(200);
-                    // raycastIntersects[0].point.add(raycastIntersects[0].face.normal);
-
-                    // newNormal.applyMatrix4(inverseGroundPlaneMatrix).normalize(); //.multiplyScalar(200);
-                    
                     // transpose of the inverse of the ground-plane model-view matrix
                     let trInvGroundPlaneMat = inverseGroundPlaneMatrix.clone().transpose();
 
@@ -348,8 +334,8 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
                         x: raycastIntersects[0].point.x,
                         y: raycastIntersects[0].point.y,
                         z: raycastIntersects[0].point.z,
-                        rayDirection: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize() // raycastIntersects[0].face.normal //raycastIntersects[0].rayDirection
-                        // rayDirection: newNormal.applyMatrix4(trInvGroundPlaneMat).normalize() // raycastIntersects[0].face.normal //raycastIntersects[0].rayDirection
+                        // NOTE: to transform a normal, you must multiply by the transpose of the inverse of the model-view matrix
+                        normalVector: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize()
                     };
                 }
             }

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -266,8 +266,8 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         });
     }
 
-    function getOcclusionObject(objectId) {
-        return worldOcclusionObjects[objectId];
+    function getObjectForWorldRaycasts(objectId) {
+        return worldOcclusionObjects[objectId] || scene.getObjectByName('areaTargetMesh');
     }
 
     function isOcclusionActive(objectId) {
@@ -482,7 +482,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     exports.getObjectByName = getObjectByName;
     exports.getGroundPlane = getGroundPlane;
     exports.setMatrixFromArray = setMatrixFromArray;
-    exports.getOcclusionObject = getOcclusionObject;
+    exports.getObjectForWorldRaycasts = getObjectForWorldRaycasts;
     exports.THREE = THREE;
     exports.FBXLoader = FBXLoader;
     exports.GLTFLoader = GLTFLoader;

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -354,7 +354,11 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         raycaster.setFromCamera( mouse, camera );
 
         //3. compute intersections
-        return raycaster.intersectObjects( objectsToCheck || scene.children, true );
+        let results = raycaster.intersectObjects( objectsToCheck || scene.children, true );
+        results.forEach(intersection => {
+            intersection.rayDirection = raycaster.ray.direction; //JSON.parse(JSON.stringify(raycaster.ray.direction));
+        });
+        return results;
     }
 
     /**

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -354,11 +354,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         raycaster.setFromCamera( mouse, camera );
 
         //3. compute intersections
-        let results = raycaster.intersectObjects( objectsToCheck || scene.children, true );
-        results.forEach(intersection => {
-            intersection.rayDirection = raycaster.ray.direction; //JSON.parse(JSON.stringify(raycaster.ray.direction));
-        });
-        return results;
+        return raycaster.intersectObjects( objectsToCheck || scene.children, true );
     }
 
     /**

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -266,6 +266,10 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         });
     }
 
+    function getOcclusionObject(objectId) {
+        return worldOcclusionObjects[objectId];
+    }
+
     function isOcclusionActive(objectId) {
         return !!worldOcclusionObjects[objectId];
     }
@@ -478,6 +482,7 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
     exports.getObjectByName = getObjectByName;
     exports.getGroundPlane = getGroundPlane;
     exports.setMatrixFromArray = setMatrixFromArray;
+    exports.getOcclusionObject = getOcclusionObject;
     exports.THREE = THREE;
     exports.FBXLoader = FBXLoader;
     exports.GLTFLoader = GLTFLoader;


### PR DESCRIPTION
If there is an occlusion mesh added to the scene (on AR devices), pointerevents posted into iframes will contain an additional `projectedZ` property calculated by raycasting against the occlusion mesh. If there isn't an occlusion mesh, but there is an area target gltf (on remote operator), raycasts against that instead.

**Question for reviewers**: are we ok accepting a performance cost on AR devices of loading the area target occlusion gltf into the three.js scene for this feature? I expect we'll make more and more use of it in the future, if we also implement snapping tools' positions to surfaces, etc.