### PR TITLE
adds environment variables and callbacks for customized area target scanning

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1688,3 +1688,8 @@ Logic Interface CSS
     -webkit-transform-style: preserve-3d;
     -webkit-transform: translateZ(3000px); /* Above web interfaces, below side buttons */
 }
+
+.suppressedRendering {
+    display: none;
+    visibility: hidden;
+}

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -154,15 +154,17 @@ createNameSpace('realityEditor.app.callbacks');
         if (typeof message.id !== 'undefined' &&
             typeof message.ip !== 'undefined') {
 
-            if (typeof message.zone !== 'undefined' && message.zone !== '') {
-                if (realityEditor.gui.settings.toggleStates.zoneState && realityEditor.gui.settings.toggleStates.zoneStateText === message.zone) {
-                    // console.log('Added object from zone=' + message.zone);
+            if (!realityEditor.device.environment.variables.suppressObjectDetections) {
+                if (typeof message.zone !== 'undefined' && message.zone !== '') {
+                    if (realityEditor.gui.settings.toggleStates.zoneState && realityEditor.gui.settings.toggleStates.zoneStateText === message.zone) {
+                        // console.log('Added object from zone=' + message.zone);
+                        realityEditor.network.addHeartbeatObject(message);
+                    }
+
+                } else if (!realityEditor.gui.settings.toggleStates.zoneState) {
+                    // console.log('Added object without zone');
                     realityEditor.network.addHeartbeatObject(message);
                 }
-
-            } else if (!realityEditor.gui.settings.toggleStates.zoneState) {
-                // console.log('Added object without zone');
-                realityEditor.network.addHeartbeatObject(message);
             }
 
             // forward the action message to the network module, to synchronize state across multiple clients

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -47,8 +47,12 @@ createNameSpace("realityEditor.device.environment");
         // matrices
         initialPocketToolRotation: null,
         supportsAreaTargetCapture: true,
+        automaticallyPromptForAreaTargetCapture: true,
         hideOriginCube: false, // explicitly don't show the 3d cubes at the world origin
-        addOcclusionGltf: true // by default loads the occlusion mesh, but a VR viewer can disable this
+        addOcclusionGltf: true, // by default loads the occlusion mesh, but a VR viewer can disable this
+        suppressObjectDetections: false, // temporarily toggle on to stop UDP messages from triggered object download
+        suppressObjectRendering: false, // temporarily toggle on to stop rendering objects/tools/nodes
+        overrideAreaTargetScanningUI: false // hide the default status textfield for the area target scanning
     };
 
     // variables can be directly set by add-ons by using the public 'variables' property

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -33,7 +33,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         onCaptureStatus: [],
         onStopScanning: [],
         onCaptureSuccessOrError: []
-    }
+    };
 
     /**
      * Public init method to enable rendering ghosts of edited frames while in editing mode.
@@ -708,33 +708,31 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         }
     }
 
-    exports.getDetectedServers = function() {
-        return detectedServers;
-    }
-
     exports.initService = initService;
 
     // allow external module to trigger the area target capture prompt
-    exports.showNotificationIfNeeded = showNotificationIfNeeded;
     exports.programmaticallyStartScan = programmaticallyStartScan;
     exports.onStartScanning = (callback) => {
         callbacks.onStartScanning.push(callback);
-    }
+    };
     exports.onStopScanning = (callback) => {
         callbacks.onStopScanning.push(callback);
-    }
+    };
     exports.onCaptureSuccessOrError = (callback) => {
         callbacks.onCaptureSuccessOrError.push(callback);
-    }
-    exports.didFindAnyWorldObjects = function() {
+    };
+    exports.didFindAnyWorldObjects = () => {
         let validWorlds = Object.keys(detectedObjects).map(key => objects[key]).filter(obj => {
             return (obj.isWorldObject || obj.type === 'world') && obj.ip !== '127.0.0.1';
         });
         return foundAnyWorldObjects && validWorlds.length > 0;
-    }
+    };
     exports.onCaptureStatus = (callback) => {
         callbacks.onCaptureStatus.push(callback);
-    }
+    };
+    exports.getDetectedServers = () => {
+        return detectedServers;
+    };
 
     // make functions available to native app callbacks
     exports.captureStatusHandler = captureStatusHandler;

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -247,6 +247,7 @@ realityEditor.gui.ar.draw.updateExtendedTrackingVisibility = function(visibleObj
 };
 
 realityEditor.gui.ar.draw.frameNeedsToBeRendered = true;
+realityEditor.gui.ar.draw.prevSuppressedRendering = false;
 
 /**
  * Previously triggered directly by the native app when the AR engine updates with a new set of recognized markers,
@@ -254,6 +255,30 @@ realityEditor.gui.ar.draw.frameNeedsToBeRendered = true;
  * @param {Object.<string, Array.<number>>} visibleObjects - set of {objectId: matrix} pairs, one per recognized marker
  */
 realityEditor.gui.ar.draw.update = function (visibleObjects) {
+    if (realityEditor.device.environment.variables.suppressObjectRendering) {
+        if (!this.prevSuppressedRendering) {
+            let toolContainer = document.getElementById('GUI');
+            let canvas = document.getElementById('canvas');
+            let glcanvas = document.getElementById('glcanvas');
+            let threejsCanvas = document.getElementById('mainThreejsCanvas');
+            [toolContainer, canvas, glcanvas, threejsCanvas].forEach(eltToHide => {
+                eltToHide.classList.add('suppressedRendering');
+            });
+        }
+        this.prevSuppressedRendering = true;
+        return; // ignore render loop while suppressing renderer
+    } else if (this.prevSuppressedRendering) {
+        this.prevSuppressedRendering = false;
+        // un-hide the hidden tools and canvases when suppressObjectRendering variable first changes
+        let toolContainer = document.getElementById('GUI');
+        let canvas = document.getElementById('canvas');
+        let glcanvas = document.getElementById('glcanvas');
+        let threejsCanvas = document.getElementById('mainThreejsCanvas');
+        [toolContainer, canvas, glcanvas, threejsCanvas].forEach(eltToHide => {
+            eltToHide.classList.remove('suppressedRendering');
+        });
+    }
+
     if (!realityEditor.gui.ar.draw.frameNeedsToBeRendered) { return; } // don't recompute multiple times between a single animation frames
     realityEditor.gui.ar.draw.frameNeedsToBeRendered = false; // gets set back to true by requestAnimationFrame code
     

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -821,7 +821,14 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
     
     // gets the width of the usable portion of the screen for the pocket
     function getWidth() {
-        let usableScreenWidth = document.getElementById('guiButtonDiv').getClientRects()[0].left - 37;
+        let guiButtonDiv = document.getElementById('guiButtonDiv');
+        let usableScreenWidth = window.innerWidth;
+        if (guiButtonDiv) {
+            let clientRects = guiButtonDiv.getClientRects();
+            if (clientRects && clientRects[0]) {
+                usableScreenWidth = clientRects[0].left - 37;
+            }
+        }
         // console.log(usableScreenWidth);
         return usableScreenWidth;
     }


### PR DESCRIPTION
 necessary for the pop-up-onboarding-addon to adjust the UI and trigger a custom area target scanning workflow

Includes:
- `suppressObjectDetections`: so that we have the option to ignore UDP heartbeats while app is in main menu
- `suppressObjectRendering`: so that we can ignore all rendering and hide all AR elements when we open various menus, or during the scanning process
- `overrideAreaTargetScanningUI`: so that we can customize the buttons/text that appears while scanning
- `automaticallyPromptForAreaTargetCapture`: can be disabled to ignore the default scanning flow
- callbacks for areaTargetScanner.js (`onStartScanning`, `onCaptureStatus`, `onStopScanning`, `onCaptureSuccessOrError`), and public method to `programmaticallyStartScan`: so that we can provide a customized UI/UX for scanning
- also adds a progress bar that updates while the area target is being generated!