### PR TITLE
Allows setting a primaryWorld to ignore other world heartbeats

### DIFF
--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -120,13 +120,15 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
             if (typeof visibleObjects[sessionObjectId] !== 'undefined') {
                 hasFirstSeenInstantWorld = true;
 
-                getStatusTextfield().innerHTML = 'Successfully localized within new scan!'
-                getStatusTextfield().style.display = 'inline';
+                if (!realityEditor.device.environment.variables.overrideAreaTargetScanningUI) {
+                    getStatusTextfield().innerHTML = 'Successfully localized within new scan!'
+                    getStatusTextfield().style.display = 'inline';
 
-                setTimeout(function() {
-                    getStatusTextfield().innerHTML = '';
-                    getStatusTextfield().style.display = 'none';
-                }, 3000);
+                    setTimeout(function() {
+                        getStatusTextfield().innerHTML = '';
+                        getStatusTextfield().style.display = 'none';
+                    }, 3000);
+                }
             }
         });
 

--- a/src/gui/ar/groundPlaneRenderer.js
+++ b/src/gui/ar/groundPlaneRenderer.js
@@ -64,6 +64,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
     }
 
     function startVisualization() {
+        globalStates.useGroundPlane = true;
         if (!gridHelper) {
             // check that the ground plane exists before we start the visualization
             let gpId = realityEditor.sceneGraph.NAMES.GROUNDPLANE;
@@ -156,6 +157,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
     }
 
     function stopVisualization() {
+        globalStates.useGroundPlane = false;
         if (gridHelper) {
             realityEditor.gui.threejsScene.removeFromScene(gridHelper);
             gridHelper = null;
@@ -194,5 +196,7 @@ createNameSpace("realityEditor.gui.ar.groundPlaneRenderer");
     }
 
     exports.initService = initService;
+    exports.startVisualization = startVisualization;
+    exports.stopVisualization = stopVisualization;
 
 }(realityEditor.gui.ar.groundPlaneRenderer));

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -126,7 +126,6 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
     // use this helper function to update the camera matrix using the camera matrix from the sceneGraph
     function setCameraPosition(matrix) {
         setMatrixFromArray(camera.matrix, matrix);
-        // renderScene(true);
     }
 
     // adds an invisible plane to the ground that you can raycast against to fill in holes in the area target
@@ -143,7 +142,7 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
         groundPlaneCollider = plane;
     }
 
-    function renderScene(oneTimeOnly) {
+    function renderScene() {
         const deltaTime = Date.now() - lastFrameTime; // In ms
         lastFrameTime = Date.now();
 
@@ -221,9 +220,7 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
             renderer.render( scene, camera );
         }
 
-        if (!oneTimeOnly) {
-            requestAnimationFrame(renderScene);
-        }
+        requestAnimationFrame(renderScene);
     }
 
     function toggleDisplayOriginBoxes(newValue) {

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -126,6 +126,7 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
     // use this helper function to update the camera matrix using the camera matrix from the sceneGraph
     function setCameraPosition(matrix) {
         setMatrixFromArray(camera.matrix, matrix);
+        // renderScene(true);
     }
 
     // adds an invisible plane to the ground that you can raycast against to fill in holes in the area target
@@ -142,7 +143,7 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
         groundPlaneCollider = plane;
     }
 
-    function renderScene() {
+    function renderScene(oneTimeOnly) {
         const deltaTime = Date.now() - lastFrameTime; // In ms
         lastFrameTime = Date.now();
 
@@ -220,7 +221,9 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
             renderer.render( scene, camera );
         }
 
-        requestAnimationFrame(renderScene);
+        if (!oneTimeOnly) {
+            requestAnimationFrame(renderScene);
+        }
     }
 
     function toggleDisplayOriginBoxes(newValue) {

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -102,17 +102,17 @@ createNameSpace("realityEditor.network.discovery");
         }
     }
     
-    let exclusiveWorld = null;
+    let primaryWorld = null;
 
-    exports.setExclusiveWorld = (ip, id) => {
-        exclusiveWorld = {
+    exports.setPrimaryWorld = (ip, id) => {
+        primaryWorld = {
             ip: ip,
             id: id
         };
     }
 
-    exports.getExclusiveWorldInfo = () => {
-        return exclusiveWorld;
+    exports.getPrimaryWorldInfo = () => {
+        return primaryWorld;
     }
 
     exports.pauseObjectDetections = () => {

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -101,6 +101,19 @@ createNameSpace("realityEditor.network.discovery");
             }
         }
     }
+    
+    let exclusiveWorld = null;
+
+    exports.setExclusiveWorld = (ip, id) => {
+        exclusiveWorld = {
+            ip: ip,
+            id: id
+        };
+    }
+
+    exports.getExclusiveWorldInfo = () => {
+        return exclusiveWorld;
+    }
 
     exports.pauseObjectDetections = () => {
         heartbeatsPaused = true;
@@ -145,7 +158,7 @@ createNameSpace("realityEditor.network.discovery");
         serverContents.forEach(serverInfo => {
             Object.keys(serverInfo).forEach(objectId => {
                 let objectInfo = serverInfo[objectId];
-                if (objectInfo.metadata.type === type) {
+                if (objectInfo.metadata && objectInfo.metadata.type === type) {
                     matchingObjects.push(objectInfo);
                 }
             });

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -11,6 +11,8 @@ createNameSpace("realityEditor.network.discovery");
     let heartbeatsPaused = false;
     let isSystemInitializing = true; // pause heartbeats for the first instant while everything is still initializing
 
+    let primaryWorld = null; // if set, we will ignore processing all world heartbeats except for the primary world
+
     let callbacks = {
         onServerDetected: [],
         onObjectDetected: []
@@ -101,8 +103,6 @@ createNameSpace("realityEditor.network.discovery");
             }
         }
     }
-    
-    let primaryWorld = null;
 
     exports.setPrimaryWorld = (ip, id) => {
         primaryWorld = {

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -523,13 +523,13 @@ realityEditor.network.addHeartbeatObject = function (beat) {
             this.getData(beat.id,  null, null, baseUrl+queryParams, function (objectKey, frameKey, nodeKey, msg) {
                 if (msg && objectKey && !objects[objectKey]) {
 
-                    // ignore this object if it's a world object and the exclusiveWorld is set but not equal to this one
-                    let exclusiveWorldInfo = realityEditor.network.discovery.getExclusiveWorldInfo();
+                    // ignore this object if it's a world object and the primaryWorld is set but not equal to this one
+                    let primaryWorldInfo = realityEditor.network.discovery.getPrimaryWorldInfo();
                     let isLocalWorld = beat.id === realityEditor.worldObjects.getLocalWorldId();
-                    if (exclusiveWorldInfo && (msg.isWorldObject || msg.type === 'world') && !isLocalWorld) {
-                        let hasIpInfo = exclusiveWorldInfo.ip;
-                        if (beat.id !== exclusiveWorldInfo.id || (hasIpInfo && beat.ip !== exclusiveWorldInfo.ip)) {
-                            console.warn('ignoring adding world object ' + beat.id + ' because it doesnt match exclusive world ' + exclusiveWorldInfo.id);
+                    if (primaryWorldInfo && (msg.isWorldObject || msg.type === 'world') && !isLocalWorld) {
+                        let hasIpInfo = primaryWorldInfo.ip;
+                        if (beat.id !== primaryWorldInfo.id || (hasIpInfo && beat.ip !== primaryWorldInfo.ip)) {
+                            console.warn('ignoring adding world object ' + beat.id + ' because it doesnt match primary world ' + primaryWorldInfo.id);
                             return;
                         }
                     }

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -522,6 +522,18 @@ realityEditor.network.addHeartbeatObject = function (beat) {
             let queryParams = '?excludeUnpinned=true';
             this.getData(beat.id,  null, null, baseUrl+queryParams, function (objectKey, frameKey, nodeKey, msg) {
                 if (msg && objectKey && !objects[objectKey]) {
+
+                    // ignore this object if it's a world object and the exclusiveWorld is set but not equal to this one
+                    let exclusiveWorldInfo = realityEditor.network.discovery.getExclusiveWorldInfo();
+                    let isLocalWorld = beat.id === realityEditor.worldObjects.getLocalWorldId();
+                    if (exclusiveWorldInfo && (msg.isWorldObject || msg.type === 'world') && !isLocalWorld) {
+                        let hasIpInfo = exclusiveWorldInfo.ip;
+                        if (beat.id !== exclusiveWorldInfo.id || (hasIpInfo && beat.ip !== exclusiveWorldInfo.ip)) {
+                            console.warn('ignoring adding world object ' + beat.id + ' because it doesnt match exclusive world ' + exclusiveWorldInfo.id);
+                            return;
+                        }
+                    }
+
                     console.log('instantiating new object with server data' + beat.id, msg);
                     
                     // add the object


### PR DESCRIPTION
If you're trying to specifically join one world and want to ignore all other world objects, you can call `realityEditor.network.discovery.setPrimaryWorld(ip, id);`

The exact consequences of being the primary world can be changed in future, but there are at least a couple scenarios where I've wanted one world object to be prioritized, e.g.:
- a Join Menu that lets you choose which world to join (e.g. if I scanned a world on my device's 127.0.0.1 in the past but now want to be a virtualizer for one on my laptop's server)
- a remote operator localhost:8081/?world=myWorld URL that specifies which out of all of the worlds in the lab do I actually want to see