### PR TITLE
Fix three-mesh-bvh import path

### DIFF
--- a/thirdPartyCode/three-mesh-bvh.module.js
+++ b/thirdPartyCode/three-mesh-bvh.module.js
@@ -1,4 +1,4 @@
-import { BufferAttribute, Vector3, Vector2, Plane, Line3, Triangle, Sphere, Box3, Matrix4, BackSide, DoubleSide, FrontSide, Object3D, BufferGeometry, Group, LineBasicMaterial, MeshBasicMaterial, Ray, Mesh, RGBAFormat, RGBFormat, RGFormat, RedFormat, RGBAIntegerFormat, RGBIntegerFormat, RGIntegerFormat, RedIntegerFormat, DataTexture, NearestFilter, IntType, UnsignedIntType, FloatType, UnsignedByteType, UnsignedShortType, ByteType, ShortType } from '../../thirdPartyCode/three/three.module.js';
+import { BufferAttribute, Vector3, Vector2, Plane, Line3, Triangle, Sphere, Box3, Matrix4, BackSide, DoubleSide, FrontSide, Object3D, BufferGeometry, Group, LineBasicMaterial, MeshBasicMaterial, Ray, Mesh, RGBAFormat, RGBFormat, RGFormat, RedFormat, RGBAIntegerFormat, RGBIntegerFormat, RGIntegerFormat, RedIntegerFormat, DataTexture, NearestFilter, IntType, UnsignedIntType, FloatType, UnsignedByteType, UnsignedShortType, ByteType, ShortType } from './three/three.module.js';
 
 // Split strategy constants
 const CENTER = 0;


### PR DESCRIPTION
The previous path went up by one too many levels which works locally but breaks on toolboxedge.net with its plethora of path components