### PR TITLE
adds rayDirection to worldIntersectPoint

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -335,7 +335,8 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
                         y: raycastIntersects[0].point.y,
                         z: raycastIntersects[0].point.z,
                         // NOTE: to transform a normal, you must multiply by the transpose of the inverse of the model-view matrix
-                        normalVector: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize()
+                        normalVector: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize(),
+                        rayDirection: raycastIntersects[0].rayDirection
                     };
                 }
             }

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -336,7 +336,8 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
                         z: raycastIntersects[0].point.z,
                         // NOTE: to transform a normal, you must multiply by the transpose of the inverse of the model-view matrix
                         normalVector: raycastIntersects[0].face.normal.clone().applyMatrix4(trInvGroundPlaneMat).normalize(),
-                        rayDirection: raycastIntersects[0].rayDirection
+                        // the ray direction is just a vector, so we don't need the transpose matrix
+                        rayDirection: raycastIntersects[0].rayDirection.clone().applyMatrix4(inverseGroundPlaneMatrix).normalize()
                     };
                 }
             }

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -354,7 +354,11 @@ import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUt
         raycaster.setFromCamera( mouse, camera );
 
         //3. compute intersections
-        return raycaster.intersectObjects( objectsToCheck || scene.children, true );
+        let results = raycaster.intersectObjects( objectsToCheck || scene.children, true );
+        results.forEach(intersection => {
+            intersection.rayDirection = raycaster.ray.direction;
+        });
+        return results;
     }
 
     /**


### PR DESCRIPTION
I realized that I didn't include this in the previous version, but you might want easy access to the `rayDirection` within the `worldIntersectPoint` provided to tools