### PR TITLE
Fix merged raycast; Improve avatar pointermove filtering

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -246,6 +246,9 @@ createNameSpace("realityEditor.avatar");
 
         document.body.addEventListener('pointermove', (e) => {
             if (!isPointerDown || realityEditor.device.isMouseEventCameraControl(e)) { return; }
+            if (network.isTouchStateFpsLimited()) {
+                return;
+            }
             // update the beam position even if not hitting background, as long as we started on the background
             setBeamOn(e.pageX, e.pageY);
         });

--- a/src/avatar/network.js
+++ b/src/avatar/network.js
@@ -117,11 +117,19 @@ createNameSpace("realityEditor.avatar.network");
 
     // write the touchState into the avatar object's storage node (internally limits data rate to FPS_LIMIT)
     function sendTouchState(keys, touchState, options) {
-        let sendData = !(options && options.limitToFps) || (Date.now() - lastWritePublicDataTimestamp > (1000 / DATA_SEND_FPS_LIMIT));
+        let sendData = !(options && options.limitToFps) || !isTouchStateFpsLimited();
         if (sendData) {
             realityEditor.network.realtime.writePublicData(keys.objectKey, keys.frameKey, keys.nodeKey, realityEditor.avatar.utils.PUBLIC_DATA_KEYS.touchState, touchState);
             lastWritePublicDataTimestamp = Date.now();
         }
+    }
+
+    /**
+     * Helper function to provide insight into the fps limiter
+     * @return {boolean}
+     */
+    function isTouchStateFpsLimited() {
+        return Date.now() - lastWritePublicDataTimestamp < (1000 / DATA_SEND_FPS_LIMIT);
     }
 
     // write the username into the avatar object's storage node
@@ -184,6 +192,7 @@ createNameSpace("realityEditor.avatar.network");
     exports.onAvatarDeleted = onAvatarDeleted;
     exports.onLoadOcclusionObject = onLoadOcclusionObject;
     exports.realtimeSendAvatarPosition = realtimeSendAvatarPosition;
+    exports.isTouchStateFpsLimited = isTouchStateFpsLimited;
     exports.sendTouchState = sendTouchState;
     exports.sendUserProfile = sendUserProfile;
     exports.processPendingAvatarInitializations = processPendingAvatarInitializations;

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -395,7 +395,9 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
                 mergedGeometry.computeBoundingBox();
 
                 // Add the BVH to the boundsTree variable so that the acceleratedRaycast can work
-                mergedGeometry.boundsTree = new MeshBVH( mergedGeometry );
+                gltf.scene.children.map(child => {
+                    child.geometry.boundsTree = new MeshBVH(child.geometry);
+                });
 
                 wireMesh = new THREE.Mesh(mergedGeometry, wireMaterial);
             }


### PR DESCRIPTION
Before:
<img width="1205" alt="before" src="https://user-images.githubusercontent.com/55107443/189374021-01d49150-5600-4cd8-96bb-1f92fcad6c53.png">

After:
<img width="1205" alt="after-both" src="https://user-images.githubusercontent.com/55107443/189374267-033ce3b7-5b7a-461c-8e38-fbed68e5e8d9.png">

I believe this closes the book on Vuforia 10.9 making area targets multi-mesh mapping mayhem