### PR TITLE
Ignore camera control clicks; Add offline check

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -346,6 +346,7 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
             type: event.type,
             pointerId: event.pointerId,
             pointerType: event.pointerType,
+            button: event.button,
             x: newCoords.x,
             y: newCoords.y
         }
@@ -588,12 +589,24 @@ realityEditor.device.disablePinchToScale = function() {
 };
 
 /**
+ * @return {boolean} If the event is intended to control the camera and not the
+ *   AR elements
+ */
+realityEditor.device.isMouseEventCameraControl = function(event) {
+  // If mouse events are enabled ignore right clicks and middle clicks
+  return realityEditor.device.environment.requiresMouseEvents() &&
+    (event.button === 2 || event.button === 1);
+};
+
+/**
  * Begin the touchTimer to enable editing mode if the user doesn't move too much before it finishes.
  * Also set point A of the globalProgram so we can start creating a link if this is a node.
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchDown = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     var target = event.currentTarget;
     var activeVehicle = realityEditor.getVehicle(target.objectId, target.frameId, target.nodeId);
@@ -663,7 +676,9 @@ realityEditor.device.onElementTouchDown = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchMove = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     if (this.previousPointerMove && this.previousPointerMove.x === event.pageX && this.previousPointerMove.y === event.pageY) {
         return; // ensure that we ignore supposed "move" events if position didn't change
@@ -698,7 +713,9 @@ realityEditor.device.onElementTouchMove = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchEnter = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     var target = event.currentTarget;
     
@@ -740,7 +757,9 @@ realityEditor.device.onElementTouchEnter = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchOut = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     var target = event.currentTarget;
     if (target.type !== "ui") {
@@ -778,7 +797,9 @@ realityEditor.device.onElementTouchOut = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onElementTouchUp = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     var target = event.currentTarget;
     var activeVehicle = this.getEditingVehicle();
@@ -982,8 +1003,10 @@ realityEditor.device.onElementMultiTouchEnd = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerDown = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
-    
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
+
     globalStates.pointerPosition = [event.clientX, event.clientY];
 
     overlayDiv.style.display = "inline";
@@ -1018,7 +1041,9 @@ realityEditor.device.onDocumentPointerDown = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerMove = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     event.preventDefault(); //TODO: why is this here but not in other document events?
 
@@ -1042,7 +1067,9 @@ realityEditor.device.onDocumentPointerMove = function(event) {
  * @param {PointerEvent} event
  */
 realityEditor.device.onDocumentPointerUp = function(event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
 
     // add the pocket node to the closest frame
     if (realityEditor.gui.buttons.getButtonState('pocket') === 'down') {
@@ -1153,7 +1180,9 @@ function modifyTouchEventIfDesktop(event) {
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchStart = function (event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchstart", realityEditor.device.touchInputs.screenTouchStart);
@@ -1210,7 +1239,9 @@ realityEditor.device.onDocumentMultiTouchStart = function (event) {
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchMove = function (event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchmove", realityEditor.device.touchInputs.screenTouchMove);
@@ -1437,7 +1468,9 @@ realityEditor.device.checkIfFramePulledIntoUnconstrained = function(activeVehicl
  * @param {TouchEvent} event
  */
 realityEditor.device.onDocumentMultiTouchEnd = function (event) {
-    if (realityEditor.device.environment.requiresMouseEvents() && event.button === 2) { return; } // ignore right-clicks
+    if (realityEditor.device.isMouseEventCameraControl(event)) {
+      return;
+    }
     modifyTouchEventIfDesktop(event);
 
     realityEditor.device.touchEventObject(event, "touchend", realityEditor.device.touchInputs.screenTouchEnd);

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -277,6 +277,41 @@ realityEditor.device.onload = function () {
         }, 1000);
     }
 
+    fetch(window.location + '/?offlineCheck=' + Date.now()).then(res => {
+        console.log('offline check', Array.from(res.headers.entries()));
+        if (!res.headers.has('X-Offline-Cache')) {
+            return;
+        }
+
+        let message = 'Network Offline. Showing last known state';
+        let lifetime = 5000;
+
+        // create UI
+        let notificationUI = document.createElement('div');
+        notificationUI.classList.add('statusBar');
+        if (realityEditor.device.environment.variables.layoutUIForPortrait) {
+            notificationUI.classList.add('statusBarPortrait');
+        }
+        notificationUI.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+        document.body.appendChild(notificationUI);
+
+        let notificationTextContainer = document.createElement('div');
+        notificationUI.classList.add('statusBarText');
+        notificationUI.appendChild(notificationTextContainer);
+
+        // show and populate with message
+        notificationUI.classList.add('statusBar');
+        notificationUI.classList.remove('statusBarHidden');
+        notificationTextContainer.innerHTML = message;
+
+        setTimeout(function() {
+            if (!notificationUI) {
+                return;
+            } // no need to hide it if it doesn't exist
+            notificationUI.parentElement.removeChild(notificationUI);
+        }, lifetime);
+    });
+
     // set up the global canvas for drawing the links
     globalCanvas.canvas = document.getElementById('canvas');
     globalCanvas.canvas.width = globalStates.height; // TODO: fix width vs height mismatch once and for all


### PR DESCRIPTION
Mass-blocks all middle mouse button and right mouse button clicks using a helper function. Adds a button property to the frame's pointer event as well (even though it should only be button: 0 in theory). Adds a notification (shamelessly stolen from the scanning api) about when the network is offline