### PR TITLE
allows multiple modules to request that rendering be suppressed/allowed without overwriting each other 

### DIFF
--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -79,7 +79,7 @@ createNameSpace("realityEditor.device.environment");
     }
 
     exports.isObjectRenderingSuppressed = () => {
-        return Object.keys(suppressedRenderingFlags).length > 0 || realityEditor.device.environment.variables.suppressObjectRendering;
+        return Object.keys(suppressedRenderingFlags).length > 0 || variables.suppressObjectRendering;
     }
 
     /**

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -78,7 +78,7 @@ createNameSpace("realityEditor.device.environment");
         delete suppressedRenderingFlags[flagName];
     }
 
-    exports.suppressObjectRendering = () => {
+    exports.isObjectRenderingSuppressed = () => {
         return Object.keys(suppressedRenderingFlags).length > 0 || realityEditor.device.environment.variables.suppressObjectRendering;
     }
 

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -66,6 +66,22 @@ createNameSpace("realityEditor.device.environment");
     // however, rather than reading these variables directly, it is preferred to use the getters:
     // this is for compatibility with future plans which will add more logic to the variables
 
+    // using variables.suppressObjectRendering allows any module to overwrite any other module's preferences
+    // but a module can add a flag, and rendering will only re-enable when all flags are cleared
+    let suppressedRenderingFlags = {};
+
+    exports.addSuppressedObjectRenderingFlag = (flagName) => {
+        suppressedRenderingFlags[flagName] = true;
+    };
+
+    exports.clearSuppressedObjectRenderingFlag = (flagName) => {
+        delete suppressedRenderingFlags[flagName];
+    }
+
+    exports.suppressObjectRendering = () => {
+        return Object.keys(suppressedRenderingFlags).length > 0 || realityEditor.device.environment.variables.suppressObjectRendering;
+    }
+
     /**
      * Whether the environment contains a service that will trigger gui.ar.draw.update
      * If not, the editor will keep the update loop running while frozen to drive line animations.

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -255,7 +255,7 @@ realityEditor.gui.ar.draw.prevSuppressedRendering = false;
  * @param {Object.<string, Array.<number>>} visibleObjects - set of {objectId: matrix} pairs, one per recognized marker
  */
 realityEditor.gui.ar.draw.update = function (visibleObjects) {
-    if (realityEditor.device.environment.variables.suppressObjectRendering) {
+    if (realityEditor.device.environment.suppressObjectRendering()) {
         if (!this.prevSuppressedRendering) {
             let toolContainer = document.getElementById('GUI');
             let canvas = document.getElementById('canvas');

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -255,7 +255,7 @@ realityEditor.gui.ar.draw.prevSuppressedRendering = false;
  * @param {Object.<string, Array.<number>>} visibleObjects - set of {objectId: matrix} pairs, one per recognized marker
  */
 realityEditor.gui.ar.draw.update = function (visibleObjects) {
-    if (realityEditor.device.environment.suppressObjectRendering()) {
+    if (realityEditor.device.environment.isObjectRenderingSuppressed()) {
         if (!this.prevSuppressedRendering) {
             let toolContainer = document.getElementById('GUI');
             let canvas = document.getElementById('canvas');


### PR DESCRIPTION
This will let remote-operator-addon prevent tools from rendering before the world mesh loads, despite pop-up-addon saying that rendering is allowed