### PR TITLE
Reliably default certain settings to disabled

### DIFF
--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -151,7 +151,7 @@ realityEditor.device.onload = function () {
             }.bind(this), 1000);
         }
 
-    }, true).moveToDevelopMenu().setValue(!window.location.href.includes('127.0.0.1')); // default value is based on the current source
+    }, { ignoreOnload: true }).moveToDevelopMenu().setValue(!window.location.href.includes('127.0.0.1')); // default value is based on the current source
 
     realityEditor.gui.settings.addToggleWithFrozenText('Discovery Server', 'load objects from static server', 'discoveryState',  '../../../svg/discovery.svg', false, 'http://...', function(newValue, textValue) {
         console.log('discovery state set to ' + newValue + ' with text ' + textValue);
@@ -171,7 +171,7 @@ realityEditor.device.onload = function () {
         } else {
             realityEditor.app.setAspectRatio(16/9);
         }
-    }, true).moveToDevelopMenu();
+    }, { ignoreOnload: true }).moveToDevelopMenu();
 
     // Add a debug toggle to the develop menu that forces the targetDownloader to re-download each time instead of using the cache
     realityEditor.gui.settings.addToggle('Reset Target Cache', 'clear cache of downloaded target data', 'resetTargetCache',  '../../../svg/object.svg', false, function(newValue) {

--- a/src/gui/ar/groundPlaneAnchors.js
+++ b/src/gui/ar/groundPlaneAnchors.js
@@ -30,12 +30,9 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     let transformControls = {};
 
     function initService() {
-        // Note that, currently, positioningMode blocks touch events from reaching anything else, so it should be toggled off when not in use
         realityEditor.gui.settings.addToggle('Reposition Ground Anchors', 'surface anchors can be dragged to move tools', 'repositionGroundAnchors',  '../../../svg/move.svg', false, function(newValue) {
-            if (isPositioningMode !== newValue) {
-                togglePositioningMode();
-            }
-        });
+            togglePositioningMode(newValue);
+        }, { dontPersist: true });
 
         realityEditor.gui.ar.draw.addUpdateListener(function(visibleObjects) {
             try {
@@ -168,8 +165,12 @@ createNameSpace("realityEditor.gui.ar.groundPlaneAnchors");
     }
 
     // show and hide the anchors as well as the touch event catcher
-    function togglePositioningMode() {
-        isPositioningMode = !isPositioningMode;
+    function togglePositioningMode(newValue) {
+        if (typeof newValue !== 'undefined') {
+            isPositioningMode = newValue;
+        } else {
+            isPositioningMode = !isPositioningMode;
+        }
         updatePositioningMode(); // refreshes the effects of the current mode
     }
 

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -23,6 +23,7 @@ import { TransformControls } from '../../thirdPartyCode/three/TransformControls.
     let mouse;
     let distanceRaycastVector = new THREE.Vector3();
     let distanceRaycastResultPosition = new THREE.Vector3();
+    let originBoxes = {};
 
     const DISPLAY_ORIGIN_BOX = true;
 
@@ -75,6 +76,12 @@ import { TransformControls } from '../../thirdPartyCode/three/TransformControls.
         addGroundPlaneCollisionObject(); // invisible object for raycasting intersections with ground plane
 
         renderScene(); // update loop
+
+        if (DISPLAY_ORIGIN_BOX) {
+            realityEditor.gui.settings.addToggle('Display Origin Boxes', 'show debug cubes at origin', 'displayOriginCubes',  '../../../svg/move.svg', false, function(newValue) {
+                toggleDisplayOriginBoxes(newValue);
+            }, { dontPersist: true });
+        }
     }
 
     // light the scene with a combination of ambient and directional white light
@@ -161,6 +168,11 @@ import { TransformControls } from '../../thirdPartyCode/three/TransformControls.
                     originBox.add(xBox);
                     originBox.add(yBox);
                     originBox.add(zBox);
+
+                    originBoxes[worldObjectId] = originBox;
+                    if (typeof realityEditor.gui.settings.toggleStates.displayOriginCubes !== 'undefined') {
+                        originBox.visible = realityEditor.gui.settings.toggleStates.displayOriginCubes;
+                    }
                 }
             }
 
@@ -198,6 +210,12 @@ import { TransformControls } from '../../thirdPartyCode/three/TransformControls.
         }
 
         requestAnimationFrame(renderScene);
+    }
+
+    function toggleDisplayOriginBoxes(newValue) {
+        Object.values(originBoxes).forEach((box) => {
+            box.visible = newValue;
+        });
     }
 
     function addToScene(obj, parameters) {
@@ -574,6 +592,7 @@ import { TransformControls } from '../../thirdPartyCode/three/TransformControls.
     exports.setMatrixFromArray = setMatrixFromArray;
     exports.getObjectForWorldRaycasts = getObjectForWorldRaycasts;
     exports.addTransformControlsTo = addTransformControlsTo;
+    exports.toggleDisplayOriginBoxes = toggleDisplayOriginBoxes;
     exports.THREE = THREE;
     exports.FBXLoader = FBXLoader;
     exports.GLTFLoader = GLTFLoader;


### PR DESCRIPTION
add options `{ dontPersist: true }` when creating a new SettingsToggle to make non-persistent settings. Uses this for the Visualize Groundplane Anchors, and a new setting, Display Origin Boxes, to set visibility to false by default.

Also exposes some APIs that the pop-up settings menu can use to show/hide these.