### PR TITLE
Move main three.js camera instead of container objects

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -812,7 +812,6 @@ body {
     left: 0;
     top: 0;
     background: transparent;
-    pointer-events: none;
     -webkit-transform-style: preserve-3d;
     -webkit-transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 }

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -43,6 +43,7 @@ createNameSpace("realityEditor.device.environment");
         lineWidthMultiplier: 1, // 5
         distanceScaleFactor: 1, // 10
         newFrameDistanceMultiplier: 1, // 10
+        transformControlsSize: 1, // on remote operator, we can scale down the gizmo size for moving groundplane anchors
         localServerPort: 49369, // the port where a local vuforia-spatial-edge-server can be expected
         screenTopOffset: 0, // if there's a menubar on the top, increase this
         // matrices

--- a/src/gui/ar/areaCreator.js
+++ b/src/gui/ar/areaCreator.js
@@ -308,23 +308,21 @@ realityEditor.gui.ar.areaCreator.didAreaUpdate = function() {
 }.bind(realityEditor.gui.ar.areaCreator);
 
 realityEditor.gui.ar.areaCreator.calculateGroundPlaneIntersection = function(event) {
-    const intersects = realityEditor.gui.threejsScene.getRaycastIntersects(event.clientX, event.clientY);
     const groundPlane = realityEditor.gui.threejsScene.getGroundPlane();
-    const intersect = intersects.find(intersect => intersect.object === groundPlane);
-    if (intersect) {
-        const point = realityEditor.gui.threejsScene.getPointAtDistanceFromCamera(event.clientX, event.clientY, intersect.distance);
-        const worldObjectToolboxMatrix = realityEditor.sceneGraph.getModelViewMatrix(realityEditor.sceneGraph.getWorldId());
+    const intersects = realityEditor.gui.threejsScene.getRaycastIntersects(event.clientX, event.clientY, [groundPlane]);
+    if (intersects.length > 0) {
+        let worldObjectToolboxMatrix = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId()).worldMatrix;
         const worldObjectThreeMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
         realityEditor.gui.threejsScene.setMatrixFromArray(worldObjectThreeMatrix, worldObjectToolboxMatrix);
-        return point.applyMatrix4(worldObjectThreeMatrix.invert());
+        return intersects[0].point.applyMatrix4(worldObjectThreeMatrix.invert());
     }
 }
 
 realityEditor.gui.ar.areaCreator.calculateFloorOffset = function() {
-    const worldObjectToolboxMatrix = realityEditor.sceneGraph.getModelViewMatrix(realityEditor.sceneGraph.getWorldId());
+    const worldObjectToolboxMatrix = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId()).worldMatrix;
     const worldObjectThreeMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
     realityEditor.gui.threejsScene.setMatrixFromArray(worldObjectThreeMatrix, worldObjectToolboxMatrix);
-    const groundPlaneToolboxMatrix = realityEditor.sceneGraph.getGroundPlaneModelViewMatrix();
+    const groundPlaneToolboxMatrix = realityEditor.sceneGraph.getGroundPlaneNode().worldMatrix;
     const groundPlaneThreeMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
     realityEditor.gui.threejsScene.setMatrixFromArray(groundPlaneThreeMatrix, groundPlaneToolboxMatrix);
     const groundToWorldMatrix = groundPlaneThreeMatrix.clone().invert().multiply(worldObjectThreeMatrix);

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -27,6 +27,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let originColor = 0xffffff;
     let mouseCursorMesh = null;
     let initialCalculationMesh = null;
+    let transformControls = {};
 
     function initService() {
         // Note that, currently, positioningMode blocks touch events from reaching anything else, so it should be toggled off when not in use
@@ -99,9 +100,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         // set the anchor matrix by taking the x, z position
         knownAnchorNodes[frameKey].setLocalMatrix(anchoredMatrix);
 
-        // we use localMatrix, not world matrix, because mesh is already a child of the ground plane
-        // realityEditor.gui.threejsScene.setMatrixFromArray(threejsGroups[frameKey].matrix, knownAnchorNodes[frameKey].localMatrix);
-        
         threejsGroups[frameKey].position.set(relativeMatrix[12], 0, relativeMatrix[14]);
     }
 
@@ -144,14 +142,20 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         group.name = getElementName(frameKey) + '_group';
         group.visible = isPositioningMode;
 
-        // let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(originBox, true, false, true, 0.2, (e) => {
-        let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, 0.2, (e) => {
+        let transformControl = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, 0.2, (e) => {
             onChange(e);
         }, (e) => {
             onDraggingChanged(e);
         });
-        transformControls.attachedGroupName = group.name;
-        transformControls.attachedFrameKey = frameKey;
+        transformControl.attachedGroupName = group.name;
+        transformControl.attachedFrameKey = frameKey;
+
+        transformControls[frameKey] = transformControl;
+
+        if (!isPositioningMode || globalStates.settingsButtonState) {
+            group.visible = false;
+            transformControl.visible = false;
+        }
 
         return group;
     }
@@ -195,6 +199,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         if (hiddenInEnvelope) {
             group.visible = false;
         }
+
+        transformControls[key].visible = group.visible;
     }
 
     // helper function to get the x,z coords of a threejs object based on its matrix

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -142,7 +142,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         group.name = getElementName(frameKey) + '_group';
         group.visible = isPositioningMode;
 
-        let transformControl = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, 0.2, (e) => {
+        let size = realityEditor.device.environment.variables.transformControlsSize || 1;
+        let transformControl = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, size, (e) => {
             onChange(e);
         }, (e) => {
             onDraggingChanged(e);

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -29,8 +29,10 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let constrainToZ = false;
     let initialAnchorPosition = null;
     let initialLocalMatrix = null;
+    let isFirstDragUpdate = false;
 
     let originColor = 0xffffff;
+    let draggableColor = 0x888888;
     let xBoxColor = 0xff0000;
     let zBoxColor = 0x0000ff;
     let selectionColor = 0xffff00;
@@ -83,6 +85,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             if (!object) { continue; }
 
             for (let frameKey in object.frames) {
+                if (frameKey === selectedGroupKey) { continue; } // don't update tools currently being dragged
+
                 let frame = realityEditor.getFrame(objectKey, frameKey);
                 if (!frame) { continue; }
                 updateFrame(frameKey);
@@ -90,7 +94,9 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         }
 
         for (let frameKey in destinationMatrices) {
-            const alpha = 0.5;
+            if (frameKey === selectedGroupKey) { continue; } // don't update tools currently being dragged
+            
+            const alpha = 0.5; // todo: change to 1 to remove animation
             let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(frameKey);
             let currentMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix);
             let destinationMatrix = destinationMatrices[frameKey];
@@ -125,7 +131,9 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         knownAnchorNodes[frameKey].setLocalMatrix(anchoredMatrix);
 
         // we use localMatrix, not world matrix, because mesh is already a child of the ground plane
-        realityEditor.gui.threejsScene.setMatrixFromArray(threejsGroups[frameKey].matrix, knownAnchorNodes[frameKey].localMatrix);
+        // realityEditor.gui.threejsScene.setMatrixFromArray(threejsGroups[frameKey].matrix, knownAnchorNodes[frameKey].localMatrix);
+        
+        threejsGroups[frameKey].position.set(relativeMatrix[12], 0, relativeMatrix[14]);
     }
 
     // when we add a sceneNode for a tool, also add one to the groundplane that is associated with it
@@ -159,7 +167,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         return mouseCursorMesh;
     }
 
-    // the initial calculation mesh stays in the location a tool's surface anchor was at when you first started dragging it. used for coordinate system calculations.
+    // // the initial calculation mesh stays in the location a tool's surface anchor was at when you first started dragging it. used for coordinate system calculations.
     function getInitialCalculationMesh() {
         if (!initialCalculationMesh) {
             const THREE = realityEditor.gui.threejsScene.THREE;
@@ -168,7 +176,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             initialCalculationMesh.name = 'initialCalculationMesh';
             // mouseCursorMesh.matrixAutoUpdate = false; // this is needed to position it directly with matrices
             initialCalculationMesh.visible = isPositioningMode;
-            initialCalculationMesh.matrixAutoUpdate = false;
+            // initialCalculationMesh.matrixAutoUpdate = false;
             realityEditor.gui.threejsScene.addToScene(initialCalculationMesh); // this adds it to the ground plane group by default
         }
         return initialCalculationMesh;
@@ -177,26 +185,40 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     // helper function to create the geometry for a surface anchor, including its X-Z axis handles
     function createAnchorGroup(frameKey) {
         const THREE = realityEditor.gui.threejsScene.THREE;
-        const group = new THREE.Group();
+        // const group = new THREE.Group();
+
+        let originSize = 100; // axisSize = 50;
+        const group = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: originColor}));
+
         group.name = getElementName(frameKey) + '_group';
-        group.matrixAutoUpdate = false; // this is needed to position it directly with matrices
+        // group.matrixAutoUpdate = false; // this is needed to position it directly with matrices
         group.visible = isPositioningMode;
-        let originSize = 100, axisSize = 50;
-        const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize),new THREE.MeshBasicMaterial({color: originColor}));
-        originBox.name = getElementName(frameKey) + '_originBox';
-        const xBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: xBoxColor}));
-        xBox.name = getElementName(frameKey) + '_xBox';
-        // const yBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color:0x00ff00}));
-        // yBox.name = getElementName(frameKey) + '_yBox';
-        const zBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: zBoxColor}));
-        zBox.name = getElementName(frameKey) + '_zBox';
-        xBox.position.x = 150;
-        // yBox.position.y = 150;
-        zBox.position.z = 150;
-        group.add(originBox);
-        originBox.add(xBox);
-        // originBox.add(yBox);
-        originBox.add(zBox);
+        // let originSize = 100; // axisSize = 50;
+        // const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: originColor}));
+        // originBox.name = getElementName(frameKey) + '_originBox';
+
+        // const draggableBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: draggableColor}));
+        // draggableBox.name = getElementName(frameKey) + '_draggableBox';
+
+        // let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(originBox, true, false, true, 0.2, (e) => {
+        let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, 0.2, (e) => {
+            onChange(e);
+        }, (e) => {
+            onDraggingChanged(e);
+        });
+        transformControls.attachedGroupName = group.name;
+        transformControls.attachedFrameKey = frameKey;
+
+        // const xBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: xBoxColor}));
+        // xBox.name = getElementName(frameKey) + '_xBox';
+        // const zBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: zBoxColor}));
+        // zBox.name = getElementName(frameKey) + '_zBox';
+        // xBox.position.x = 150;
+        // zBox.position.z = 150;
+        // group.add(originBox);
+        // group.add(draggableBox);
+        // originBox.add(xBox);
+        // originBox.add(zBox);
         return group;
     }
 
@@ -218,22 +240,22 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             updateGroupVisibility(threejsGroups[key], key);
         }
         if (mouseCursorMesh) { mouseCursorMesh.visible = false; }
-        if (initialCalculationMesh) { initialCalculationMesh.visible = false; }
+        // if (initialCalculationMesh) { initialCalculationMesh.visible = false; }
 
         let threejsCanvas = document.getElementById('mainThreejsCanvas');
         if (!threejsCanvas) {
             return;
         }
         if (isPositioningMode && !globalStates.settingsButtonState) {
-            threejsCanvas.addEventListener('pointerdown', onPointerDown, false);
-            threejsCanvas.addEventListener('pointerup', onPointerUp, false);
-            threejsCanvas.addEventListener('pointercancel', onPointerUp, false);
-            threejsCanvas.addEventListener('pointermove', onPointerMove, false);
+            // threejsCanvas.addEventListener('pointerdown', onPointerDown, false);
+            // threejsCanvas.addEventListener('pointerup', onPointerUp, false);
+            // threejsCanvas.addEventListener('pointercancel', onPointerUp, false);
+            // threejsCanvas.addEventListener('pointermove', onPointerMove, false);
         } else {
-            threejsCanvas.removeEventListener('pointerdown', onPointerDown, false);
-            threejsCanvas.removeEventListener('pointerup', onPointerUp, false);
-            threejsCanvas.removeEventListener('pointercancel', onPointerUp, false);
-            threejsCanvas.removeEventListener('pointermove', onPointerMove, false);
+            // threejsCanvas.removeEventListener('pointerdown', onPointerDown, false);
+            // threejsCanvas.removeEventListener('pointerup', onPointerUp, false);
+            // threejsCanvas.removeEventListener('pointercancel', onPointerUp, false);
+            // threejsCanvas.removeEventListener('pointermove', onPointerMove, false);
         }
     }
 
@@ -257,46 +279,46 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         }
     }
 
-    // hit test threeJsScene to see if we hit any of the anchor threeJsGroups
-    // if we are, keep track of it so we can move it on pointermove. also give visual feedback
-    function onPointerDown(e) {
-        isPointerDown = true;
-
-        let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-
-        intersects.forEach(function(intersect) {
-            if (selectedGroupKey) { return; }
-
-            let meshName = intersect.object.name;
-            let matchingKey = Object.keys(threejsGroups).find(function(key) {
-                return meshName.includes(key);
-            });
-            if (!matchingKey) { return; }
-
-            constrainToX = meshName.includes('_xBox');
-            constrainToZ = meshName.includes('_zBox');
-
-            selectedMeshName = meshName;
-            selectedGroupKey = matchingKey;
-
-            intersect.object.material.color.setHex(selectionColor);
-
-            initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
-            let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-            if (frameSceneNode) {
-                initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix)
-            }
-
-            let initialMesh = getInitialCalculationMesh();
-            initialMesh.visible = true;
-            realityEditor.gui.threejsScene.setMatrixFromArray(initialMesh.matrix, threejsGroups[selectedGroupKey].matrix.elements);
-
-            realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, true);
-
-            // stop propagation if we hit anything, otherwise pass the event on to the rest of the application
-            e.stopPropagation();
-        });
-    }
+    // // hit test threeJsScene to see if we hit any of the anchor threeJsGroups
+    // // if we are, keep track of it so we can move it on pointermove. also give visual feedback
+    // function onPointerDown(e) {
+    //     isPointerDown = true;
+    //
+    //     let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
+    //
+    //     intersects.forEach(function(intersect) {
+    //         if (selectedGroupKey) { return; }
+    //
+    //         let meshName = intersect.object.name;
+    //         let matchingKey = Object.keys(threejsGroups).find(function(key) {
+    //             return meshName.includes(key);
+    //         });
+    //         if (!matchingKey) { return; }
+    //
+    //         constrainToX = meshName.includes('_xBox');
+    //         constrainToZ = meshName.includes('_zBox');
+    //
+    //         selectedMeshName = meshName;
+    //         selectedGroupKey = matchingKey;
+    //
+    //         intersect.object.material.color.setHex(selectionColor);
+    //
+    //         initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
+    //         let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+    //         if (frameSceneNode) {
+    //             initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix)
+    //         }
+    //
+    //         let initialMesh = getInitialCalculationMesh();
+    //         initialMesh.visible = true;
+    //         realityEditor.gui.threejsScene.setMatrixFromArray(initialMesh.matrix, threejsGroups[selectedGroupKey].matrix.elements);
+    //
+    //         realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, true);
+    //
+    //         // stop propagation if we hit anything, otherwise pass the event on to the rest of the application
+    //         e.stopPropagation();
+    //     });
+    // }
 
     // helper function to get the x,z coords of a threejs object based on its matrix
     function getPositionXZ(threeJsObject) {
@@ -307,111 +329,188 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         };
     }
 
-    // sets the localMatrix of a tool's scene node such that its surface anchor will move to the mouseCursor mesh's position
-    function moveSelectedToolToMouseCursor(animated) {
-        if (!initialAnchorPosition || !initialLocalMatrix || !selectedGroupKey) { return; }
+    // // sets the localMatrix of a tool's scene node such that its surface anchor will move to the mouseCursor mesh's position
+    // function moveSelectedToolToMouseCursor(animated) {
+    //     if (!initialAnchorPosition || !initialLocalMatrix || !selectedGroupKey) { return; }
+    //
+    //     // move tool to correct position
+    //     let oldAnchorLocalPosition = initialAnchorPosition;
+    //     let newAnchorLocalPosition = getPositionXZ(getMouseCursorMesh());
+    //
+    //     let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
+    //     let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
+    //
+    //     let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+    //     let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(initialLocalMatrix);
+    //     localMatrix[12] += dx;
+    //     localMatrix[14] += dz;
+    //
+    //     if (animated) {
+    //         destinationMatrices[selectedGroupKey] = localMatrix;
+    //     } else {
+    //         frameSceneNode.setLocalMatrix(localMatrix);
+    //     }
+    // }
 
-        // move tool to correct position
-        let oldAnchorLocalPosition = initialAnchorPosition;
-        let newAnchorLocalPosition = getPositionXZ(getMouseCursorMesh());
+    // // when we touch up, move the selected anchor's tool to match the movement of the mouse cursor mesh relative to its anchor
+    // function onPointerUp(_e) {
+    //     // e.stopPropagation(); // we can propagate touch up/cancel events in case gui is stuck in state before catcher shows
+    //     isPointerDown = false;
+    //
+    //     // reset mesh color
+    //     if (selectedGroupKey && threejsGroups[selectedGroupKey]) {
+    //         let group = threejsGroups[selectedGroupKey];
+    //         let mesh = group.getObjectByName(selectedMeshName);
+    //         if (mesh) {
+    //             if (constrainToX) {
+    //                 mesh.material.color.setHex(xBoxColor);
+    //             } else if (constrainToZ) {
+    //                 mesh.material.color.setHex(zBoxColor);
+    //             } else {
+    //                 mesh.material.color.setHex(originColor);
+    //             }
+    //         }
+    //
+    //         // move tool to correct position
+    //         moveSelectedToolToMouseCursor(false);
+    //         delete destinationMatrices[selectedGroupKey];
+    //
+    //         realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, false);
+    //
+    //         // post its position to the server so it persists
+    //         let sceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+    //         if (sceneNode && sceneNode.linkedVehicle) {
+    //             realityEditor.network.postVehiclePosition(sceneNode.linkedVehicle);
+    //             console.log('post vehicle position');
+    //         }
+    //     }
+    //
+    //     // reset any editing state
+    //     selectedGroupKey = null;
+    //     selectedMeshName = null;
+    //     constrainToX = false;
+    //     constrainToZ = false;
+    //     initialAnchorPosition = null;
+    //     initialLocalMatrix = null;
+    //
+    //     getMouseCursorMesh().visible = false;
+    //     // getInitialCalculationMesh().visible = false;
+    // }
+    
+    // function getAnchorMeshByFrameKey(frameKey) {
+    //     return threejsGroups[frameKey].children[0];
+    // }
+    // function getDraggableMeshByFrameKey(frameKey) {
+    //     return threejsGroups[frameKey].children[1];
+    // }
 
-        let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
-        let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
-
-        let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-        let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(initialLocalMatrix);
-        localMatrix[12] += dx;
-        localMatrix[14] += dz;
-
-        if (animated) {
-            destinationMatrices[selectedGroupKey] = localMatrix;
-        } else {
-            frameSceneNode.setLocalMatrix(localMatrix);
-        }
-    }
-
-    // when we touch up, move the selected anchor's tool to match the movement of the mouse cursor mesh relative to its anchor
-    function onPointerUp(_e) {
-        // e.stopPropagation(); // we can propagate touch up/cancel events in case gui is stuck in state before catcher shows
-        isPointerDown = false;
-
-        // reset mesh color
-        if (selectedGroupKey && threejsGroups[selectedGroupKey]) {
-            let group = threejsGroups[selectedGroupKey];
-            let mesh = group.getObjectByName(selectedMeshName);
-            if (mesh) {
-                if (constrainToX) {
-                    mesh.material.color.setHex(xBoxColor);
-                } else if (constrainToZ) {
-                    mesh.material.color.setHex(zBoxColor);
-                } else {
-                    mesh.material.color.setHex(originColor);
-                }
-            }
+    function onChange(e) {
+        console.log('onChange', e.target.attachedGroupName);
+        if (e.target.attachedFrameKey === selectedGroupKey) {
 
             // move tool to correct position
-            moveSelectedToolToMouseCursor(false);
-            delete destinationMatrices[selectedGroupKey];
+            let oldAnchorLocalPosition = getPositionXZ(getInitialCalculationMesh());
+            let newAnchorLocalPosition = getPositionXZ(threejsGroups[selectedGroupKey]); //getAnchorMeshByFrameKey(selectedGroupKey));
+            
+            console.log(newAnchorLocalPosition);
 
-            realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, false);
-
-            // post its position to the server so it persists
-            let sceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-            if (sceneNode && sceneNode.linkedVehicle) {
-                realityEditor.network.postVehiclePosition(sceneNode.linkedVehicle);
-                console.log('post vehicle position');
+            let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
+            let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
+            
+            if (isFirstDragUpdate) {
+                dx = 0;
+                dz = 0;
+                isFirstDragUpdate = false;
             }
-        }
 
-        // reset any editing state
-        selectedGroupKey = null;
-        selectedMeshName = null;
-        constrainToX = false;
-        constrainToZ = false;
-        initialAnchorPosition = null;
-        initialLocalMatrix = null;
+            let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+            let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(initialLocalMatrix);
+            localMatrix[12] += dx;
+            localMatrix[14] += dz;
+            frameSceneNode.setLocalMatrix(localMatrix);
+            
+            // let cursorMesh = getMouseCursorMesh();
+            // cursorMesh.position.set(newAnchorLocalPosition.x, 0, newAnchorLocalPosition.z);
 
-        getMouseCursorMesh().visible = false;
-        getInitialCalculationMesh().visible = false;
-    }
-
-    // if we touched down on anything, calculate where to move mesh along its x-z plane so that it lines up with mouse position
-    function onPointerMove(e) {
-        // e.stopPropagation();
-        if (!isPointerDown) { return; }
-        if (!selectedGroupKey) { return; }
-
-        let thisGroup = threejsGroups[selectedGroupKey];
-        let thisAnchorNode = knownAnchorNodes[selectedGroupKey];
-        if (!thisGroup || !thisAnchorNode) { return; }
-
-        let cursorMesh = getMouseCursorMesh();
-
-        let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-
-        let areaTargetIntersect = null;
-        intersects.forEach(function(intersect) {
-            if (areaTargetIntersect) { return; }
-            if (intersect.object.name === 'mesh_0' || intersect.object.name === 'groundPlaneElement') {
-                areaTargetIntersect = intersect;
-            }
-        });
-
-        if (!areaTargetIntersect) { return; }
-
-        let result = realityEditor.gui.threejsScene.getPointAtDistanceFromCamera(e.clientX, e.clientY, areaTargetIntersect.distance);
-        let relativePosition = getInitialCalculationMesh().worldToLocal(result);
-        let initialPosition = getPositionXZ(getInitialCalculationMesh());
-        // adjust the initial position by relativePosition (but snap to axis if one is selected)
-        let newX = constrainToZ ? initialPosition.x : relativePosition.x + initialPosition.x;
-        let newZ = constrainToX ? initialPosition.z : relativePosition.z + initialPosition.z;
-        cursorMesh.position.set(newX, 0, newZ);
-        cursorMesh.visible = true;
-
-        if (REALTIME_DRAG_UPDATE) {
-            moveSelectedToolToMouseCursor(true);
+            // initialAnchorPosition = {
+            //     x: newAnchorLocalPosition.x,
+            //     z: newAnchorLocalPosition.z
+            // };
+            
+            // initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(localMatrix);
         }
     }
+
+    function onDraggingChanged(e) {
+        if (e.value) {
+            console.log('started drag on ' + e.target.attachedGroupName);
+            selectedGroupKey = e.target.attachedFrameKey;
+            initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]); //getAnchorMeshByFrameKey(selectedGroupKey));
+            let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+            if (frameSceneNode) {
+                initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix)
+            }
+
+            let initialMesh = getInitialCalculationMesh();
+            initialMesh.visible = true;
+            // let anchorPosition = getAnchorMeshByFrameKey(selectedGroupKey).position;
+            let anchorGroupPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
+            // initialMesh.position.set(anchorPosition.x + anchorGroupPosition.x, anchorPosition.y, anchorPosition.z + anchorGroupPosition.z);
+            initialMesh.position.set(anchorGroupPosition.x, 0, anchorGroupPosition.z);
+            // realityEditor.gui.threejsScene.setMatrixFromArray(initialMesh.matrix, getAnchorMeshByFrameKey(selectedGroupKey).matrix.elements);
+            isFirstDragUpdate = true;
+        } else {
+            console.log('stopped drag on ' + e.target.attachedGroupName);
+            // getAnchorMeshByFrameKey(selectedGroupKey).position.set(0, 0, 0);
+            selectedGroupKey = null;
+            selectedMeshName = null;
+            constrainToX = false;
+            constrainToZ = false;
+            initialAnchorPosition = null;
+            initialLocalMatrix = null;
+            isFirstDragUpdate = false;
+            let initialMesh = getInitialCalculationMesh();
+            initialMesh.visible = false;
+        }
+    }
+
+    // // if we touched down on anything, calculate where to move mesh along its x-z plane so that it lines up with mouse position
+    // function onPointerMove(e) {
+    //     // e.stopPropagation();
+    //     if (!isPointerDown) { return; }
+    //     if (!selectedGroupKey) { return; }
+    //
+    //     let thisGroup = threejsGroups[selectedGroupKey];
+    //     let thisAnchorNode = knownAnchorNodes[selectedGroupKey];
+    //     if (!thisGroup || !thisAnchorNode) { return; }
+    //
+    //     let cursorMesh = getMouseCursorMesh();
+    //
+    //     let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
+    //
+    //     let areaTargetIntersect = null;
+    //     intersects.forEach(function(intersect) {
+    //         if (areaTargetIntersect) { return; }
+    //         if (intersect.object.name === 'mesh_0' || intersect.object.name === 'groundPlaneElement') {
+    //             areaTargetIntersect = intersect;
+    //         }
+    //     });
+    //
+    //     if (!areaTargetIntersect) { return; }
+    //
+    //     let result = realityEditor.gui.threejsScene.getPointAtDistanceFromCamera(e.clientX, e.clientY, areaTargetIntersect.distance);
+    //     let relativePosition = getInitialCalculationMesh().worldToLocal(result);
+    //     let initialPosition = getPositionXZ(getInitialCalculationMesh());
+    //     // adjust the initial position by relativePosition (but snap to axis if one is selected)
+    //     let newX = constrainToZ ? initialPosition.x : relativePosition.x + initialPosition.x;
+    //     let newZ = constrainToX ? initialPosition.z : relativePosition.z + initialPosition.z;
+    //     cursorMesh.position.set(newX, 0, newZ);
+    //     cursorMesh.visible = true;
+    //
+    //     if (REALTIME_DRAG_UPDATE) {
+    //         moveSelectedToolToMouseCursor(true);
+    //     }
+    // }
 
     exports.initService = initService;
     exports.getMatrix = getMatrix;

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -21,28 +21,12 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let knownAnchorNodes = {};
     let threejsGroups = {};
     let isPositioningMode = false;
-    let isPointerDown = false;
-
     let selectedGroupKey = null;
-    let selectedMeshName = null;
-    let constrainToX = false;
-    let constrainToZ = false;
-    let initialAnchorPosition = null;
     let initialLocalMatrix = null;
     let isFirstDragUpdate = false;
-
     let originColor = 0xffffff;
-    let draggableColor = 0x888888;
-    let xBoxColor = 0xff0000;
-    let zBoxColor = 0x0000ff;
-    let selectionColor = 0xffff00;
-    let mouseCursorColor = 0xffffff;
     let mouseCursorMesh = null;
     let initialCalculationMesh = null;
-
-    const REALTIME_DRAG_UPDATE = true;
-
-    let destinationMatrices = {};
 
     function initService() {
         // Note that, currently, positioningMode blocks touch events from reaching anything else, so it should be toggled off when not in use
@@ -92,21 +76,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
                 updateFrame(frameKey);
             }
         }
-
-        for (let frameKey in destinationMatrices) {
-            if (frameKey === selectedGroupKey) { continue; } // don't update tools currently being dragged
-            
-            const alpha = 0.5; // todo: change to 1 to remove animation
-            let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(frameKey);
-            let currentMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix);
-            let destinationMatrix = destinationMatrices[frameKey];
-            let animatedMatrix = [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1];
-            for (let i = 0; i < currentMatrix.length; i++) {
-                animatedMatrix[i] = (destinationMatrix[i] * alpha) + (currentMatrix[i] * (1 - alpha));
-            }
-            frameSceneNode.setLocalMatrix(animatedMatrix);
-        }
-
     }
 
     function updateFrame(frameKey) {
@@ -153,20 +122,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         threejsGroups[frameKey] = group;
     }
 
-    // the mouse cursor mesh sticks to groundplane but moves to follow the mouse when dragging a surface anchor. used for coordinate system calculations.
-    function getMouseCursorMesh() {
-        if (!mouseCursorMesh) {
-            const THREE = realityEditor.gui.threejsScene.THREE;
-            let size = 100;
-            mouseCursorMesh = new THREE.Mesh(new THREE.BoxGeometry(size, size, size),new THREE.MeshBasicMaterial({color: mouseCursorColor}));
-            mouseCursorMesh.name = 'mouseCursorMesh';
-            // mouseCursorMesh.matrixAutoUpdate = false; // this is needed to position it directly with matrices
-            mouseCursorMesh.visible = isPositioningMode;
-            realityEditor.gui.threejsScene.addToScene(mouseCursorMesh); // this adds it to the ground plane group by default
-        }
-        return mouseCursorMesh;
-    }
-
     // // the initial calculation mesh stays in the location a tool's surface anchor was at when you first started dragging it. used for coordinate system calculations.
     function getInitialCalculationMesh() {
         if (!initialCalculationMesh) {
@@ -174,9 +129,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             let size = 100;
             initialCalculationMesh = new THREE.Mesh(new THREE.BoxGeometry(size, size, size),new THREE.MeshBasicMaterial({color: 0xffffff, opacity: 0.3, transparent: true}));
             initialCalculationMesh.name = 'initialCalculationMesh';
-            // mouseCursorMesh.matrixAutoUpdate = false; // this is needed to position it directly with matrices
             initialCalculationMesh.visible = isPositioningMode;
-            // initialCalculationMesh.matrixAutoUpdate = false;
             realityEditor.gui.threejsScene.addToScene(initialCalculationMesh); // this adds it to the ground plane group by default
         }
         return initialCalculationMesh;
@@ -185,20 +138,11 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     // helper function to create the geometry for a surface anchor, including its X-Z axis handles
     function createAnchorGroup(frameKey) {
         const THREE = realityEditor.gui.threejsScene.THREE;
-        // const group = new THREE.Group();
 
-        let originSize = 100; // axisSize = 50;
+        let originSize = 100;
         const group = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: originColor}));
-
         group.name = getElementName(frameKey) + '_group';
-        // group.matrixAutoUpdate = false; // this is needed to position it directly with matrices
         group.visible = isPositioningMode;
-        // let originSize = 100; // axisSize = 50;
-        // const originBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: originColor}));
-        // originBox.name = getElementName(frameKey) + '_originBox';
-
-        // const draggableBox = new THREE.Mesh(new THREE.BoxGeometry(originSize, originSize, originSize), new THREE.MeshBasicMaterial({color: draggableColor}));
-        // draggableBox.name = getElementName(frameKey) + '_draggableBox';
 
         // let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(originBox, true, false, true, 0.2, (e) => {
         let transformControls = realityEditor.gui.threejsScene.addTransformControlsTo(group, true, false, true, 0.2, (e) => {
@@ -209,16 +153,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         transformControls.attachedGroupName = group.name;
         transformControls.attachedFrameKey = frameKey;
 
-        // const xBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: xBoxColor}));
-        // xBox.name = getElementName(frameKey) + '_xBox';
-        // const zBox = new THREE.Mesh(new THREE.BoxGeometry(axisSize, axisSize, axisSize),new THREE.MeshBasicMaterial({color: zBoxColor}));
-        // zBox.name = getElementName(frameKey) + '_zBox';
-        // xBox.position.x = 150;
-        // zBox.position.z = 150;
-        // group.add(originBox);
-        // group.add(draggableBox);
-        // originBox.add(xBox);
-        // originBox.add(zBox);
         return group;
     }
 
@@ -240,23 +174,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             updateGroupVisibility(threejsGroups[key], key);
         }
         if (mouseCursorMesh) { mouseCursorMesh.visible = false; }
-        // if (initialCalculationMesh) { initialCalculationMesh.visible = false; }
-
-        let threejsCanvas = document.getElementById('mainThreejsCanvas');
-        if (!threejsCanvas) {
-            return;
-        }
-        if (isPositioningMode && !globalStates.settingsButtonState) {
-            // threejsCanvas.addEventListener('pointerdown', onPointerDown, false);
-            // threejsCanvas.addEventListener('pointerup', onPointerUp, false);
-            // threejsCanvas.addEventListener('pointercancel', onPointerUp, false);
-            // threejsCanvas.addEventListener('pointermove', onPointerMove, false);
-        } else {
-            // threejsCanvas.removeEventListener('pointerdown', onPointerDown, false);
-            // threejsCanvas.removeEventListener('pointerup', onPointerUp, false);
-            // threejsCanvas.removeEventListener('pointercancel', onPointerUp, false);
-            // threejsCanvas.removeEventListener('pointermove', onPointerMove, false);
-        }
+        if (initialCalculationMesh) { initialCalculationMesh.visible = false; }
     }
 
     function updateGroupVisibility(group, key) {
@@ -279,47 +197,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         }
     }
 
-    // // hit test threeJsScene to see if we hit any of the anchor threeJsGroups
-    // // if we are, keep track of it so we can move it on pointermove. also give visual feedback
-    // function onPointerDown(e) {
-    //     isPointerDown = true;
-    //
-    //     let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-    //
-    //     intersects.forEach(function(intersect) {
-    //         if (selectedGroupKey) { return; }
-    //
-    //         let meshName = intersect.object.name;
-    //         let matchingKey = Object.keys(threejsGroups).find(function(key) {
-    //             return meshName.includes(key);
-    //         });
-    //         if (!matchingKey) { return; }
-    //
-    //         constrainToX = meshName.includes('_xBox');
-    //         constrainToZ = meshName.includes('_zBox');
-    //
-    //         selectedMeshName = meshName;
-    //         selectedGroupKey = matchingKey;
-    //
-    //         intersect.object.material.color.setHex(selectionColor);
-    //
-    //         initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
-    //         let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-    //         if (frameSceneNode) {
-    //             initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix)
-    //         }
-    //
-    //         let initialMesh = getInitialCalculationMesh();
-    //         initialMesh.visible = true;
-    //         realityEditor.gui.threejsScene.setMatrixFromArray(initialMesh.matrix, threejsGroups[selectedGroupKey].matrix.elements);
-    //
-    //         realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, true);
-    //
-    //         // stop propagation if we hit anything, otherwise pass the event on to the rest of the application
-    //         e.stopPropagation();
-    //     });
-    // }
-
     // helper function to get the x,z coords of a threejs object based on its matrix
     function getPositionXZ(threeJsObject) {
         if (!threeJsObject || typeof threeJsObject.matrix === 'undefined') { return null; }
@@ -329,83 +206,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         };
     }
 
-    // // sets the localMatrix of a tool's scene node such that its surface anchor will move to the mouseCursor mesh's position
-    // function moveSelectedToolToMouseCursor(animated) {
-    //     if (!initialAnchorPosition || !initialLocalMatrix || !selectedGroupKey) { return; }
-    //
-    //     // move tool to correct position
-    //     let oldAnchorLocalPosition = initialAnchorPosition;
-    //     let newAnchorLocalPosition = getPositionXZ(getMouseCursorMesh());
-    //
-    //     let dx = newAnchorLocalPosition.x - oldAnchorLocalPosition.x;
-    //     let dz = newAnchorLocalPosition.z - oldAnchorLocalPosition.z;
-    //
-    //     let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-    //     let localMatrix = realityEditor.gui.ar.utilities.copyMatrix(initialLocalMatrix);
-    //     localMatrix[12] += dx;
-    //     localMatrix[14] += dz;
-    //
-    //     if (animated) {
-    //         destinationMatrices[selectedGroupKey] = localMatrix;
-    //     } else {
-    //         frameSceneNode.setLocalMatrix(localMatrix);
-    //     }
-    // }
-
-    // // when we touch up, move the selected anchor's tool to match the movement of the mouse cursor mesh relative to its anchor
-    // function onPointerUp(_e) {
-    //     // e.stopPropagation(); // we can propagate touch up/cancel events in case gui is stuck in state before catcher shows
-    //     isPointerDown = false;
-    //
-    //     // reset mesh color
-    //     if (selectedGroupKey && threejsGroups[selectedGroupKey]) {
-    //         let group = threejsGroups[selectedGroupKey];
-    //         let mesh = group.getObjectByName(selectedMeshName);
-    //         if (mesh) {
-    //             if (constrainToX) {
-    //                 mesh.material.color.setHex(xBoxColor);
-    //             } else if (constrainToZ) {
-    //                 mesh.material.color.setHex(zBoxColor);
-    //             } else {
-    //                 mesh.material.color.setHex(originColor);
-    //             }
-    //         }
-    //
-    //         // move tool to correct position
-    //         moveSelectedToolToMouseCursor(false);
-    //         delete destinationMatrices[selectedGroupKey];
-    //
-    //         realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, false);
-    //
-    //         // post its position to the server so it persists
-    //         let sceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
-    //         if (sceneNode && sceneNode.linkedVehicle) {
-    //             realityEditor.network.postVehiclePosition(sceneNode.linkedVehicle);
-    //             console.log('post vehicle position');
-    //         }
-    //     }
-    //
-    //     // reset any editing state
-    //     selectedGroupKey = null;
-    //     selectedMeshName = null;
-    //     constrainToX = false;
-    //     constrainToZ = false;
-    //     initialAnchorPosition = null;
-    //     initialLocalMatrix = null;
-    //
-    //     getMouseCursorMesh().visible = false;
-    //     // getInitialCalculationMesh().visible = false;
-    // }
-    
-    // function getAnchorMeshByFrameKey(frameKey) {
-    //     return threejsGroups[frameKey].children[0];
-    // }
-    // function getDraggableMeshByFrameKey(frameKey) {
-    //     return threejsGroups[frameKey].children[1];
-    // }
-
     function onChange(e) {
-        console.log('onChange', e.target.attachedGroupName);
         if (e.target.attachedFrameKey === selectedGroupKey) {
 
             // move tool to correct position
@@ -428,16 +229,6 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
             localMatrix[12] += dx;
             localMatrix[14] += dz;
             frameSceneNode.setLocalMatrix(localMatrix);
-            
-            // let cursorMesh = getMouseCursorMesh();
-            // cursorMesh.position.set(newAnchorLocalPosition.x, 0, newAnchorLocalPosition.z);
-
-            // initialAnchorPosition = {
-            //     x: newAnchorLocalPosition.x,
-            //     z: newAnchorLocalPosition.z
-            // };
-            
-            // initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(localMatrix);
         }
     }
 
@@ -445,72 +236,33 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
         if (e.value) {
             console.log('started drag on ' + e.target.attachedGroupName);
             selectedGroupKey = e.target.attachedFrameKey;
-            initialAnchorPosition = getPositionXZ(threejsGroups[selectedGroupKey]); //getAnchorMeshByFrameKey(selectedGroupKey));
             let frameSceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
             if (frameSceneNode) {
                 initialLocalMatrix = realityEditor.gui.ar.utilities.copyMatrix(frameSceneNode.localMatrix)
             }
-
             let initialMesh = getInitialCalculationMesh();
             initialMesh.visible = true;
-            // let anchorPosition = getAnchorMeshByFrameKey(selectedGroupKey).position;
             let anchorGroupPosition = getPositionXZ(threejsGroups[selectedGroupKey]);
-            // initialMesh.position.set(anchorPosition.x + anchorGroupPosition.x, anchorPosition.y, anchorPosition.z + anchorGroupPosition.z);
             initialMesh.position.set(anchorGroupPosition.x, 0, anchorGroupPosition.z);
-            // realityEditor.gui.threejsScene.setMatrixFromArray(initialMesh.matrix, getAnchorMeshByFrameKey(selectedGroupKey).matrix.elements);
             isFirstDragUpdate = true;
         } else {
             console.log('stopped drag on ' + e.target.attachedGroupName);
-            // getAnchorMeshByFrameKey(selectedGroupKey).position.set(0, 0, 0);
+
+            realityEditor.device.sendEditingStateToFrameContents(selectedGroupKey, false);
+
+            // post its position to the server so it persists
+            let sceneNode = realityEditor.sceneGraph.getSceneNodeById(selectedGroupKey);
+            if (sceneNode && sceneNode.linkedVehicle) {
+                realityEditor.network.postVehiclePosition(sceneNode.linkedVehicle);
+                console.log('post vehicle position');
+            }
+
             selectedGroupKey = null;
-            selectedMeshName = null;
-            constrainToX = false;
-            constrainToZ = false;
-            initialAnchorPosition = null;
             initialLocalMatrix = null;
             isFirstDragUpdate = false;
-            let initialMesh = getInitialCalculationMesh();
-            initialMesh.visible = false;
+            getInitialCalculationMesh().visible = false;
         }
     }
-
-    // // if we touched down on anything, calculate where to move mesh along its x-z plane so that it lines up with mouse position
-    // function onPointerMove(e) {
-    //     // e.stopPropagation();
-    //     if (!isPointerDown) { return; }
-    //     if (!selectedGroupKey) { return; }
-    //
-    //     let thisGroup = threejsGroups[selectedGroupKey];
-    //     let thisAnchorNode = knownAnchorNodes[selectedGroupKey];
-    //     if (!thisGroup || !thisAnchorNode) { return; }
-    //
-    //     let cursorMesh = getMouseCursorMesh();
-    //
-    //     let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY);
-    //
-    //     let areaTargetIntersect = null;
-    //     intersects.forEach(function(intersect) {
-    //         if (areaTargetIntersect) { return; }
-    //         if (intersect.object.name === 'mesh_0' || intersect.object.name === 'groundPlaneElement') {
-    //             areaTargetIntersect = intersect;
-    //         }
-    //     });
-    //
-    //     if (!areaTargetIntersect) { return; }
-    //
-    //     let result = realityEditor.gui.threejsScene.getPointAtDistanceFromCamera(e.clientX, e.clientY, areaTargetIntersect.distance);
-    //     let relativePosition = getInitialCalculationMesh().worldToLocal(result);
-    //     let initialPosition = getPositionXZ(getInitialCalculationMesh());
-    //     // adjust the initial position by relativePosition (but snap to axis if one is selected)
-    //     let newX = constrainToZ ? initialPosition.x : relativePosition.x + initialPosition.x;
-    //     let newZ = constrainToX ? initialPosition.z : relativePosition.z + initialPosition.z;
-    //     cursorMesh.position.set(newX, 0, newZ);
-    //     cursorMesh.visible = true;
-    //
-    //     if (REALTIME_DRAG_UPDATE) {
-    //         moveSelectedToolToMouseCursor(true);
-    //     }
-    // }
 
     exports.initService = initService;
     exports.getMatrix = getMatrix;

--- a/src/gui/ar/groundPlaneRenderer.js
+++ b/src/gui/ar/groundPlaneRenderer.js
@@ -14,6 +14,8 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
 
 (function(exports) {
 
+    const sceneSize = 30; // meters
+
     let shouldVisualize = false;
     var isUpdateListenerRegistered = false;
 
@@ -95,10 +97,10 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
         document.getElementById('GUI').appendChild(origin);
         
         if (!gridHelper) {
-            const divisions = 10 * 2;
+            const divisions = sceneSize * 2;
             const size = (1000 / 2) * divisions;
             const THREE = realityEditor.gui.threejsScene.THREE;
-            const colorCenterLine = new THREE.Color(0, 0.3, 0.3);
+            const colorCenterLine = new THREE.Color(1, 1, 1);
             const colorGrid = new THREE.Color(0, 1, 1);
             gridHelper = new THREE.GridHelper( size, divisions, colorCenterLine, colorGrid );
             gridHelper.name = 'groundPlaneVisualizer';

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -5,6 +5,7 @@ import { FBXLoader } from '../../thirdPartyCode/three/FBXLoader.js';
 import { GLTFLoader } from '../../thirdPartyCode/three/GLTFLoader.module.js';
 import { BufferGeometryUtils } from '../../thirdPartyCode/three/BufferGeometryUtils.module.js';
 import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh.module.js';
+import { TransformControls } from '../../thirdPartyCode/three/TransformControls.js';
 
 (function(exports) {
 
@@ -39,6 +40,7 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
         renderer.domElement.id = 'mainThreejsCanvas'; // this applies some css to make it fullscreen
         document.body.appendChild( renderer.domElement );
         camera = new THREE.PerspectiveCamera( 70, aspectRatio, 1, 1000 );
+        camera.matrixAutoUpdate = false;
         scene = new THREE.Scene();
         scene.add(camera); // Normally not needed, but needed in order to add child objects relative to camera
 
@@ -48,16 +50,7 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
         threejsContainerObj.matrixAutoUpdate = false; // this is needed to position it directly with matrices
         scene.add(threejsContainerObj);
 
-        // light the scene with a combination of ambient and directional white light
-        var ambLight = new THREE.AmbientLight(0xffffff);
-        scene.add(ambLight);
-        var dirLight = new THREE.DirectionalLight(0xffffff, 2);
-        dirLight.position.set(-10, -10, 1000);
-        scene.add(dirLight);
-        var spotLight = new THREE.SpotLight(0xffffff);
-        spotLight.position.set(-30, -30, 150);
-        spotLight.castShadow = true;
-        scene.add(spotLight);
+        setupLighting();
 
         customMaterials = new CustomMaterials();
 
@@ -84,8 +77,43 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
         renderScene(); // update loop
     }
 
+    // light the scene with a combination of ambient and directional white light
+    function setupLighting() {
+        // This doesn't seem to work with the area target model material, but adding it for everything else
+        let ambLight = new THREE.AmbientLight(0xffffff);
+        scene.add(ambLight);
+
+        // attempts to light the scene evenly with directional lights from each side, but mostly from the top
+        let dirLightTopDown = new THREE.DirectionalLight(0xffffff, 2);
+        dirLightTopDown.position.set(0, 1, 0); // top-down
+        scene.add(dirLightTopDown);
+
+        let dirLightXLeft = new THREE.DirectionalLight(0xffffff, 0.5);
+        dirLightXLeft.position.set(1, 0, 0);
+        scene.add(dirLightXLeft);
+
+        let dirLightXRight = new THREE.DirectionalLight(0xffffff, 0.5);
+        dirLightXRight.position.set(-1, 0, 0);
+        scene.add(dirLightXRight);
+
+        let dirLightZLeft = new THREE.DirectionalLight(0xffffff, 0.5);
+        dirLightZLeft.position.set(0, 0, 1);
+        scene.add(dirLightZLeft);
+
+        let dirLightZRight = new THREE.DirectionalLight(0xffffff, 0.5);
+        dirLightZRight.position.set(0, 0, -1);
+        scene.add(dirLightZRight);
+    }
+
+    // use this helper function to update the camera matrix using the camera matrix from the sceneGraph
+    function setCameraPosition(matrix) {
+        setMatrixFromArray(camera.matrix, matrix);
+    }
+
+    // adds an invisible plane to the ground that you can raycast against to fill in holes in the area target
+    // this is different from the ground plane visualizer element
     function addGroundPlaneCollisionObject() {
-        const sceneSizeInMeters = 10;
+        const sceneSizeInMeters = 30;
         const geometry = new THREE.PlaneGeometry( 1000 * sceneSizeInMeters, 1000 * sceneSizeInMeters);
         const material = new THREE.MeshBasicMaterial( {color: 0x00ffff, side: THREE.DoubleSide} );
         const plane = new THREE.Mesh( geometry, material );
@@ -133,24 +161,18 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
                     originBox.add(xBox);
                     originBox.add(yBox);
                     originBox.add(zBox);
-
-                    // const plane =
-
-                    // const geometry = new THREE.PlaneGeometry( 1000, 1000 );
-                    // const material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
-                    // const groundplaneMesh = new THREE.Mesh( geometry, material );
-                    // group.add(groundplaneMesh);
-                    // // realityEditor.gui.threejsScene.addToScene(groundplaneMesh, {attach: true});
                 }
             }
+
+            // each of the world object containers has its origin set to the origin matrix of that world object
             const group = worldObjectGroups[worldObjectId];
-            const modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrix(worldObjectId);
-            if (modelViewMatrix) {
-                setMatrixFromArray(group.matrix, modelViewMatrix);
+            const worldMatrix = realityEditor.sceneGraph.getSceneNodeById(worldObjectId).worldMatrix;
+            if (worldMatrix) {
+                setMatrixFromArray(group.matrix, worldMatrix);
                 group.visible = true;
 
                 if (worldOcclusionObjects[worldObjectId]) {
-                    setMatrixFromArray(worldOcclusionObjects[worldObjectId].matrix, modelViewMatrix);
+                    setMatrixFromArray(worldOcclusionObjects[worldObjectId].matrix, worldMatrix);
                     worldOcclusionObjects[worldObjectId].visible = true;
                 }
             } else {
@@ -162,9 +184,10 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
             }
         });
 
-        const rootModelViewMatrix = realityEditor.sceneGraph.getGroundPlaneModelViewMatrix();
-        if (rootModelViewMatrix) {
-            setMatrixFromArray(threejsContainerObj.matrix, rootModelViewMatrix);
+        // the main three.js container object has its origin set to the ground plane origin
+        const rootMatrix = realityEditor.sceneGraph.getGroundPlaneNode().worldMatrix;
+        if (rootMatrix) {
+            setMatrixFromArray(threejsContainerObj.matrix, rootMatrix);
         }
 
         customMaterials.update();
@@ -502,7 +525,27 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
         }
     }
 
+    function addTransformControlsTo(object, showX, showY, showZ, size, onChange, onDraggingChanged) {
+        let transformControls = new TransformControls(camera, renderer.domElement);
+        transformControls.showX = showX;
+        transformControls.showY = showY;
+        transformControls.showZ = showZ;
+        transformControls.attach(object);
+        transformControls.size = size;
+        scene.add(transformControls);
+        console.log('added transform controls', transformControls);
+
+        if (onChange) {
+            transformControls.addEventListener('change', onChange);
+        }
+        if (onDraggingChanged) {
+            transformControls.addEventListener('dragging-changed', onDraggingChanged)
+        }
+        return transformControls;
+    }
+
     exports.initService = initService;
+    exports.setCameraPosition = setCameraPosition;
     exports.addOcclusionGltf = addOcclusionGltf;
     exports.isOcclusionActive = isOcclusionActive;
     exports.addGltfToScene = addGltfToScene;
@@ -516,6 +559,7 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
     exports.getGroundPlane = getGroundPlane;
     exports.setMatrixFromArray = setMatrixFromArray;
     exports.getObjectForWorldRaycasts = getObjectForWorldRaycasts;
+    exports.addTransformControlsTo = addTransformControlsTo;
     exports.THREE = THREE;
     exports.FBXLoader = FBXLoader;
     exports.GLTFLoader = GLTFLoader;

--- a/src/sceneGraph/index.js
+++ b/src/sceneGraph/index.js
@@ -147,6 +147,9 @@ createNameSpace("realityEditor.sceneGraph");
     function setCameraPosition(cameraMatrix) {
         if (!cameraNode) { return; }
         cameraNode.setLocalMatrix(cameraMatrix);
+        if (realityEditor.gui.threejsScene.setCameraPosition) {
+            realityEditor.gui.threejsScene.setCameraPosition(cameraMatrix);
+        }
     }
 
     function setGroundPlanePosition(groundPlaneMatrix) {

--- a/thirdPartyCode/three/TransformControls.js
+++ b/thirdPartyCode/three/TransformControls.js
@@ -1,0 +1,1564 @@
+import {
+	BoxGeometry,
+	BufferGeometry,
+	CylinderGeometry,
+	DoubleSide,
+	Euler,
+	Float32BufferAttribute,
+	Line,
+	LineBasicMaterial,
+	Matrix4,
+	Mesh,
+	MeshBasicMaterial,
+	Object3D,
+	OctahedronGeometry,
+	PlaneGeometry,
+	Quaternion,
+	Raycaster,
+	SphereGeometry,
+	TorusGeometry,
+	Vector3
+} from './three.module.js';
+
+const _raycaster = new Raycaster();
+
+const _tempVector = new Vector3();
+const _tempVector2 = new Vector3();
+const _tempQuaternion = new Quaternion();
+const _unit = {
+	X: new Vector3( 1, 0, 0 ),
+	Y: new Vector3( 0, 1, 0 ),
+	Z: new Vector3( 0, 0, 1 )
+};
+
+const _changeEvent = { type: 'change' };
+const _mouseDownEvent = { type: 'mouseDown' };
+const _mouseUpEvent = { type: 'mouseUp', mode: null };
+const _objectChangeEvent = { type: 'objectChange' };
+
+class TransformControls extends Object3D {
+
+	constructor( camera, domElement ) {
+
+		super();
+
+		if ( domElement === undefined ) {
+
+			console.warn( 'THREE.TransformControls: The second parameter "domElement" is now mandatory.' );
+			domElement = document;
+
+		}
+
+		this.isTransformControls = true;
+
+		this.visible = false;
+		this.domElement = domElement;
+		this.domElement.style.touchAction = 'none'; // disable touch scroll
+
+		const _gizmo = new TransformControlsGizmo();
+		this._gizmo = _gizmo;
+		this.add( _gizmo );
+
+		const _plane = new TransformControlsPlane();
+		this._plane = _plane;
+		this.add( _plane );
+
+		const scope = this;
+
+		// Defined getter, setter and store for a property
+		function defineProperty( propName, defaultValue ) {
+
+			let propValue = defaultValue;
+
+			Object.defineProperty( scope, propName, {
+
+				get: function () {
+
+					return propValue !== undefined ? propValue : defaultValue;
+
+				},
+
+				set: function ( value ) {
+
+					if ( propValue !== value ) {
+
+						propValue = value;
+						_plane[ propName ] = value;
+						_gizmo[ propName ] = value;
+
+						scope.dispatchEvent( { type: propName + '-changed', value: value } );
+						scope.dispatchEvent( _changeEvent );
+
+					}
+
+				}
+
+			} );
+
+			scope[ propName ] = defaultValue;
+			_plane[ propName ] = defaultValue;
+			_gizmo[ propName ] = defaultValue;
+
+		}
+
+		// Define properties with getters/setter
+		// Setting the defined property will automatically trigger change event
+		// Defined properties are passed down to gizmo and plane
+
+		defineProperty( 'camera', camera );
+		defineProperty( 'object', undefined );
+		defineProperty( 'enabled', true );
+		defineProperty( 'axis', null );
+		defineProperty( 'mode', 'translate' );
+		defineProperty( 'translationSnap', null );
+		defineProperty( 'rotationSnap', null );
+		defineProperty( 'scaleSnap', null );
+		defineProperty( 'space', 'world' );
+		defineProperty( 'size', 1 );
+		defineProperty( 'dragging', false );
+		defineProperty( 'showX', true );
+		defineProperty( 'showY', true );
+		defineProperty( 'showZ', true );
+
+		// Reusable utility variables
+
+		const worldPosition = new Vector3();
+		const worldPositionStart = new Vector3();
+		const worldQuaternion = new Quaternion();
+		const worldQuaternionStart = new Quaternion();
+		const cameraPosition = new Vector3();
+		const cameraQuaternion = new Quaternion();
+		const pointStart = new Vector3();
+		const pointEnd = new Vector3();
+		const rotationAxis = new Vector3();
+		const rotationAngle = 0;
+		const eye = new Vector3();
+
+		// TODO: remove properties unused in plane and gizmo
+
+		defineProperty( 'worldPosition', worldPosition );
+		defineProperty( 'worldPositionStart', worldPositionStart );
+		defineProperty( 'worldQuaternion', worldQuaternion );
+		defineProperty( 'worldQuaternionStart', worldQuaternionStart );
+		defineProperty( 'cameraPosition', cameraPosition );
+		defineProperty( 'cameraQuaternion', cameraQuaternion );
+		defineProperty( 'pointStart', pointStart );
+		defineProperty( 'pointEnd', pointEnd );
+		defineProperty( 'rotationAxis', rotationAxis );
+		defineProperty( 'rotationAngle', rotationAngle );
+		defineProperty( 'eye', eye );
+
+		this._offset = new Vector3();
+		this._startNorm = new Vector3();
+		this._endNorm = new Vector3();
+		this._cameraScale = new Vector3();
+
+		this._parentPosition = new Vector3();
+		this._parentQuaternion = new Quaternion();
+		this._parentQuaternionInv = new Quaternion();
+		this._parentScale = new Vector3();
+
+		this._worldScaleStart = new Vector3();
+		this._worldQuaternionInv = new Quaternion();
+		this._worldScale = new Vector3();
+
+		this._positionStart = new Vector3();
+		this._quaternionStart = new Quaternion();
+		this._scaleStart = new Vector3();
+
+		this._getPointer = getPointer.bind( this );
+		this._onPointerDown = onPointerDown.bind( this );
+		this._onPointerHover = onPointerHover.bind( this );
+		this._onPointerMove = onPointerMove.bind( this );
+		this._onPointerUp = onPointerUp.bind( this );
+
+		this.domElement.addEventListener( 'pointerdown', this._onPointerDown );
+		this.domElement.addEventListener( 'pointermove', this._onPointerHover );
+		this.domElement.addEventListener( 'pointerup', this._onPointerUp );
+
+	}
+
+	// updateMatrixWorld  updates key transformation variables
+	updateMatrixWorld() {
+
+		if ( this.object !== undefined ) {
+
+			this.object.updateMatrixWorld();
+
+			if ( this.object.parent === null ) {
+
+				console.error( 'TransformControls: The attached 3D object must be a part of the scene graph.' );
+
+			} else {
+
+				this.object.parent.matrixWorld.decompose( this._parentPosition, this._parentQuaternion, this._parentScale );
+
+			}
+
+			this.object.matrixWorld.decompose( this.worldPosition, this.worldQuaternion, this._worldScale );
+
+			this._parentQuaternionInv.copy( this._parentQuaternion ).invert();
+			this._worldQuaternionInv.copy( this.worldQuaternion ).invert();
+
+		}
+
+		this.camera.updateMatrixWorld();
+		this.camera.matrixWorld.decompose( this.cameraPosition, this.cameraQuaternion, this._cameraScale );
+
+		if ( this.camera.isOrthographicCamera ) {
+
+			this.camera.getWorldDirection( this.eye );
+
+		} else {
+
+			this.eye.copy( this.cameraPosition ).sub( this.worldPosition ).normalize();
+
+		}
+
+		super.updateMatrixWorld( this );
+
+	}
+
+	pointerHover( pointer ) {
+
+		if ( this.object === undefined || this.dragging === true ) return;
+
+		_raycaster.setFromCamera( pointer, this.camera );
+
+		const intersect = intersectObjectWithRay( this._gizmo.picker[ this.mode ], _raycaster );
+
+		if ( intersect ) {
+
+			this.axis = intersect.object.name;
+
+		} else {
+
+			this.axis = null;
+
+		}
+
+	}
+
+	pointerDown( pointer ) {
+
+		if ( this.object === undefined || this.dragging === true || pointer.button !== 0 ) return;
+
+		if ( this.axis !== null ) {
+
+			_raycaster.setFromCamera( pointer, this.camera );
+
+			const planeIntersect = intersectObjectWithRay( this._plane, _raycaster, true );
+
+			if ( planeIntersect ) {
+
+				this.object.updateMatrixWorld();
+				this.object.parent.updateMatrixWorld();
+
+				this._positionStart.copy( this.object.position );
+				this._quaternionStart.copy( this.object.quaternion );
+				this._scaleStart.copy( this.object.scale );
+
+				this.object.matrixWorld.decompose( this.worldPositionStart, this.worldQuaternionStart, this._worldScaleStart );
+
+				this.pointStart.copy( planeIntersect.point ).sub( this.worldPositionStart );
+
+			}
+
+			this.dragging = true;
+			_mouseDownEvent.mode = this.mode;
+			this.dispatchEvent( _mouseDownEvent );
+
+		}
+
+	}
+
+	pointerMove( pointer ) {
+
+		const axis = this.axis;
+		const mode = this.mode;
+		const object = this.object;
+		let space = this.space;
+
+		if ( mode === 'scale' ) {
+
+			space = 'local';
+
+		} else if ( axis === 'E' || axis === 'XYZE' || axis === 'XYZ' ) {
+
+			space = 'world';
+
+		}
+
+		if ( object === undefined || axis === null || this.dragging === false || pointer.button !== - 1 ) return;
+
+		_raycaster.setFromCamera( pointer, this.camera );
+
+		const planeIntersect = intersectObjectWithRay( this._plane, _raycaster, true );
+
+		if ( ! planeIntersect ) return;
+
+		this.pointEnd.copy( planeIntersect.point ).sub( this.worldPositionStart );
+
+		if ( mode === 'translate' ) {
+
+			// Apply translate
+
+			this._offset.copy( this.pointEnd ).sub( this.pointStart );
+
+			if ( space === 'local' && axis !== 'XYZ' ) {
+
+				this._offset.applyQuaternion( this._worldQuaternionInv );
+
+			}
+
+			if ( axis.indexOf( 'X' ) === - 1 ) this._offset.x = 0;
+			if ( axis.indexOf( 'Y' ) === - 1 ) this._offset.y = 0;
+			if ( axis.indexOf( 'Z' ) === - 1 ) this._offset.z = 0;
+
+			if ( space === 'local' && axis !== 'XYZ' ) {
+
+				this._offset.applyQuaternion( this._quaternionStart ).divide( this._parentScale );
+
+			} else {
+
+				this._offset.applyQuaternion( this._parentQuaternionInv ).divide( this._parentScale );
+
+			}
+
+			object.position.copy( this._offset ).add( this._positionStart );
+
+			// Apply translation snap
+
+			if ( this.translationSnap ) {
+
+				if ( space === 'local' ) {
+
+					object.position.applyQuaternion( _tempQuaternion.copy( this._quaternionStart ).invert() );
+
+					if ( axis.search( 'X' ) !== - 1 ) {
+
+						object.position.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					if ( axis.search( 'Y' ) !== - 1 ) {
+
+						object.position.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					if ( axis.search( 'Z' ) !== - 1 ) {
+
+						object.position.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					object.position.applyQuaternion( this._quaternionStart );
+
+				}
+
+				if ( space === 'world' ) {
+
+					if ( object.parent ) {
+
+						object.position.add( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
+
+					}
+
+					if ( axis.search( 'X' ) !== - 1 ) {
+
+						object.position.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					if ( axis.search( 'Y' ) !== - 1 ) {
+
+						object.position.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					if ( axis.search( 'Z' ) !== - 1 ) {
+
+						object.position.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
+
+					}
+
+					if ( object.parent ) {
+
+						object.position.sub( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
+
+					}
+
+				}
+
+			}
+
+		} else if ( mode === 'scale' ) {
+
+			if ( axis.search( 'XYZ' ) !== - 1 ) {
+
+				let d = this.pointEnd.length() / this.pointStart.length();
+
+				if ( this.pointEnd.dot( this.pointStart ) < 0 ) d *= - 1;
+
+				_tempVector2.set( d, d, d );
+
+			} else {
+
+				_tempVector.copy( this.pointStart );
+				_tempVector2.copy( this.pointEnd );
+
+				_tempVector.applyQuaternion( this._worldQuaternionInv );
+				_tempVector2.applyQuaternion( this._worldQuaternionInv );
+
+				_tempVector2.divide( _tempVector );
+
+				if ( axis.search( 'X' ) === - 1 ) {
+
+					_tempVector2.x = 1;
+
+				}
+
+				if ( axis.search( 'Y' ) === - 1 ) {
+
+					_tempVector2.y = 1;
+
+				}
+
+				if ( axis.search( 'Z' ) === - 1 ) {
+
+					_tempVector2.z = 1;
+
+				}
+
+			}
+
+			// Apply scale
+
+			object.scale.copy( this._scaleStart ).multiply( _tempVector2 );
+
+			if ( this.scaleSnap ) {
+
+				if ( axis.search( 'X' ) !== - 1 ) {
+
+					object.scale.x = Math.round( object.scale.x / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+
+				}
+
+				if ( axis.search( 'Y' ) !== - 1 ) {
+
+					object.scale.y = Math.round( object.scale.y / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+
+				}
+
+				if ( axis.search( 'Z' ) !== - 1 ) {
+
+					object.scale.z = Math.round( object.scale.z / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+
+				}
+
+			}
+
+		} else if ( mode === 'rotate' ) {
+
+			this._offset.copy( this.pointEnd ).sub( this.pointStart );
+
+			const ROTATION_SPEED = 20 / this.worldPosition.distanceTo( _tempVector.setFromMatrixPosition( this.camera.matrixWorld ) );
+
+			if ( axis === 'E' ) {
+
+				this.rotationAxis.copy( this.eye );
+				this.rotationAngle = this.pointEnd.angleTo( this.pointStart );
+
+				this._startNorm.copy( this.pointStart ).normalize();
+				this._endNorm.copy( this.pointEnd ).normalize();
+
+				this.rotationAngle *= ( this._endNorm.cross( this._startNorm ).dot( this.eye ) < 0 ? 1 : - 1 );
+
+			} else if ( axis === 'XYZE' ) {
+
+				this.rotationAxis.copy( this._offset ).cross( this.eye ).normalize();
+				this.rotationAngle = this._offset.dot( _tempVector.copy( this.rotationAxis ).cross( this.eye ) ) * ROTATION_SPEED;
+
+			} else if ( axis === 'X' || axis === 'Y' || axis === 'Z' ) {
+
+				this.rotationAxis.copy( _unit[ axis ] );
+
+				_tempVector.copy( _unit[ axis ] );
+
+				if ( space === 'local' ) {
+
+					_tempVector.applyQuaternion( this.worldQuaternion );
+
+				}
+
+				this.rotationAngle = this._offset.dot( _tempVector.cross( this.eye ).normalize() ) * ROTATION_SPEED;
+
+			}
+
+			// Apply rotation snap
+
+			if ( this.rotationSnap ) this.rotationAngle = Math.round( this.rotationAngle / this.rotationSnap ) * this.rotationSnap;
+
+			// Apply rotate
+			if ( space === 'local' && axis !== 'E' && axis !== 'XYZE' ) {
+
+				object.quaternion.copy( this._quaternionStart );
+				object.quaternion.multiply( _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle ) ).normalize();
+
+			} else {
+
+				this.rotationAxis.applyQuaternion( this._parentQuaternionInv );
+				object.quaternion.copy( _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle ) );
+				object.quaternion.multiply( this._quaternionStart ).normalize();
+
+			}
+
+		}
+
+		this.dispatchEvent( _changeEvent );
+		this.dispatchEvent( _objectChangeEvent );
+
+	}
+
+	pointerUp( pointer ) {
+
+		if ( pointer.button !== 0 ) return;
+
+		if ( this.dragging && ( this.axis !== null ) ) {
+
+			_mouseUpEvent.mode = this.mode;
+			this.dispatchEvent( _mouseUpEvent );
+
+		}
+
+		this.dragging = false;
+		this.axis = null;
+
+	}
+
+	dispose() {
+
+		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
+		this.domElement.removeEventListener( 'pointermove', this._onPointerHover );
+		this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+		this.domElement.removeEventListener( 'pointerup', this._onPointerUp );
+
+		this.traverse( function ( child ) {
+
+			if ( child.geometry ) child.geometry.dispose();
+			if ( child.material ) child.material.dispose();
+
+		} );
+
+	}
+
+	// Set current object
+	attach( object ) {
+
+		this.object = object;
+		this.visible = true;
+
+		return this;
+
+	}
+
+	// Detatch from object
+	detach() {
+
+		this.object = undefined;
+		this.visible = false;
+		this.axis = null;
+
+		return this;
+
+	}
+
+	reset() {
+
+		if ( ! this.enabled ) return;
+
+		if ( this.dragging ) {
+
+			this.object.position.copy( this._positionStart );
+			this.object.quaternion.copy( this._quaternionStart );
+			this.object.scale.copy( this._scaleStart );
+
+			this.dispatchEvent( _changeEvent );
+			this.dispatchEvent( _objectChangeEvent );
+
+			this.pointStart.copy( this.pointEnd );
+
+		}
+
+	}
+
+	getRaycaster() {
+
+		return _raycaster;
+
+	}
+
+	// TODO: deprecate
+
+	getMode() {
+
+		return this.mode;
+
+	}
+
+	setMode( mode ) {
+
+		this.mode = mode;
+
+	}
+
+	setTranslationSnap( translationSnap ) {
+
+		this.translationSnap = translationSnap;
+
+	}
+
+	setRotationSnap( rotationSnap ) {
+
+		this.rotationSnap = rotationSnap;
+
+	}
+
+	setScaleSnap( scaleSnap ) {
+
+		this.scaleSnap = scaleSnap;
+
+	}
+
+	setSize( size ) {
+
+		this.size = size;
+
+	}
+
+	setSpace( space ) {
+
+		this.space = space;
+
+	}
+
+	update() {
+
+		console.warn( 'THREE.TransformControls: update function has no more functionality and therefore has been deprecated.' );
+
+	}
+
+}
+
+// mouse / touch event handlers
+
+function getPointer( event ) {
+
+	if ( this.domElement.ownerDocument.pointerLockElement ) {
+
+		return {
+			x: 0,
+			y: 0,
+			button: event.button
+		};
+
+	} else {
+
+		const rect = this.domElement.getBoundingClientRect();
+
+		return {
+			x: ( event.clientX - rect.left ) / rect.width * 2 - 1,
+			y: - ( event.clientY - rect.top ) / rect.height * 2 + 1,
+			button: event.button
+		};
+
+	}
+
+}
+
+function onPointerHover( event ) {
+
+	if ( ! this.enabled ) return;
+
+	switch ( event.pointerType ) {
+
+		case 'mouse':
+		case 'pen':
+			this.pointerHover( this._getPointer( event ) );
+			break;
+
+	}
+
+}
+
+function onPointerDown( event ) {
+
+	if ( ! this.enabled ) return;
+
+	if ( ! document.pointerLockElement ) {
+
+		this.domElement.setPointerCapture( event.pointerId );
+
+	}
+
+	this.domElement.addEventListener( 'pointermove', this._onPointerMove );
+
+	this.pointerHover( this._getPointer( event ) );
+	this.pointerDown( this._getPointer( event ) );
+
+}
+
+function onPointerMove( event ) {
+
+	if ( ! this.enabled ) return;
+
+	this.pointerMove( this._getPointer( event ) );
+
+}
+
+function onPointerUp( event ) {
+
+	if ( ! this.enabled ) return;
+
+	this.domElement.releasePointerCapture( event.pointerId );
+
+	this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+
+	this.pointerUp( this._getPointer( event ) );
+
+}
+
+function intersectObjectWithRay( object, raycaster, includeInvisible ) {
+
+	const allIntersections = raycaster.intersectObject( object, true );
+
+	for ( let i = 0; i < allIntersections.length; i ++ ) {
+
+		if ( allIntersections[ i ].object.visible || includeInvisible ) {
+
+			return allIntersections[ i ];
+
+		}
+
+	}
+
+	return false;
+
+}
+
+//
+
+// Reusable utility variables
+
+const _tempEuler = new Euler();
+const _alignVector = new Vector3( 0, 1, 0 );
+const _zeroVector = new Vector3( 0, 0, 0 );
+const _lookAtMatrix = new Matrix4();
+const _tempQuaternion2 = new Quaternion();
+const _identityQuaternion = new Quaternion();
+const _dirVector = new Vector3();
+const _tempMatrix = new Matrix4();
+
+const _unitX = new Vector3( 1, 0, 0 );
+const _unitY = new Vector3( 0, 1, 0 );
+const _unitZ = new Vector3( 0, 0, 1 );
+
+const _v1 = new Vector3();
+const _v2 = new Vector3();
+const _v3 = new Vector3();
+
+class TransformControlsGizmo extends Object3D {
+
+	constructor() {
+
+		super();
+
+		this.isTransformControlsGizmo = true;
+
+		this.type = 'TransformControlsGizmo';
+
+		// shared materials
+
+		const gizmoMaterial = new MeshBasicMaterial( {
+			depthTest: false,
+			depthWrite: false,
+			fog: false,
+			toneMapped: false,
+			transparent: true
+		} );
+
+		const gizmoLineMaterial = new LineBasicMaterial( {
+			depthTest: false,
+			depthWrite: false,
+			fog: false,
+			toneMapped: false,
+			transparent: true
+		} );
+
+		// Make unique material for each axis/color
+
+		const matInvisible = gizmoMaterial.clone();
+		matInvisible.opacity = 0.15;
+
+		const matHelper = gizmoLineMaterial.clone();
+		matHelper.opacity = 0.5;
+
+		const matRed = gizmoMaterial.clone();
+		matRed.color.setHex( 0xff0000 );
+
+		const matGreen = gizmoMaterial.clone();
+		matGreen.color.setHex( 0x00ff00 );
+
+		const matBlue = gizmoMaterial.clone();
+		matBlue.color.setHex( 0x0000ff );
+
+		const matRedTransparent = gizmoMaterial.clone();
+		matRedTransparent.color.setHex( 0xff0000 );
+		matRedTransparent.opacity = 0.5;
+
+		const matGreenTransparent = gizmoMaterial.clone();
+		matGreenTransparent.color.setHex( 0x00ff00 );
+		matGreenTransparent.opacity = 0.5;
+
+		const matBlueTransparent = gizmoMaterial.clone();
+		matBlueTransparent.color.setHex( 0x0000ff );
+		matBlueTransparent.opacity = 0.5;
+
+		const matWhiteTransparent = gizmoMaterial.clone();
+		matWhiteTransparent.opacity = 0.25;
+
+		const matYellowTransparent = gizmoMaterial.clone();
+		matYellowTransparent.color.setHex( 0xffff00 );
+		matYellowTransparent.opacity = 0.25;
+
+		const matYellow = gizmoMaterial.clone();
+		matYellow.color.setHex( 0xffff00 );
+
+		const matGray = gizmoMaterial.clone();
+		matGray.color.setHex( 0x787878 );
+
+		// reusable geometry
+
+		const arrowGeometry = new CylinderGeometry( 0, 0.04, 0.1, 12 );
+		arrowGeometry.translate( 0, 0.05, 0 );
+
+		const scaleHandleGeometry = new BoxGeometry( 0.08, 0.08, 0.08 );
+		scaleHandleGeometry.translate( 0, 0.04, 0 );
+
+		const lineGeometry = new BufferGeometry();
+		lineGeometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0,	1, 0, 0 ], 3 ) );
+
+		const lineGeometry2 = new CylinderGeometry( 0.0075, 0.0075, 0.5, 3 );
+		lineGeometry2.translate( 0, 0.25, 0 );
+
+		function CircleGeometry( radius, arc ) {
+
+			const geometry = new TorusGeometry( radius, 0.0075, 3, 64, arc * Math.PI * 2 );
+			geometry.rotateY( Math.PI / 2 );
+			geometry.rotateX( Math.PI / 2 );
+			return geometry;
+
+		}
+
+		// Special geometry for transform helper. If scaled with position vector it spans from [0,0,0] to position
+
+		function TranslateHelperGeometry() {
+
+			const geometry = new BufferGeometry();
+
+			geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 1, 1, 1 ], 3 ) );
+
+			return geometry;
+
+		}
+
+		// Gizmo definitions - custom hierarchy definitions for setupGizmo() function
+
+		const gizmoTranslate = {
+			X: [
+				[ new Mesh( arrowGeometry, matRed ), [ 0.5, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+				[ new Mesh( arrowGeometry, matRed ), [ - 0.5, 0, 0 ], [ 0, 0, Math.PI / 2 ]],
+				[ new Mesh( lineGeometry2, matRed ), [ 0, 0, 0 ], [ 0, 0, - Math.PI / 2 ]]
+			],
+			Y: [
+				[ new Mesh( arrowGeometry, matGreen ), [ 0, 0.5, 0 ]],
+				[ new Mesh( arrowGeometry, matGreen ), [ 0, - 0.5, 0 ], [ Math.PI, 0, 0 ]],
+				[ new Mesh( lineGeometry2, matGreen ) ]
+			],
+			Z: [
+				[ new Mesh( arrowGeometry, matBlue ), [ 0, 0, 0.5 ], [ Math.PI / 2, 0, 0 ]],
+				[ new Mesh( arrowGeometry, matBlue ), [ 0, 0, - 0.5 ], [ - Math.PI / 2, 0, 0 ]],
+				[ new Mesh( lineGeometry2, matBlue ), null, [ Math.PI / 2, 0, 0 ]]
+			],
+			XYZ: [
+				[ new Mesh( new OctahedronGeometry( 0.1, 0 ), matWhiteTransparent.clone() ), [ 0, 0, 0 ]]
+			],
+			XY: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matBlueTransparent.clone() ), [ 0.15, 0.15, 0 ]]
+			],
+			YZ: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matRedTransparent.clone() ), [ 0, 0.15, 0.15 ], [ 0, Math.PI / 2, 0 ]]
+			],
+			XZ: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matGreenTransparent.clone() ), [ 0.15, 0, 0.15 ], [ - Math.PI / 2, 0, 0 ]]
+			]
+		};
+
+		const pickerTranslate = {
+			X: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0.3, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ - 0.3, 0, 0 ], [ 0, 0, Math.PI / 2 ]]
+			],
+			Y: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0.3, 0 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, - 0.3, 0 ], [ 0, 0, Math.PI ]]
+			],
+			Z: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0, 0.3 ], [ Math.PI / 2, 0, 0 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0, - 0.3 ], [ - Math.PI / 2, 0, 0 ]]
+			],
+			XYZ: [
+				[ new Mesh( new OctahedronGeometry( 0.2, 0 ), matInvisible ) ]
+			],
+			XY: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0.15, 0.15, 0 ]]
+			],
+			YZ: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0, 0.15, 0.15 ], [ 0, Math.PI / 2, 0 ]]
+			],
+			XZ: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0.15, 0, 0.15 ], [ - Math.PI / 2, 0, 0 ]]
+			]
+		};
+
+		const helperTranslate = {
+			START: [
+				[ new Mesh( new OctahedronGeometry( 0.01, 2 ), matHelper ), null, null, null, 'helper' ]
+			],
+			END: [
+				[ new Mesh( new OctahedronGeometry( 0.01, 2 ), matHelper ), null, null, null, 'helper' ]
+			],
+			DELTA: [
+				[ new Line( TranslateHelperGeometry(), matHelper ), null, null, null, 'helper' ]
+			],
+			X: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ - 1e3, 0, 0 ], null, [ 1e6, 1, 1 ], 'helper' ]
+			],
+			Y: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ 0, - 1e3, 0 ], [ 0, 0, Math.PI / 2 ], [ 1e6, 1, 1 ], 'helper' ]
+			],
+			Z: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ 0, 0, - 1e3 ], [ 0, - Math.PI / 2, 0 ], [ 1e6, 1, 1 ], 'helper' ]
+			]
+		};
+
+		const gizmoRotate = {
+			XYZE: [
+				[ new Mesh( CircleGeometry( 0.5, 1 ), matGray ), null, [ 0, Math.PI / 2, 0 ]]
+			],
+			X: [
+				[ new Mesh( CircleGeometry( 0.5, 0.5 ), matRed ) ]
+			],
+			Y: [
+				[ new Mesh( CircleGeometry( 0.5, 0.5 ), matGreen ), null, [ 0, 0, - Math.PI / 2 ]]
+			],
+			Z: [
+				[ new Mesh( CircleGeometry( 0.5, 0.5 ), matBlue ), null, [ 0, Math.PI / 2, 0 ]]
+			],
+			E: [
+				[ new Mesh( CircleGeometry( 0.75, 1 ), matYellowTransparent ), null, [ 0, Math.PI / 2, 0 ]]
+			]
+		};
+
+		const helperRotate = {
+			AXIS: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ - 1e3, 0, 0 ], null, [ 1e6, 1, 1 ], 'helper' ]
+			]
+		};
+
+		const pickerRotate = {
+			XYZE: [
+				[ new Mesh( new SphereGeometry( 0.25, 10, 8 ), matInvisible ) ]
+			],
+			X: [
+				[ new Mesh( new TorusGeometry( 0.5, 0.1, 4, 24 ), matInvisible ), [ 0, 0, 0 ], [ 0, - Math.PI / 2, - Math.PI / 2 ]],
+			],
+			Y: [
+				[ new Mesh( new TorusGeometry( 0.5, 0.1, 4, 24 ), matInvisible ), [ 0, 0, 0 ], [ Math.PI / 2, 0, 0 ]],
+			],
+			Z: [
+				[ new Mesh( new TorusGeometry( 0.5, 0.1, 4, 24 ), matInvisible ), [ 0, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+			],
+			E: [
+				[ new Mesh( new TorusGeometry( 0.75, 0.1, 2, 24 ), matInvisible ) ]
+			]
+		};
+
+		const gizmoScale = {
+			X: [
+				[ new Mesh( scaleHandleGeometry, matRed ), [ 0.5, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+				[ new Mesh( lineGeometry2, matRed ), [ 0, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+				[ new Mesh( scaleHandleGeometry, matRed ), [ - 0.5, 0, 0 ], [ 0, 0, Math.PI / 2 ]],
+			],
+			Y: [
+				[ new Mesh( scaleHandleGeometry, matGreen ), [ 0, 0.5, 0 ]],
+				[ new Mesh( lineGeometry2, matGreen ) ],
+				[ new Mesh( scaleHandleGeometry, matGreen ), [ 0, - 0.5, 0 ], [ 0, 0, Math.PI ]],
+			],
+			Z: [
+				[ new Mesh( scaleHandleGeometry, matBlue ), [ 0, 0, 0.5 ], [ Math.PI / 2, 0, 0 ]],
+				[ new Mesh( lineGeometry2, matBlue ), [ 0, 0, 0 ], [ Math.PI / 2, 0, 0 ]],
+				[ new Mesh( scaleHandleGeometry, matBlue ), [ 0, 0, - 0.5 ], [ - Math.PI / 2, 0, 0 ]]
+			],
+			XY: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matBlueTransparent ), [ 0.15, 0.15, 0 ]]
+			],
+			YZ: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matRedTransparent ), [ 0, 0.15, 0.15 ], [ 0, Math.PI / 2, 0 ]]
+			],
+			XZ: [
+				[ new Mesh( new BoxGeometry( 0.15, 0.15, 0.01 ), matGreenTransparent ), [ 0.15, 0, 0.15 ], [ - Math.PI / 2, 0, 0 ]]
+			],
+			XYZ: [
+				[ new Mesh( new BoxGeometry( 0.1, 0.1, 0.1 ), matWhiteTransparent.clone() ) ],
+			]
+		};
+
+		const pickerScale = {
+			X: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0.3, 0, 0 ], [ 0, 0, - Math.PI / 2 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ - 0.3, 0, 0 ], [ 0, 0, Math.PI / 2 ]]
+			],
+			Y: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0.3, 0 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, - 0.3, 0 ], [ 0, 0, Math.PI ]]
+			],
+			Z: [
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0, 0.3 ], [ Math.PI / 2, 0, 0 ]],
+				[ new Mesh( new CylinderGeometry( 0.2, 0, 0.6, 4 ), matInvisible ), [ 0, 0, - 0.3 ], [ - Math.PI / 2, 0, 0 ]]
+			],
+			XY: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0.15, 0.15, 0 ]],
+			],
+			YZ: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0, 0.15, 0.15 ], [ 0, Math.PI / 2, 0 ]],
+			],
+			XZ: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.01 ), matInvisible ), [ 0.15, 0, 0.15 ], [ - Math.PI / 2, 0, 0 ]],
+			],
+			XYZ: [
+				[ new Mesh( new BoxGeometry( 0.2, 0.2, 0.2 ), matInvisible ), [ 0, 0, 0 ]],
+			]
+		};
+
+		const helperScale = {
+			X: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ - 1e3, 0, 0 ], null, [ 1e6, 1, 1 ], 'helper' ]
+			],
+			Y: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ 0, - 1e3, 0 ], [ 0, 0, Math.PI / 2 ], [ 1e6, 1, 1 ], 'helper' ]
+			],
+			Z: [
+				[ new Line( lineGeometry, matHelper.clone() ), [ 0, 0, - 1e3 ], [ 0, - Math.PI / 2, 0 ], [ 1e6, 1, 1 ], 'helper' ]
+			]
+		};
+
+		// Creates an Object3D with gizmos described in custom hierarchy definition.
+
+		function setupGizmo( gizmoMap ) {
+
+			const gizmo = new Object3D();
+
+			for ( const name in gizmoMap ) {
+
+				for ( let i = gizmoMap[ name ].length; i --; ) {
+
+					const object = gizmoMap[ name ][ i ][ 0 ].clone();
+					const position = gizmoMap[ name ][ i ][ 1 ];
+					const rotation = gizmoMap[ name ][ i ][ 2 ];
+					const scale = gizmoMap[ name ][ i ][ 3 ];
+					const tag = gizmoMap[ name ][ i ][ 4 ];
+
+					// name and tag properties are essential for picking and updating logic.
+					object.name = name;
+					object.tag = tag;
+
+					if ( position ) {
+
+						object.position.set( position[ 0 ], position[ 1 ], position[ 2 ] );
+
+					}
+
+					if ( rotation ) {
+
+						object.rotation.set( rotation[ 0 ], rotation[ 1 ], rotation[ 2 ] );
+
+					}
+
+					if ( scale ) {
+
+						object.scale.set( scale[ 0 ], scale[ 1 ], scale[ 2 ] );
+
+					}
+
+					object.updateMatrix();
+
+					const tempGeometry = object.geometry.clone();
+					tempGeometry.applyMatrix4( object.matrix );
+					object.geometry = tempGeometry;
+					object.renderOrder = Infinity;
+
+					object.position.set( 0, 0, 0 );
+					object.rotation.set( 0, 0, 0 );
+					object.scale.set( 1, 1, 1 );
+
+					gizmo.add( object );
+
+				}
+
+			}
+
+			return gizmo;
+
+		}
+
+		// Gizmo creation
+
+		this.gizmo = {};
+		this.picker = {};
+		this.helper = {};
+
+		this.add( this.gizmo[ 'translate' ] = setupGizmo( gizmoTranslate ) );
+		this.add( this.gizmo[ 'rotate' ] = setupGizmo( gizmoRotate ) );
+		this.add( this.gizmo[ 'scale' ] = setupGizmo( gizmoScale ) );
+		this.add( this.picker[ 'translate' ] = setupGizmo( pickerTranslate ) );
+		this.add( this.picker[ 'rotate' ] = setupGizmo( pickerRotate ) );
+		this.add( this.picker[ 'scale' ] = setupGizmo( pickerScale ) );
+		this.add( this.helper[ 'translate' ] = setupGizmo( helperTranslate ) );
+		this.add( this.helper[ 'rotate' ] = setupGizmo( helperRotate ) );
+		this.add( this.helper[ 'scale' ] = setupGizmo( helperScale ) );
+
+		// Pickers should be hidden always
+
+		this.picker[ 'translate' ].visible = false;
+		this.picker[ 'rotate' ].visible = false;
+		this.picker[ 'scale' ].visible = false;
+
+	}
+
+	// updateMatrixWorld will update transformations and appearance of individual handles
+
+	updateMatrixWorld( force ) {
+
+		const space = ( this.mode === 'scale' ) ? 'local' : this.space; // scale always oriented to local rotation
+
+		const quaternion = ( space === 'local' ) ? this.worldQuaternion : _identityQuaternion;
+
+		// Show only gizmos for current transform mode
+
+		this.gizmo[ 'translate' ].visible = this.mode === 'translate';
+		this.gizmo[ 'rotate' ].visible = this.mode === 'rotate';
+		this.gizmo[ 'scale' ].visible = this.mode === 'scale';
+
+		this.helper[ 'translate' ].visible = this.mode === 'translate';
+		this.helper[ 'rotate' ].visible = this.mode === 'rotate';
+		this.helper[ 'scale' ].visible = this.mode === 'scale';
+
+
+		let handles = [];
+		handles = handles.concat( this.picker[ this.mode ].children );
+		handles = handles.concat( this.gizmo[ this.mode ].children );
+		handles = handles.concat( this.helper[ this.mode ].children );
+
+		for ( let i = 0; i < handles.length; i ++ ) {
+
+			const handle = handles[ i ];
+
+			// hide aligned to camera
+
+			handle.visible = true;
+			handle.rotation.set( 0, 0, 0 );
+			handle.position.copy( this.worldPosition );
+
+			let factor;
+
+			if ( this.camera.isOrthographicCamera ) {
+
+				factor = ( this.camera.top - this.camera.bottom ) / this.camera.zoom;
+
+			} else {
+
+				factor = this.worldPosition.distanceTo( this.cameraPosition ) * Math.min( 1.9 * Math.tan( Math.PI * this.camera.fov / 360 ) / this.camera.zoom, 7 );
+
+			}
+
+			handle.scale.set( 1, 1, 1 ).multiplyScalar( factor * this.size / 4 );
+
+			// TODO: simplify helpers and consider decoupling from gizmo
+
+			if ( handle.tag === 'helper' ) {
+
+				handle.visible = false;
+
+				if ( handle.name === 'AXIS' ) {
+
+					handle.position.copy( this.worldPositionStart );
+					handle.visible = !! this.axis;
+
+					if ( this.axis === 'X' ) {
+
+						_tempQuaternion.setFromEuler( _tempEuler.set( 0, 0, 0 ) );
+						handle.quaternion.copy( quaternion ).multiply( _tempQuaternion );
+
+						if ( Math.abs( _alignVector.copy( _unitX ).applyQuaternion( quaternion ).dot( this.eye ) ) > 0.9 ) {
+
+							handle.visible = false;
+
+						}
+
+					}
+
+					if ( this.axis === 'Y' ) {
+
+						_tempQuaternion.setFromEuler( _tempEuler.set( 0, 0, Math.PI / 2 ) );
+						handle.quaternion.copy( quaternion ).multiply( _tempQuaternion );
+
+						if ( Math.abs( _alignVector.copy( _unitY ).applyQuaternion( quaternion ).dot( this.eye ) ) > 0.9 ) {
+
+							handle.visible = false;
+
+						}
+
+					}
+
+					if ( this.axis === 'Z' ) {
+
+						_tempQuaternion.setFromEuler( _tempEuler.set( 0, Math.PI / 2, 0 ) );
+						handle.quaternion.copy( quaternion ).multiply( _tempQuaternion );
+
+						if ( Math.abs( _alignVector.copy( _unitZ ).applyQuaternion( quaternion ).dot( this.eye ) ) > 0.9 ) {
+
+							handle.visible = false;
+
+						}
+
+					}
+
+					if ( this.axis === 'XYZE' ) {
+
+						_tempQuaternion.setFromEuler( _tempEuler.set( 0, Math.PI / 2, 0 ) );
+						_alignVector.copy( this.rotationAxis );
+						handle.quaternion.setFromRotationMatrix( _lookAtMatrix.lookAt( _zeroVector, _alignVector, _unitY ) );
+						handle.quaternion.multiply( _tempQuaternion );
+						handle.visible = this.dragging;
+
+					}
+
+					if ( this.axis === 'E' ) {
+
+						handle.visible = false;
+
+					}
+
+
+				} else if ( handle.name === 'START' ) {
+
+					handle.position.copy( this.worldPositionStart );
+					handle.visible = this.dragging;
+
+				} else if ( handle.name === 'END' ) {
+
+					handle.position.copy( this.worldPosition );
+					handle.visible = this.dragging;
+
+				} else if ( handle.name === 'DELTA' ) {
+
+					handle.position.copy( this.worldPositionStart );
+					handle.quaternion.copy( this.worldQuaternionStart );
+					_tempVector.set( 1e-10, 1e-10, 1e-10 ).add( this.worldPositionStart ).sub( this.worldPosition ).multiplyScalar( - 1 );
+					_tempVector.applyQuaternion( this.worldQuaternionStart.clone().invert() );
+					handle.scale.copy( _tempVector );
+					handle.visible = this.dragging;
+
+				} else {
+
+					handle.quaternion.copy( quaternion );
+
+					if ( this.dragging ) {
+
+						handle.position.copy( this.worldPositionStart );
+
+					} else {
+
+						handle.position.copy( this.worldPosition );
+
+					}
+
+					if ( this.axis ) {
+
+						handle.visible = this.axis.search( handle.name ) !== - 1;
+
+					}
+
+				}
+
+				// If updating helper, skip rest of the loop
+				continue;
+
+			}
+
+			// Align handles to current local or world rotation
+
+			handle.quaternion.copy( quaternion );
+
+			if ( this.mode === 'translate' || this.mode === 'scale' ) {
+
+				// Hide translate and scale axis facing the camera
+
+				const AXIS_HIDE_TRESHOLD = 0.99;
+				const PLANE_HIDE_TRESHOLD = 0.2;
+
+				if ( handle.name === 'X' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitX ).applyQuaternion( quaternion ).dot( this.eye ) ) > AXIS_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+				if ( handle.name === 'Y' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitY ).applyQuaternion( quaternion ).dot( this.eye ) ) > AXIS_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+				if ( handle.name === 'Z' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitZ ).applyQuaternion( quaternion ).dot( this.eye ) ) > AXIS_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+				if ( handle.name === 'XY' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitZ ).applyQuaternion( quaternion ).dot( this.eye ) ) < PLANE_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+				if ( handle.name === 'YZ' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitX ).applyQuaternion( quaternion ).dot( this.eye ) ) < PLANE_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+				if ( handle.name === 'XZ' ) {
+
+					if ( Math.abs( _alignVector.copy( _unitY ).applyQuaternion( quaternion ).dot( this.eye ) ) < PLANE_HIDE_TRESHOLD ) {
+
+						handle.scale.set( 1e-10, 1e-10, 1e-10 );
+						handle.visible = false;
+
+					}
+
+				}
+
+			} else if ( this.mode === 'rotate' ) {
+
+				// Align handles to current local or world rotation
+
+				_tempQuaternion2.copy( quaternion );
+				_alignVector.copy( this.eye ).applyQuaternion( _tempQuaternion.copy( quaternion ).invert() );
+
+				if ( handle.name.search( 'E' ) !== - 1 ) {
+
+					handle.quaternion.setFromRotationMatrix( _lookAtMatrix.lookAt( this.eye, _zeroVector, _unitY ) );
+
+				}
+
+				if ( handle.name === 'X' ) {
+
+					_tempQuaternion.setFromAxisAngle( _unitX, Math.atan2( - _alignVector.y, _alignVector.z ) );
+					_tempQuaternion.multiplyQuaternions( _tempQuaternion2, _tempQuaternion );
+					handle.quaternion.copy( _tempQuaternion );
+
+				}
+
+				if ( handle.name === 'Y' ) {
+
+					_tempQuaternion.setFromAxisAngle( _unitY, Math.atan2( _alignVector.x, _alignVector.z ) );
+					_tempQuaternion.multiplyQuaternions( _tempQuaternion2, _tempQuaternion );
+					handle.quaternion.copy( _tempQuaternion );
+
+				}
+
+				if ( handle.name === 'Z' ) {
+
+					_tempQuaternion.setFromAxisAngle( _unitZ, Math.atan2( _alignVector.y, _alignVector.x ) );
+					_tempQuaternion.multiplyQuaternions( _tempQuaternion2, _tempQuaternion );
+					handle.quaternion.copy( _tempQuaternion );
+
+				}
+
+			}
+
+			// Hide disabled axes
+			handle.visible = handle.visible && ( handle.name.indexOf( 'X' ) === - 1 || this.showX );
+			handle.visible = handle.visible && ( handle.name.indexOf( 'Y' ) === - 1 || this.showY );
+			handle.visible = handle.visible && ( handle.name.indexOf( 'Z' ) === - 1 || this.showZ );
+			handle.visible = handle.visible && ( handle.name.indexOf( 'E' ) === - 1 || ( this.showX && this.showY && this.showZ ) );
+
+			// highlight selected axis
+
+			handle.material._color = handle.material._color || handle.material.color.clone();
+			handle.material._opacity = handle.material._opacity || handle.material.opacity;
+
+			handle.material.color.copy( handle.material._color );
+			handle.material.opacity = handle.material._opacity;
+
+			if ( this.enabled && this.axis ) {
+
+				if ( handle.name === this.axis ) {
+
+					handle.material.color.setHex( 0xffff00 );
+					handle.material.opacity = 1.0;
+
+				} else if ( this.axis.split( '' ).some( function ( a ) {
+
+					return handle.name === a;
+
+				} ) ) {
+
+					handle.material.color.setHex( 0xffff00 );
+					handle.material.opacity = 1.0;
+
+				}
+
+			}
+
+		}
+
+		super.updateMatrixWorld( force );
+
+	}
+
+}
+
+//
+
+class TransformControlsPlane extends Mesh {
+
+	constructor() {
+
+		super(
+			new PlaneGeometry( 100000, 100000, 2, 2 ),
+			new MeshBasicMaterial( { visible: false, wireframe: true, side: DoubleSide, transparent: true, opacity: 0.1, toneMapped: false } )
+		);
+
+		this.isTransformControlsPlane = true;
+
+		this.type = 'TransformControlsPlane';
+
+	}
+
+	updateMatrixWorld( force ) {
+
+		let space = this.space;
+
+		this.position.copy( this.worldPosition );
+
+		if ( this.mode === 'scale' ) space = 'local'; // scale always oriented to local rotation
+
+		_v1.copy( _unitX ).applyQuaternion( space === 'local' ? this.worldQuaternion : _identityQuaternion );
+		_v2.copy( _unitY ).applyQuaternion( space === 'local' ? this.worldQuaternion : _identityQuaternion );
+		_v3.copy( _unitZ ).applyQuaternion( space === 'local' ? this.worldQuaternion : _identityQuaternion );
+
+		// Align the plane for current transform mode, axis and space.
+
+		_alignVector.copy( _v2 );
+
+		switch ( this.mode ) {
+
+			case 'translate':
+			case 'scale':
+				switch ( this.axis ) {
+
+					case 'X':
+						_alignVector.copy( this.eye ).cross( _v1 );
+						_dirVector.copy( _v1 ).cross( _alignVector );
+						break;
+					case 'Y':
+						_alignVector.copy( this.eye ).cross( _v2 );
+						_dirVector.copy( _v2 ).cross( _alignVector );
+						break;
+					case 'Z':
+						_alignVector.copy( this.eye ).cross( _v3 );
+						_dirVector.copy( _v3 ).cross( _alignVector );
+						break;
+					case 'XY':
+						_dirVector.copy( _v3 );
+						break;
+					case 'YZ':
+						_dirVector.copy( _v1 );
+						break;
+					case 'XZ':
+						_alignVector.copy( _v3 );
+						_dirVector.copy( _v2 );
+						break;
+					case 'XYZ':
+					case 'E':
+						_dirVector.set( 0, 0, 0 );
+						break;
+
+				}
+
+				break;
+			case 'rotate':
+			default:
+				// special case for rotate
+				_dirVector.set( 0, 0, 0 );
+
+		}
+
+		if ( _dirVector.length() === 0 ) {
+
+			// If in rotate mode, make the plane parallel to camera
+			this.quaternion.copy( this.cameraQuaternion );
+
+		} else {
+
+			_tempMatrix.lookAt( _tempVector.set( 0, 0, 0 ), _dirVector, _alignVector );
+
+			this.quaternion.setFromRotationMatrix( _tempMatrix );
+
+		}
+
+		super.updateMatrixWorld( force );
+
+	}
+
+}
+
+export { TransformControls, TransformControlsGizmo, TransformControlsPlane };


### PR DESCRIPTION
Finally made the change so that the camera moves in the threejsScene, simplifying the coordinate systems.
The threejs mainContainerObj.matrix is set to the groundPlaneSceneNode.worldMatrix, rather than the modelViewMatrix.

Consequences:
- the math for dragging the groundPlaneAnchors was broken, so I took the opportunity to add THREE.TransformControls to translate them in a more standard way
-  @dangond-ptc's areaCreator calculateGroundPlaneIntersection needed an adjustment (but could be simplified a bit – correct me if I'm wrong but it didn't seem necessary to use the getPointAtDistanceFromCamera anymore)
- the main threejs scene lighting was messed up, because it was actually just being lit by a spotlight that happened to cover it because of the way the scene was transformed. I tried replacing it with an ambient light but our area target material doesn't seem to be affected by ambient lighting, so I added a set of directional lights as a temporary replacement. Might need some help improving this if anyone has time to play with it in the future.
- the camera following (in the remote-operator-addon) needed to be updated because of some calculations it did using threejs
- the virtualizers aren't affected at all by the change 👍 
