### PR TITLE
Refactor discovery into its own module + a couple bug fixes and UI updates

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1506,15 +1506,23 @@ Logic Interface CSS
     border: 2px solid cyan;
 }
 
-#exitEnvelopeButton {
+.envelopeMenuButton {
     position: absolute;
-    left: 0;
-    top: 0;
     width: 60px;
     height: 60px;
     /* this is a hack for adding the interface in front of the transformed web interface but behind the pocket*/
     -webkit-transform: translateZ(2900px);
     z-index: 290;
+}
+
+#exitEnvelopeButton {
+    left: 10px;
+    top: 0;
+}
+
+#minimizeEnvelopeButton {
+    left: 70px;
+    top: 0;
 }
 
 .hoverPocketElement {

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
     <script src="src/network/frameContentAPI.js"></script>
     <script src="src/network/availableFrames.js"></script>
     <script src="src/network/search.js"></script>
+    <script src="src/network/discovery.js"></script>
 
     <script src="src/cloud/index.js"></script>
 

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -179,26 +179,6 @@ createNameSpace('realityEditor.app.callbacks');
             
             realityEditor.network.discovery.processHeartbeat(message);
 
-            // let ignoreFromPause = false;
-            // if (heartbeatsPaused) {
-            //     ignoreFromPause = !exceptions.some(name => message.id.includes(name));
-            // }
-            //
-            // if (!realityEditor.device.environment.variables.suppressObjectDetections && !ignoreFromPause) {
-            //     if (typeof message.zone !== 'undefined' && message.zone !== '') {
-            //         if (realityEditor.gui.settings.toggleStates.zoneState && realityEditor.gui.settings.toggleStates.zoneStateText === message.zone) {
-            //             // console.log('Added object from zone=' + message.zone);
-            //             realityEditor.network.addHeartbeatObject(message);
-            //         }
-            //
-            //     } else if (!realityEditor.gui.settings.toggleStates.zoneState) {
-            //         // console.log('Added object without zone');
-            //         realityEditor.network.addHeartbeatObject(message);
-            //     }
-            // } else {
-            //     queuedHeartbeats.push(message);
-            // }
-
             // forward the action message to the network module, to synchronize state across multiple clients
         } else if (typeof message.action !== 'undefined') {
             realityEditor.network.onAction(message.action);

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -78,7 +78,8 @@ createNameSpace("realityEditor.app.targetDownloader");
 
     let callbacks = {
         onCreateNavmesh: [],
-        onMarkerAdded: []
+        onMarkerAdded: [],
+        onTargetState: []
     }
 
     /**
@@ -233,6 +234,7 @@ createNameSpace("realityEditor.app.targetDownloader");
 
             console.log('successfully downloaded XML file: ' + fileName);
             targetDownloadStates[objectID].XML = DownloadState.SUCCEEDED;
+            triggerDownloadStateCallbacks(objectID);
 
             var datAddress = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/obj/' + object.name + '/target/target.dat');
 
@@ -250,6 +252,7 @@ createNameSpace("realityEditor.app.targetDownloader");
         } else {
             console.log('failed to download XML file: ' + fileName);
             targetDownloadStates[objectID].XML = DownloadState.FAILED;
+            triggerDownloadStateCallbacks(objectID);
             onDownloadFailed(objectID);
         }
     }
@@ -270,6 +273,7 @@ createNameSpace("realityEditor.app.targetDownloader");
 
             console.log('successfully downloaded DAT file: ' + fileName);
             targetDownloadStates[objectID].DAT = DownloadState.SUCCEEDED;
+            triggerDownloadStateCallbacks(objectID);
 
             var xmlFileName = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/obj/' + object.name + '/target/target.xml');
             realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
@@ -295,6 +299,7 @@ createNameSpace("realityEditor.app.targetDownloader");
         } else {
             console.log('failed to download DAT file: ' + fileName);
             targetDownloadStates[objectID].DAT = DownloadState.FAILED;
+            triggerDownloadStateCallbacks(objectID);
 
             if (isAlreadyDownloaded(objectID, 'JPG')) {
                 onTargetJPGDownloaded(true, jpgAddress); // just directly trigger onTargetXMLDownloaded
@@ -326,6 +331,8 @@ createNameSpace("realityEditor.app.targetDownloader");
             onDownloadFailed(objectID);
         }
         createNavmesh(fileName, objectID);
+
+        triggerDownloadStateCallbacks(objectID);
     }
 
     /**
@@ -363,6 +370,8 @@ createNameSpace("realityEditor.app.targetDownloader");
             targetDownloadStates[objectID].JPG = DownloadState.FAILED;
             onDownloadFailed(objectID);
         }
+
+        triggerDownloadStateCallbacks(objectID);
     }
 
     /**
@@ -379,17 +388,19 @@ createNameSpace("realityEditor.app.targetDownloader");
             console.log('successfully added marker: ' + fileName);
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.SUCCEEDED;
             saveDownloadInfo(objectID); // only caches the target images after we confirm that they work
-
-            callbacks.onMarkerAdded.forEach(listener => {
-                if (listener.objectId === objectID) {
-                    listener.callback(targetDownloadStates[objectID]);
-                }
-            });
         } else {
             console.log('failed to add marker: ' + fileName);
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.FAILED;
             onDownloadFailed(objectID);
         }
+
+        triggerDownloadStateCallbacks(objectID);
+
+        callbacks.onMarkerAdded.forEach(listener => {
+            if (listener.objectId === objectID) {
+                listener.callback(success, targetDownloadStates[objectID]);
+            }
+        });
     }
 
     /**
@@ -674,7 +685,7 @@ createNameSpace("realityEditor.app.targetDownloader");
         "type": "object",
         "items": {
             "properties": {
-                "obj": {"type": "string", "minLength": 1, "maxLength": 25, "pattern": "^[A-Za-z0-9_]*$"},
+                "obj": {"type": "string", "minLength": 1, "maxLength": 50, "pattern": "^[A-Za-z0-9_]*$"},
                 "server" : {"type": "string", "minLength": 0, "maxLength": 2000, "pattern": "^[A-Za-z0-9~!@$%^&*()-_=+|;:,.]"},
             },
             "required": ["server", "obj"],
@@ -685,7 +696,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     function getObjectIDFromFilename(fileName) {
         let urlObj = io.parseUrl(fileName, schema)
         if (!urlObj) {
-            console.warn('io.parseUrl failed', fileName);
+            console.warn('io.parseUrl failed. this may cause targets not to download', fileName);
             return;
         }
         const ip = urlObj.server;
@@ -769,6 +780,33 @@ createNameSpace("realityEditor.app.targetDownloader");
             objectId: objectId,
             callback: callback
         });
+        
+        if (typeof targetDownloadStates[objectId] !== 'undefined') {
+            if (targetDownloadStates[objectId].MARKER_ADDED === DownloadState.SUCCEEDED) {
+                // process any previously added targets in case we added the listener too late
+                callback(true, targetDownloadStates[objectId]);
+            }
+        }
+    }
+    
+    exports.addTargetStateCallback = function(objectId, callback) {
+        callbacks.onMarkerAdded.push({
+            objectId: objectId,
+            callback: callback
+        });
+
+        if (typeof targetDownloadStates[objectId] !== 'undefined') {
+            // process any previously added targets in case we added the listener too late
+            callback(targetDownloadStates[objectId]);
+        }
+    }
+
+    function triggerDownloadStateCallbacks(objectID) {
+        callbacks.onTargetState.forEach(listener => {
+            if (listener.objectId === objectID) {
+                listener.callback(targetDownloadStates[objectID]);
+            }
+        });
     }
 
     // These functions are the public API that should be called by other modules
@@ -778,6 +816,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     exports.isObjectReadyToRetryDownload = isObjectReadyToRetryDownload;
     exports.resetTargetDownloadCache = resetTargetDownloadCache;
     exports.reinstatePreviouslyAddedTargets = reinstatePreviouslyAddedTargets;
+    exports.DownloadState = DownloadState;
 
     // These functions are public only because they need to be triggered by native app callbacks
     exports.onTargetXMLDownloaded = onTargetXMLDownloaded;

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -790,7 +790,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
     
     exports.addTargetStateCallback = function(objectId, callback) {
-        callbacks.onMarkerAdded.push({
+        callbacks.onTargetState.push({
             objectId: objectId,
             callback: callback
         });

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -57,6 +57,10 @@ createNameSpace("realityEditor.avatar");
         realityEditor.worldObjects.onLocalizedWithinWorld(function(worldObjectKey) {
             if (worldObjectKey === realityEditor.worldObjects.getLocalWorldId()) { return; }
 
+            // todo: for now, we don't create a new avatar object for each world we see, but in future we may want to
+            //       migrate our existing avatar to the server hosting the current world object that we're looking at
+            if (myAvatarObject || myAvatarId) { return; }
+
             connectionStatus.isLocalized = true;
             refreshStatusUI();
             network.processPendingAvatarInitializations(connectionStatus, cachedWorldObject, onOtherAvatarInitialized);

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -351,6 +351,7 @@ realityEditor.device.onload = function () {
     realityEditor.gui.ar.areaTargetScanner.initService();
     realityEditor.gui.ar.areaCreator.initService();
     realityEditor.device.touchPropagation.initService();
+    realityEditor.network.discovery.initService();
     realityEditor.network.realtime.initService();
     realityEditor.gui.crafting.initService();
     realityEditor.worldObjects.initService();

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -205,17 +205,22 @@ createNameSpace("realityEditor.envelopeManager");
     function updateExitButton() {
         var numberOfOpenEnvelopes = getOpenEnvelopes().length;
         if (numberOfOpenEnvelopes === 0) {
-            // hide exit button
+            // hide exit and minimize buttons
+            let minimizeButton = document.getElementById('minimizeEnvelopeButton');
+            if (minimizeButton) {
+                minimizeButton.style.display = 'none';
+            }
             let exitButton = document.getElementById('exitEnvelopeButton');
             if (exitButton) {
                 exitButton.style.display = 'none';
-                callbacks.onExitButtonHidden.forEach(cb => cb(exitButton));
             }
+            callbacks.onExitButtonHidden.forEach(cb => cb(exitButton, minimizeButton));
         } else {
             // show (create if needed) exit button
             let exitButton = document.getElementById('exitEnvelopeButton');
             if (!exitButton) {
                 exitButton = document.createElement('img');
+                exitButton.classList.add('envelopeMenuButton');
                 exitButton.src = 'svg/envelope-x-button.svg';
                 exitButton.id = 'exitEnvelopeButton';
                 exitButton.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
@@ -229,7 +234,19 @@ createNameSpace("realityEditor.envelopeManager");
                 });
             }
             exitButton.style.display = 'inline';
-            callbacks.onExitButtonShown.forEach(cb => cb(exitButton));
+
+            let minimizeButton = document.getElementById('minimizeEnvelopeButton');
+            if (!minimizeButton) {
+                minimizeButton = document.createElement('img');
+                minimizeButton.classList.add('envelopeMenuButton');
+                minimizeButton.src = 'svg/envelope-minimize-button.svg';
+                minimizeButton.id = 'minimizeEnvelopeButton';
+                minimizeButton.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
+                document.body.appendChild(minimizeButton);
+            }
+            minimizeButton.style.display = 'inline';
+
+            callbacks.onExitButtonShown.forEach(cb => cb(exitButton, minimizeButton));
         }
     }
     

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -231,6 +231,7 @@ createNameSpace("realityEditor.envelopeManager");
                     getOpenEnvelopes().forEach(function(envelope) {
                         closeEnvelope(envelope.frame);
                     });
+                    // TODO: send a message to the tool to make it lose focus (or have a sessionManager or focusManager to handle it)
                 });
             }
             exitButton.style.display = 'inline';
@@ -243,6 +244,13 @@ createNameSpace("realityEditor.envelopeManager");
                 minimizeButton.id = 'minimizeEnvelopeButton';
                 minimizeButton.style.top = realityEditor.device.environment.variables.screenTopOffset + 'px';
                 document.body.appendChild(minimizeButton);
+
+                minimizeButton.addEventListener('pointerup', function() {
+                    // TODO: only minimize the envelope that has focus, not all of them
+                    getOpenEnvelopes().forEach(function(envelope) {
+                        closeEnvelope(envelope.frame);
+                    });
+                });
             }
             minimizeButton.style.display = 'inline';
 

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -25,6 +25,11 @@ createNameSpace("realityEditor.envelopeManager");
      */
     var knownEnvelopes = {};
     
+    let callbacks = {
+        onExitButtonShown: [],
+        onExitButtonHidden: []
+    };
+    
     /**
      * Init envelope manager module
      */
@@ -204,6 +209,7 @@ createNameSpace("realityEditor.envelopeManager");
             let exitButton = document.getElementById('exitEnvelopeButton');
             if (exitButton) {
                 exitButton.style.display = 'none';
+                callbacks.onExitButtonHidden.forEach(cb => cb(exitButton));
             }
         } else {
             // show (create if needed) exit button
@@ -223,7 +229,16 @@ createNameSpace("realityEditor.envelopeManager");
                 });
             }
             exitButton.style.display = 'inline';
+            callbacks.onExitButtonShown.forEach(cb => cb(exitButton));
         }
+    }
+    
+    exports.onExitButtonHidden = (callback) => {
+        callbacks.onExitButtonHidden.push(callback);
+    }
+
+    exports.onExitButtonShown = (callback) => {
+        callbacks.onExitButtonShown.push(callback);
     }
 
     /**

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -422,7 +422,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                 return detectedServer !== '127.0.0.1';
             })[0]; // this is guaranteed to have at least one entry if we get here
         }
-        pendingAddedObjectName = "_WORLD_instantScan";
+        pendingAddedObjectName = "_WORLD_instantScan" + globalStates.tempUuid;
 
         realityEditor.network.discovery.addExceptionToPausedObjectDetections(pendingAddedObjectName);
 

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -405,7 +405,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         }
 
         // show loading animation. hide when successOrError finishes.
-        showLoadingDialog('Generating Dataset...', 'Please wait. Converting scan into AR target files.');
+        showLoadingDialog('Generating Dataset...', 'Please wait.'); // Converting scan into AR target files.');
 
         callbacks.onStopScanning.forEach(cb => {
             cb();
@@ -538,12 +538,25 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
     }
 
     function onAreaTargetGenerateProgress(percentGenerated) {
-        // onAreaTargetGenerateProgress
         console.log('Generated: ' + percentGenerated);
         let progressBarContainer = getProgressBar();
         progressBarContainer.style.display = '';
         let bar = progressBarContainer.querySelector('#scanGenerateProgressBar');
         bar.style.width = (percentGenerated * 100) + '%';
+
+        if (loadingDialog) {
+            let description = 'Please wait. Preparing scan.';
+            if (percentGenerated > 0.05 && percentGenerated < 0.4) {
+                description = 'Please wait. Fusing depth data.';
+            } else if (percentGenerated < 0.7) {
+                description = 'Please wait. Generating textures.';
+            } else if (percentGenerated < 0.9) {
+                description = 'Please wait. Generating Vuforia dataset.';
+            } else if (percentGenerated >= 0.9) {
+                description = 'Please wait. Finalizing files for upload.';
+            }
+            loadingDialog.domElements.description.innerHTML = description;
+        }
     }
 
     function captureSuccessOrError(success, errorMessage) {

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -422,7 +422,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                 return detectedServer !== '127.0.0.1';
             })[0]; // this is guaranteed to have at least one entry if we get here
         }
-        pendingAddedObjectName = "_WORLD_instantScan" + globalStates.tempUuid;
+        pendingAddedObjectName = "_WORLD_instantScan";// + globalStates.tempUuid;
 
         realityEditor.network.discovery.addExceptionToPausedObjectDetections(pendingAddedObjectName);
 

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -424,7 +424,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         }
         pendingAddedObjectName = "_WORLD_instantScan";
 
-        realityEditor.app.callbacks.addExceptionToPausedObjectDetections(pendingAddedObjectName);
+        realityEditor.network.discovery.addExceptionToPausedObjectDetections(pendingAddedObjectName);
 
         const port = realityEditor.network.getPortByIp(serverIp);
         addObject(pendingAddedObjectName, serverIp, port); // TODO: get port programmatically

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -562,11 +562,6 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                 getProgressBar().style.display = 'none';
                 showLoadingDialog('Uploading Target Data...', 'Please wait. Uploading data to server.');
                 
-                setTimeout(() => {
-                    loadingDialog.dismiss();
-                    loadingDialog = null;
-                }, 1500);
-                
                 let alreadyProcessed = false;
                 realityEditor.app.targetDownloader.addTargetStateCallback(sessionObjectId, (targetDownloadState) => {
                     if (alreadyProcessed) { return; }
@@ -577,19 +572,13 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                     if (targetDownloadState.XML === SUCCEEDED && targetDownloadState.DAT === SUCCEEDED) {
                         alreadyProcessed = true;
 
+                        loadingDialog.dismiss();
+                        loadingDialog = null;
+
                         // objects aren't fully initialized until they have a target.jpg, so we upload a screenshot to be the "icon"
                         realityEditor.app.getScreenshot('S', 'realityEditor.gui.ar.areaTargetScanner.onScreenshotReceived');
                     }
-                })
-
-                // setTimeout(function() {
-                //     loadingDialog.dismiss();
-                //     loadingDialog = null;
-                //     console.log("uploading target data timed out");
-                //
-                //     // objects aren't fully initialized until they have a target.jpg, so we upload a screenshot to be the "icon"
-                //     realityEditor.app.getScreenshot('S', 'realityEditor.gui.ar.areaTargetScanner.onScreenshotReceived');
-                // }, 1500);
+                });
             }, 1000);
 
             showMessage('Successful capture.', 2000);

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ var realityEditor = realityEditor || {
         utilities: {}
     },
     network: {
+        discovery: {},
         frameContentAPI: {},
         availableFrames: {},
         realtime: {},

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -1,0 +1,10 @@
+createNameSpace("realityEditor.network.discovery");
+
+(function(exports) {
+    let heartbeatMap = {};
+    function initService() {
+        realityEditor.network.addUDPMessageHandler('beat', () => {
+        });
+    }
+    exports.initService = initService;
+})(realityEditor.network.discovery);

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -1,10 +1,52 @@
 createNameSpace("realityEditor.network.discovery");
 
 (function(exports) {
-    let heartbeatMap = {};
+
+    /* Structure:
+    {
+        '10.10.10.10': {
+            'feeder01_lkjh0987: { heartbeat }
+        },
+        '192.168.0.10: {
+            'testObject_asdf1234': { heartbeat },
+            '_WORLD_test_qwer2345: { heartbeat }
+        }
+    }
+    */
+    let discoveryMap = {};    
+
+    let callbacks = {
+        onServerDetected: [],
+        onObjectDetected: []
+    };
+    
     function initService() {
-        realityEditor.network.addUDPMessageHandler('beat', () => {
+        realityEditor.network.addUDPMessageHandler('id', (message) => {
+            if (typeof message.id === 'undefined' || typeof message.ip === 'undefined') {
+                return;
+            }
+            if (typeof discoveryMap[message.ip] === 'undefined') {
+                discoveryMap[message.ip] = {};
+            }
+            discoveryMap[message.ip][message.id] = message;
         });
     }
+    
+    exports.onServerDetected = (callback) => {
+        callbacks.onServerDetected.push(callback);
+    }
+    
+    exports.onObjectDetected = (callback) => {
+        callbacks.onObjectDetected.push(callback);
+    }
+    
+    exports.getDetectedServerIPs = () => {
+        return Object.keys(discoveryMap);
+    }
+    
+    exports.getDetectedObjectIDs = () => {
+        return Object.values(discoveryMap).map(serverContents => Object.keys(serverContents)).flat();
+    }
+    
     exports.initService = initService;
 })(realityEditor.network.discovery);

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -13,40 +13,110 @@ createNameSpace("realityEditor.network.discovery");
         }
     }
     */
-    let discoveryMap = {};    
+    let discoveryMap = {};
 
     let callbacks = {
         onServerDetected: [],
         onObjectDetected: []
     };
-    
+
+    // Allows us to pause object discovery from the time the app loads until we have finished scanning
+    let exceptions = []; // when scanning a world object, we add its name to the exceptions so we can still load it
+    let queuedHeartbeats = []; // heartbeats received while paused will be processed after resuming
+    let heartbeatsPaused = false;
+
+    exports.pauseObjectDetections = () => {
+        heartbeatsPaused = true;
+    }
+
+    exports.resumeObjectDetections = () => {
+        heartbeatsPaused = false;
+        processNextQueuedHeartbeat();
+    }
+
+    function processNextQueuedHeartbeat() {
+        if (queuedHeartbeats.length === 0) { return; }
+        let message = queuedHeartbeats.pop();
+        processHeartbeat(message);
+        setTimeout(processNextQueuedHeartbeat, 10); // process async to avoid overwhelming all at once
+    }
+
+    exports.addExceptionToPausedObjectDetections = (objectName) => {
+        exceptions.push(objectName);
+    }
+
     function initService() {
-        realityEditor.network.addUDPMessageHandler('id', (message) => {
-            if (typeof message.id === 'undefined' || typeof message.ip === 'undefined') {
-                return;
-            }
-            if (typeof discoveryMap[message.ip] === 'undefined') {
-                discoveryMap[message.ip] = {};
-            }
-            discoveryMap[message.ip][message.id] = message;
+        console.log('init network/discovery.js');
+
+        realityEditor.network.registerCallback('objectDeleted', (params) => {
+            deleteFromDiscoveryMap(params.objectIP, params.objectID);
         });
     }
-    
+
+    function deleteFromDiscoveryMap(ip, id) {
+        if (typeof discoveryMap[ip] === 'undefined') { return; }
+        if (typeof discoveryMap[ip][id] === 'undefined') { return; }
+        delete discoveryMap[ip][id];
+        // todo: trigger any callbacks? depends if other modules are subscribed to the full discoveryMap or not
+        // todo: can we detect when a server turns off so we can delete it from our map?
+    }
+
+    function updateDiscoveryMap(message) {
+        if (typeof discoveryMap[message.ip] === 'undefined') {
+            discoveryMap[message.ip] = {};
+            callbacks.onServerDetected.forEach(cb => cb(message.ip));
+        }
+        if (typeof discoveryMap[message.ip][message.id] === 'undefined') {
+            callbacks.onObjectDetected.forEach(cb => cb(message.ip));
+            discoveryMap[message.ip][message.id] = message;
+        }
+        // TODO: should this module concern itself with the heartbeat checksum? probably not, we are only concerned about presence
+    }
+
+    // This should be directly triggered by whatever is listening for UDP messages
+    function processHeartbeat(message) {
+        // upon a new object discovery message, add the object and download its target files
+        if (typeof message.id === 'undefined' || typeof message.ip === 'undefined') {
+            return;
+        }
+
+        updateDiscoveryMap(message);
+
+        let ignoreFromPause = false;
+        if (heartbeatsPaused) {
+            ignoreFromPause = !exceptions.some(name => message.id.includes(name));
+        }
+
+        if (realityEditor.device.environment.variables.suppressObjectDetections || ignoreFromPause) {
+            queuedHeartbeats.push(message);
+        } else {
+            if (typeof message.zone !== 'undefined' && message.zone !== '') {
+                if (realityEditor.gui.settings.toggleStates.zoneState && realityEditor.gui.settings.toggleStates.zoneStateText === message.zone) {
+                    realityEditor.network.addHeartbeatObject(message);
+                }
+            } else if (!realityEditor.gui.settings.toggleStates.zoneState) {
+                realityEditor.network.addHeartbeatObject(message);
+            }
+        }
+    }
+
     exports.onServerDetected = (callback) => {
         callbacks.onServerDetected.push(callback);
     }
-    
+
     exports.onObjectDetected = (callback) => {
         callbacks.onObjectDetected.push(callback);
     }
-    
+
     exports.getDetectedServerIPs = () => {
         return Object.keys(discoveryMap);
     }
-    
+
     exports.getDetectedObjectIDs = () => {
         return Object.values(discoveryMap).map(serverContents => Object.keys(serverContents)).flat();
     }
-    
+
     exports.initService = initService;
+    exports.processHeartbeat = processHeartbeat;
+
 })(realityEditor.network.discovery);

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -146,8 +146,20 @@ createNameSpace("realityEditor.network.discovery");
         })
         return matchingObjects;
     }
+    
+    function deleteObject(ip, id) {
+        // remove from discovery map
+        if (typeof discoveryMap[ip] !== 'undefined') {
+            delete discoveryMap[ip][id];
+        }
+        queuedHeartbeats = queuedHeartbeats.filter(message => {
+            return message.id !== id && message.ip !== ip;
+        });
+        console.log(discoveryMap, queuedHeartbeats);
+    }
 
     exports.initService = initService;
     exports.processHeartbeat = processHeartbeat;
+    exports.deleteObject = deleteObject;
 
 })(realityEditor.network.discovery);

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -908,13 +908,14 @@ realityEditor.network.onAction = function (action) {
 
         if (thisAction.reloadObject.object in objects) {
 
-            let urlEndpoint = realityEditor.network.getURL(objects[thisAction.reloadObject.object].ip, realityEditor.network.getPort(objects[thisAction.reloadObject.object]), '/object/' + thisAction.reloadObject.object);
+            let objectIP = objects[thisAction.reloadObject.object].ip;
+            let urlEndpoint = realityEditor.network.getURL(objectIP, realityEditor.network.getPort(objects[thisAction.reloadObject.object]), '/object/' + thisAction.reloadObject.object);
 
             this.getData(thisAction.reloadObject.object, thisAction.reloadObject.frame, null, urlEndpoint, function (objectKey, frameKey, nodeKey, res) {
 
                 if (!res) {
                     delete objects[objectKey];
-                    realityEditor.network.callbackHandler.triggerCallbacks('objectDeleted', {objectKey: objectKey});
+                    realityEditor.network.callbackHandler.triggerCallbacks('objectDeleted', { objectKey: objectKey, objectIP: objectIP });
                     return;
                 }
 

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -505,6 +505,16 @@ createNameSpace("realityEditor.network.realtime");
         }
         publicDataCache[frameKey][nodeKey] = node.publicData;
     }
+    
+    function sendDisconnectMessage(worldId) {
+        if (!worldId || !objects[worldId]) { return; }
+        let ioTitle = realityEditor.network.getIoTitle(objects[worldId].port, '/disconnectEditor');
+        let serverSocket = getServerSocketForObject(worldId);
+        if (!serverSocket) { return; }
+        serverSocket.emit(ioTitle, JSON.stringify({
+            editorId: globalStates.tempUuid
+        }));
+    }
 
     /**
      * Updates an object property on the server (and synchronizes all other clients if necessary) using a websocket
@@ -684,5 +694,7 @@ createNameSpace("realityEditor.network.realtime");
 
     exports.writePublicData = writePublicData;
     exports.subscribeToPublicData = subscribeToPublicData;
+    
+    exports.sendDisconnectMessage = sendDisconnectMessage; // trigger this when app closes / exits to menu to ensure avatar is deleted
 
 }(realityEditor.network.realtime));

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -505,7 +505,8 @@ createNameSpace("realityEditor.network.realtime");
         }
         publicDataCache[frameKey][nodeKey] = node.publicData;
     }
-    
+
+    // trigger this before doing window.location.reload() to ensure avatar is deleted (required if world is on local server)
     function sendDisconnectMessage(worldId) {
         if (!worldId || !objects[worldId]) { return; }
         let ioTitle = realityEditor.network.getIoTitle(objects[worldId].port, '/disconnectEditor');
@@ -695,6 +696,6 @@ createNameSpace("realityEditor.network.realtime");
     exports.writePublicData = writePublicData;
     exports.subscribeToPublicData = subscribeToPublicData;
     
-    exports.sendDisconnectMessage = sendDisconnectMessage; // trigger this when app closes / exits to menu to ensure avatar is deleted
+    exports.sendDisconnectMessage = sendDisconnectMessage;
 
 }(realityEditor.network.realtime));


### PR DESCRIPTION
- src/network/discovery.js handles heartbeat messages rather than all the logic being in the callbacks.js
- discovery.js has methods to pause/resume processing heartbeats, and to query which objects/servers it is aware of
- adds new Minimize button to envelope UI (currently same functionality as Close button but will update soon)
- adds new status messages while generating the area target
- fixes bug with avatar deletion on pop-up app by sending explicit disconnect message
- targetDownloader.js triggers callbacks that area target scanner can use to more precisely time its events

Remote operator requires a PR for compatibility with the discovery.js module