### PR TITLE
Avatar sends keepObjectAlive UDP message on a 10 second interval

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -12,6 +12,8 @@ createNameSpace("realityEditor.avatar");
 
     let network, draw, utils; // shortcuts to access realityEditor.avatar._____
 
+    const KEEP_ALIVE_HEARTBEAT_INTERVAL = 10000; // once per 10 seconds
+
     let myAvatarId = null;
     let myAvatarObject = null;
     let avatarObjects = {}; // avatar objects are stored here, so that we know which ones we've discovered/initialized
@@ -130,6 +132,12 @@ createNameSpace("realityEditor.avatar");
                 writeUsername(myUsername);
             }
         });
+
+        setInterval(() => {
+            if (myAvatarId && myAvatarObject) {
+                network.keepObjectAlive(myAvatarId);
+            }
+        }, KEEP_ALIVE_HEARTBEAT_INTERVAL);
     }
 
     // initialize the avatar object representing my own device, and those representing other devices

--- a/src/avatar/network.js
+++ b/src/avatar/network.js
@@ -174,6 +174,11 @@ createNameSpace("realityEditor.avatar.network");
         });
     }
 
+    // signal the server that this avatar object is still active and shouldn't be deleted
+    function keepObjectAlive(objectKey) {
+        realityEditor.app.sendUDPMessage({type: 'keepObjectAlive', objectKey: objectKey });
+    }
+
     exports.addAvatarObject = addAvatarObject;
     exports.onAvatarDiscovered = onAvatarDiscovered;
     exports.onAvatarDeleted = onAvatarDeleted;
@@ -185,5 +190,6 @@ createNameSpace("realityEditor.avatar.network");
     exports.processPendingAvatarInitializations = processPendingAvatarInitializations;
     exports.addPendingAvatarInitialization = addPendingAvatarInitialization;
     exports.subscribeToAvatarPublicData = subscribeToAvatarPublicData;
+    exports.keepObjectAlive = keepObjectAlive;
 
 }(realityEditor.avatar.network));


### PR DESCRIPTION
Keeps the avatar object alive while the app is open, even if the avatar isn't moving (e.g on remote operator, if you keep the camera perspective the same). 

Goes with https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/600, although neither strictly requires the other