### PR TITLE
temporary fix for avatar detection flakiness (check if name includes _AVATAR_)

### DIFF
--- a/src/avatarObjects.js
+++ b/src/avatarObjects.js
@@ -131,7 +131,7 @@ createNameSpace("realityEditor.avatarObjects");
     }
 
     function handleDiscoveredObject(object, objectKey) {
-        if (object.type === 'avatar') {
+        if (isAvatarObject(object)) {
             if (typeof avatarObjects[objectKey] === 'undefined') {
                 avatarObjects[objectKey] = object;
                 
@@ -714,9 +714,14 @@ createNameSpace("realityEditor.avatarObjects");
         overlay.style.display = isVisible ? 'inline' : 'none';
     }
 
+    function isAvatarObject(object) {
+        return object.type === 'avatar' || object.objectId.indexOf('_AVATAR_') === 0;
+    }
+
     exports.initService = initService;
     exports.getAvatarObjects = getAvatarObjects;
     exports.setBeamOn = setBeamOn;
     exports.setBeamOff = setBeamOff;
+    exports.isAvatarObject = isAvatarObject;
 
 }(realityEditor.avatarObjects));

--- a/src/gui/ar/anchors.js
+++ b/src/gui/ar/anchors.js
@@ -57,7 +57,7 @@ createNameSpace("realityEditor.gui.ar.anchors");
      */
     function isAnchorObject(objectId) {
         let object = realityEditor.getObject(objectId);
-        if (object.type === 'human' || object.type === 'avatar') { return false; }
+        if (object.type === 'human' || realityEditor.avatarObjects.isAvatarObject(object)) { return false; }
         return anchorObjects.hasOwnProperty(objectId);
     }
 

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -376,7 +376,7 @@ realityEditor.gui.ar.draw.update = function (visibleObjects) {
 
         // for now, totally ignore avatar objects in the rendering engine
         // TODO: if we want to render tools relative to each avatar, we can remove this and add them to the visibleObjects list
-        if (this.activeObject.type === 'avatar') { continue; }
+        if (realityEditor.avatarObjects.isAvatarObject(this.activeObject)) { continue; }
         
         // if this object was detected by the AR engine this frame, render its nodes and/or frames
         if (this.visibleObjects.hasOwnProperty(objectKey)) {


### PR DESCRIPTION
Ideally we can just check `object.type`, but until I figure out where type is being overwritten we check the name of the object to more robustly identify avatars and ignore them.