### PR TITLE
add screenTopOffset to move envelope X button lower

### DIFF
--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -44,6 +44,7 @@ createNameSpace("realityEditor.device.environment");
         distanceScaleFactor: 1, // 10
         newFrameDistanceMultiplier: 1, // 10
         localServerPort: 49369, // the port where a local vuforia-spatial-edge-server can be expected
+        screenTopOffset: 0, // if there's a menubar on the top, increase this
         // matrices
         initialPocketToolRotation: null,
         supportsAreaTargetCapture: true,

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -212,6 +212,7 @@ createNameSpace("realityEditor.envelopeManager");
                 exitButton = document.createElement('img');
                 exitButton.src = 'svg/menu/exit.svg';
                 exitButton.id = 'exitEnvelopeButton';
+                exitButton.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
                 document.body.appendChild(exitButton);
                 
                 exitButton.addEventListener('pointerup', function() {


### PR DESCRIPTION
Allows remote operator menubar to adjust the top alignment. Could also be used in future by portrait mode app to avoid the screen notch at the top.