### PR TITLE
Wrap native APIs in Promises for cleaner asynchronous getters

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
 
     <script src="src/app/index.js"></script>
     <script src="src/app/callbacks.js"></script>
+    <script src="src/app/promises.js"></script>
     <script src="src/app/targetDownloader.js"></script>
 
     <script src="src/addons/index.js"></script>

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -92,7 +92,9 @@ createNameSpace('realityEditor.app.callbacks');
         }
 
         // start the AR framework in native iOS
-        realityEditor.app.getVuforiaReady('realityEditor.app.callbacks.vuforiaIsReady');
+        realityEditor.app.promises.getVuforiaReady().then(success => {
+            vuforiaIsReady(success);
+        });
     }
 
     /**
@@ -213,20 +215,6 @@ createNameSpace('realityEditor.app.callbacks');
 
         // forward the message to a generic message handler that various modules use to subscribe to different messages
         realityEditor.network.onUDPMessage(message);
-    }
-
-    /**
-     * Callback for realityEditor.app.getDeviceReady
-     * Returns the native device name, which can be used to adjust the UI based on the phone/device type
-     * e.g. iPhone 6s is "iPhone8,1", iPhone 6s Plus is "iPhone8,2", iPhoneX is "iPhone10,3"
-     * see: https://gist.github.com/adamawolf/3048717#file-ios_device_types-txt
-     * or:  https://support.hockeyapp.net/kb/client-integration-ios-mac-os-x-tvos/ios-device-types
-     * @param {string} deviceName - e.g. "iPhone10,3" or "iPad2,1"
-     */
-    function getDeviceReady(deviceName) {
-        globalStates.device = deviceName;
-        console.log('The Reality Editor is loaded on a ' + globalStates.device);
-        realityEditor.device.layout.adjustForDevice(deviceName);
     }
 
     /**
@@ -737,7 +725,6 @@ createNameSpace('realityEditor.app.callbacks');
     exports.vuforiaIsReady = vuforiaIsReady;
     exports.receivedProjectionMatrix = receivedProjectionMatrix;
     exports.receivedUDPMessage = receivedUDPMessage;
-    exports.getDeviceReady = getDeviceReady;
     exports.receiveGroundPlaneMatricesFromAR = receiveGroundPlaneMatricesFromAR;
     exports.receiveMatricesFromAR = receiveMatricesFromAR;
     exports.receivePoses = receivePoses;

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -94,6 +94,8 @@ createNameSpace('realityEditor.app.callbacks');
         // start the AR framework in native iOS
         realityEditor.app.promises.getVuforiaReady().then(success => {
             vuforiaIsReady(success);
+        }).catch(reason => {
+            console.warn('getVuforiaReady rejected due to ' + reason);
         });
     }
 

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -94,8 +94,6 @@ createNameSpace('realityEditor.app.callbacks');
         // start the AR framework in native iOS
         realityEditor.app.promises.getVuforiaReady().then(success => {
             vuforiaIsReady(success);
-        }).catch(reason => {
-            console.warn('getVuforiaReady rejected due to ' + reason);
         });
     }
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -82,6 +82,14 @@ realityEditor.app.getVuforiaReady = function(callBack){
 };
 
 /**
+ * Checks if the device has a depth sensor, e.g. LiDAR, and thus supports Area Target Scanning
+ * @param {FunctionName} callBack
+ */
+realityEditor.app.doesDeviceHaveDepthSensor = function(callBack) {
+    this.appFunctionCall('doesDeviceHaveDepthSensor', null, 'realityEditor.app.callBack('+callBack+', [__ARG1__])');
+};
+
+/**
  * Adds a new marker and fires a callback with error or success
  * and the markerName for reference
  * @param {string} markerName

--- a/src/app/promises.js
+++ b/src/app/promises.js
@@ -1,0 +1,67 @@
+createNameSpace("realityEditor.app.promises");
+
+// provides a simpler interface to the native APIs
+(function(exports) {
+    // assume APIs fail if they take longer than 3 seconds to resolve, they should be almost instantaneous
+    const TIMEOUT = 3000;
+    const app = realityEditor.app;
+
+    // promises must be resolved externally due to the inner workings of how callbacks signatures get passed to swift
+    let deferredPromises = {
+        getDeviceReady: [],
+        doesDeviceHaveDepthSensor: [],
+        didGrantNetworkPermissions: []
+    };
+
+    exports.getDeviceReady = makeAPI(deferredPromises.getDeviceReady, app.getDeviceReady.bind(app), '_getDeviceReadyCallback');
+    exports._getDeviceReadyCallback = makeAPICallback(deferredPromises.getDeviceReady);
+
+    exports.didGrantNetworkPermissions = makeAPI(deferredPromises.didGrantNetworkPermissions, app.didGrantNetworkPermissions.bind(app), '_didGrantNetworkPermissionsCallback');
+    exports._didGrantNetworkPermissionsCallback = makeAPICallback(deferredPromises.didGrantNetworkPermissions);
+
+    exports.getVuforiaReady = makeAPI(deferredPromises.getVuforiaReady, app.getVuforiaReady.bind(app), '_getVuforiaReadyCallback');
+    exports._getVuforiaReadyCallback = makeAPICallback(deferredPromises.getVuforiaReady);
+
+    exports.doesDeviceHaveDepthSensor = makeAPI(deferredPromises.doesDeviceHaveDepthSensor, app.doesDeviceHaveDepthSensor.bind(app), '_doesDeviceHaveDepthSensorCallback');
+    exports._doesDeviceHaveDepthSensorCallback = makeAPICallback(deferredPromises.doesDeviceHaveDepthSensor);
+
+
+    // adapted from: https://stackoverflow.com/a/34637436 and https://www.30secondsofcode.org/articles/s/javascript-await-timeout
+    class Deferred {
+        constructor(maxDelay, onFinally) {
+            this.promise = Promise.race([
+                new Promise((resolve, reject) => {
+                    this.reject = reject;
+                    this.resolve = resolve;
+                }),
+                new Promise(resolve => {
+                    setTimeout(() => {
+                        resolve(); // todo: should this be a reject?
+                    }, maxDelay)
+                })
+            ]);
+            this.promise.finally(onFinally); // use this to clean up state after it's done
+        }
+    }
+
+    function makeAPI(deferredPromiseList, appFunctionCall, localCallbackSignature) {
+        return function() {
+            let deferred = new Deferred(TIMEOUT, () => {
+                deferredPromiseList.splice(deferredPromiseList.indexOf(deferred), 1);
+            });
+            deferredPromiseList.push(deferred);
+            appFunctionCall('realityEditor.app.promises.' + localCallbackSignature);
+            // realityEditor.app.getDeviceReady('realityEditor.app.promises._getDeviceReadyCallback');
+            return deferred.promise;
+        }
+    }
+
+    function makeAPICallback(deferredPromiseList) {
+        return function() {
+            deferredPromiseList.forEach(deferred => {
+                deferred.resolve.apply(null, arguments);
+            });
+        }
+    }
+
+})(realityEditor.app.promises);

--- a/src/app/promises.js
+++ b/src/app/promises.js
@@ -43,13 +43,14 @@ createNameSpace("realityEditor.app.promises");
     // The name of each resolve param should be included iff the native API returns multiple values
     function makeAPI(appFunctionCall, resolveParams) {
         return function() {
+            const functionUuid = '_proxy_' + realityEditor.device.utilities.uuidTime();
+
             // when the API is called, create a new Promise
             let deferred = new Deferred(() => {
                 delete realityEditor.app.promises._callbackProxies[functionUuid];
             });
 
             // create a new function to be used as the callback that is passed to the native code
-            const functionUuid = '_proxy_' + realityEditor.device.utilities.uuidTime();
             realityEditor.app.promises._callbackProxies[functionUuid] = function() {
                 // when the callback is triggered, resolve the promise
                 if (Array.from(arguments).length < 2) {

--- a/src/app/promises.js
+++ b/src/app/promises.js
@@ -1,103 +1,75 @@
 createNameSpace("realityEditor.app.promises");
 
-// provides a simpler interface to some native APIs which are essentially getters but act
-// asynchronously because of the communication channel with the native app
+/**
+ * @fileOverview
+ * Provides a simpler interface to some APIs defined in app/index.js, by wrapping them in a Promise
+ * APIs that return a single value vs those that return multiple values should be accessed like:
+ * getDeviceReady().then(deviceName => {})
+ * addNewMarker('target.xml').then(({success, fileName}) => {})
+ * APIs for subscriptions, such as the matrix stream, should still be accessed directly using app/index.js
+ */
 (function(exports) {
     const app = realityEditor.app;
 
-    // promises must be resolved externally due to the inner workings of how callbacks signatures get passed to swift.
-    // in the current implementation, if multiple calls to the same API are made before any of them resolve, then all
-    // pending API calls of that type will be resolved when the first API returns. this works for getters that will
-    // return a consistent value, but the approach should change in order to support other types of APIs
-    let deferredPromises = {
-        getDeviceReady: [],
-        didGrantNetworkPermissions: [],
-        getVuforiaReady: [],
-        doesDeviceHaveDepthSensor: []
-    };
+    // resolves to deviceName: string
+    exports.getDeviceReady = makeAPI(app.getDeviceReady.bind(app));
+    // resolves to success: boolean
+    exports.didGrantNetworkPermissions = makeAPI(app.didGrantNetworkPermissions.bind(app));
+    // resolves to success: boolean
+    exports.getVuforiaReady = makeAPI(app.getVuforiaReady.bind(app));
+    // resolves to success: boolean
+    exports.doesDeviceHaveDepthSensor = makeAPI(app.doesDeviceHaveDepthSensor.bind(app));
 
-    exports.getDeviceReady = makeAPI(deferredPromises.getDeviceReady, app.getDeviceReady.bind(app), '_getDeviceReadyCallback');
-    exports._getDeviceReadyCallback = makeAPICallback(deferredPromises.getDeviceReady);
+    // params: [markerName], resolves to: {success: boolean, fileName: string]}
+    exports.addNewMarker = makeAPI(app.addNewMarker.bind(app), ['success', 'fileName']);
+    // params: [markerName, objectID, targetWidthMeters], resolves to: {success: boolean, fileName: string]}
+    exports.addNewMarkerJPG = makeAPI(app.addNewMarkerJPG.bind(app), ['success', 'fileName']);
 
-    exports.didGrantNetworkPermissions = makeAPI(deferredPromises.didGrantNetworkPermissions, app.didGrantNetworkPermissions.bind(app), '_didGrantNetworkPermissionsCallback');
-    exports._didGrantNetworkPermissionsCallback = makeAPICallback(deferredPromises.didGrantNetworkPermissions);
-
-    exports.getVuforiaReady = makeAPI(deferredPromises.getVuforiaReady, app.getVuforiaReady.bind(app), '_getVuforiaReadyCallback');
-    exports._getVuforiaReadyCallback = makeAPICallback(deferredPromises.getVuforiaReady);
-
-    exports.doesDeviceHaveDepthSensor = makeAPI(deferredPromises.doesDeviceHaveDepthSensor, app.doesDeviceHaveDepthSensor.bind(app), '_doesDeviceHaveDepthSensorCallback');
-    exports._doesDeviceHaveDepthSensorCallback = makeAPICallback(deferredPromises.doesDeviceHaveDepthSensor);
-    
-    exports.addNewMarker = makeUniqueAPI(app.addNewMarker.bind(app));
-    
-    exports.callbackProxies = {};
-    exports.callbackUuidToDeferred = {};
-
-    function makeUniqueAPI(appFunctionCall, localCallbackSignature) {
-
-        return function() {
-
-            let deferred = new Deferred(undefined, () => {
-                delete realityEditor.app.promises.callbackProxies[functionUuid];
-            });
-            
-            // realityEditor.app.promises.callbackUuidToDeferred[functionUuid] = deferred;
-
-            const functionUuid = realityEditor.device.utilities.uuidTime();
-            realityEditor.app.promises.callbackProxies[functionUuid] = function() {
-                console.log('realityEditor.app.promises.' + localCallbackSignature);
-                // realityEditor.app.promises.callbackProxies[functionUuid].apply(null, arguments);
-                // realityEditor.app.promises[localCallbackSignature].apply(null, arguments);
-
-                deferred.resolve.apply(null, arguments);
-            };
-
-            const argumentsPlusCallback = Array.from(arguments);
-            argumentsPlusCallback.push('realityEditor.app.promises.callbackProxies.' + functionUuid);
-            appFunctionCall.apply(null, argumentsPlusCallback); //arguments, 'realityEditor.app.promises.callbackProxies.' + functionUuid);
-            return deferred.promise;
-        }
-    }
-
-    // adapted from: https://stackoverflow.com/a/34637436 and https://www.30secondsofcode.org/articles/s/javascript-await-timeout
+    // adapted from: https://stackoverflow.com/a/34637436
     class Deferred {
-        constructor(maxDelay, onFinally) {
-            let promiseList = [
-                new Promise((resolve, reject) => {
-                    this.reject = reject;
-                    this.resolve = resolve;
-                })
-            ];
-            if (typeof maxDelay !== 'undefined') {
-                promiseList.push(
-                    new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                            reject('API Timeout (' + maxDelay + 'ms)');
-                        }, maxDelay)
-                    })
-                );
-            }
-            this.promise = Promise.race(promiseList);
+        constructor(onFinally) {
+            this.promise = new Promise((resolve, reject) => {
+                this.reject = reject;
+                this.resolve = resolve;
+            });
             this.promise.finally(onFinally); // use this to clean up state after it's done
         }
     }
 
-    function makeAPI(deferredPromiseList, appFunctionCall, localCallbackSignature) {
-        return function(timeoutMs = undefined) { // timeout is optional, and will cause the API to reject if it exceeds this length
-            let deferred = new Deferred(timeoutMs, () => {
-                deferredPromiseList.splice(deferredPromiseList.indexOf(deferred), 1);
-            });
-            deferredPromiseList.push(deferred);
-            appFunctionCall('realityEditor.app.promises.' + localCallbackSignature);
-            return deferred.promise;
-        }
-    }
+    // exposes randomly generated public function signatures to resolve the deferred promises when the native code returns
+    exports._callbackProxies = {};
 
-    function makeAPICallback(deferredPromiseList) {
+    // Helper function to wrap the appFunctionCall in a deferred promise that will resolve when the native code finishes
+    // The name of each resolve param should be included iff the native API returns multiple values
+    function makeAPI(appFunctionCall, resolveParams) {
         return function() {
-            deferredPromiseList.forEach(deferred => {
-                deferred.resolve.apply(null, arguments);
+            // when the API is called, create a new Promise
+            let deferred = new Deferred(() => {
+                delete realityEditor.app.promises._callbackProxies[functionUuid];
             });
+
+            // create a new function to be used as the callback that is passed to the native code
+            const functionUuid = '_proxy_' + realityEditor.device.utilities.uuidTime();
+            realityEditor.app.promises._callbackProxies[functionUuid] = function() {
+                // when the callback is triggered, resolve the promise
+                if (Array.from(arguments).length < 2) {
+                    deferred.resolve.apply(null, arguments);
+                    return;
+                }
+
+                // if the native code returned multiple arguments, pack them into an object and resolve
+                let argMap = {};
+                Array.from(arguments).forEach((arg, i) => {
+                    argMap[resolveParams[i]] = arg;
+                });
+                deferred.resolve(argMap);
+            };
+
+            // the APIs in app/index.js expect the callback signature as the final argument
+            const argumentsPlusCallback = Array.from(arguments);
+            argumentsPlusCallback.push('realityEditor.app.promises._callbackProxies.' + functionUuid);
+            appFunctionCall.apply(null, argumentsPlusCallback);
+            return deferred.promise;
         }
     }
 

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -276,7 +276,9 @@ createNameSpace("realityEditor.app.targetDownloader");
             triggerDownloadStateCallbacks(objectID);
 
             var xmlFileName = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/obj/' + object.name + '/target/target.xml');
-            realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
+            realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
+                onMarkerAdded(success, fileName);
+            });
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
             targetDownloadStates[objectID].FILENAME = fileName;
             realityEditor.getObject(objectID).isJpgTarget = false;
@@ -656,7 +658,9 @@ createNameSpace("realityEditor.app.targetDownloader");
                     return fileName.indexOf('xml') > -1;
                 })[0];
 
-                realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
+                realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
+                    onMarkerAdded(success, fileName);
+                });
                 targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
                 targetDownloadStates[objectID].FILENAME = xmlFileName;
 
@@ -746,7 +750,9 @@ createNameSpace("realityEditor.app.targetDownloader");
         // synchronizes the two async download calls to add the marker when both tasks have completed
         var xmlFileName = isXML ? fileName : fileName.slice(0, -3) + 'xml';
         if (hasXML && hasDAT && markerNotAdded) {
-            realityEditor.app.addNewMarker(xmlFileName, moduleName + '.onMarkerAdded');
+            realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
+                onMarkerAdded(success, fileName);
+            });
             targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
             targetDownloadStates[objectID].FILENAME = fileName;
 
@@ -769,7 +775,9 @@ createNameSpace("realityEditor.app.targetDownloader");
                     targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
                 } else if (states.DAT === DownloadState.SUCCEEDED) {
                     console.log('>> add DAT target again: ' + objectID);
-                    realityEditor.app.addNewMarker(targetDownloadStates[objectID].FILENAME, moduleName + '.onMarkerAdded');
+                    realityEditor.app.promises.addNewMarker(targetDownloadStates[objectID].FILENAME).then(({success, fileName}) => {
+                        onMarkerAdded(success, fileName);
+                    });
                 }
             }
         });
@@ -824,7 +832,6 @@ createNameSpace("realityEditor.app.targetDownloader");
     exports.onTargetJPGDownloaded = onTargetJPGDownloaded;
     exports.onTargetGLBDownloaded = onTargetGLBDownloaded;
     exports.createNavmesh = createNavmesh;
-    exports.onMarkerAdded = onMarkerAdded;
     exports.doTargetFilesExist = doTargetFilesExist;
     exports.onTargetFileDownloaded = onTargetFileDownloaded;
 

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -368,7 +368,11 @@ realityEditor.device.onload = function () {
     realityEditor.avatar.initService();
     realityEditor.humanPose.initService();
 
-    realityEditor.app.getDeviceReady('realityEditor.app.callbacks.getDeviceReady');
+    realityEditor.app.promises.getDeviceReady().then(deviceName => {
+        globalStates.device = deviceName;
+        console.log('The Reality Editor is loaded on a ' + globalStates.device);
+        realityEditor.device.layout.adjustForDevice(deviceName);
+    });
 
     globalStates.tempUuid = realityEditor.device.utilities.uuidTimeShort();
     this.cout("This editor's session UUID: " + globalStates.tempUuid);
@@ -439,7 +443,9 @@ realityEditor.device.onload = function () {
     })();
     
     if (realityEditor.device.initFunctions.length === 0) {
-        realityEditor.app.didGrantNetworkPermissions('realityEditor.app.callbacks.receiveNetworkPermissions');
+        realityEditor.app.promises.didGrantNetworkPermissions().then(success => {
+            realityEditor.app.callbacks.receiveNetworkPermissions(success);
+        });
     } else {
         realityEditor.device.initFunctions.forEach(function(initFunction) {
             initFunction();

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -372,6 +372,8 @@ realityEditor.device.onload = function () {
         globalStates.device = deviceName;
         console.log('The Reality Editor is loaded on a ' + globalStates.device);
         realityEditor.device.layout.adjustForDevice(deviceName);
+    }).catch(reason => {
+        console.warn('getDeviceReady rejected due to ' + reason);
     });
 
     globalStates.tempUuid = realityEditor.device.utilities.uuidTimeShort();
@@ -445,6 +447,8 @@ realityEditor.device.onload = function () {
     if (realityEditor.device.initFunctions.length === 0) {
         realityEditor.app.promises.didGrantNetworkPermissions().then(success => {
             realityEditor.app.callbacks.receiveNetworkPermissions(success);
+        }).catch(reason => {
+            console.warn('didGrantNetworkPermissions rejected due to ' + reason);
         });
     } else {
         realityEditor.device.initFunctions.forEach(function(initFunction) {

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -372,8 +372,6 @@ realityEditor.device.onload = function () {
         globalStates.device = deviceName;
         console.log('The Reality Editor is loaded on a ' + globalStates.device);
         realityEditor.device.layout.adjustForDevice(deviceName);
-    }).catch(reason => {
-        console.warn('getDeviceReady rejected due to ' + reason);
     });
 
     globalStates.tempUuid = realityEditor.device.utilities.uuidTimeShort();
@@ -447,8 +445,6 @@ realityEditor.device.onload = function () {
     if (realityEditor.device.initFunctions.length === 0) {
         realityEditor.app.promises.didGrantNetworkPermissions().then(success => {
             realityEditor.app.callbacks.receiveNetworkPermissions(success);
-        }).catch(reason => {
-            console.warn('didGrantNetworkPermissions rejected due to ' + reason);
         });
     } else {
         realityEditor.device.initFunctions.forEach(function(initFunction) {

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -35,15 +35,24 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         onCaptureSuccessOrError: []
     };
 
-    /**
-     * Public init method to enable rendering ghosts of edited frames while in editing mode.
-     */
     function initService() {
         if (!realityEditor.device.environment.variables.supportsAreaTargetCapture) {
             console.log('This device doesn\'t support area target capture');
             return;
         }
 
+        realityEditor.app.promises.doesDeviceHaveDepthSensor().then(supportsCapture => {
+            if (supportsCapture) {
+                initServiceInternal();
+            } else {
+                console.log('No depth sensor - cant support area target capture');
+                realityEditor.device.environment.variables.supportsAreaTargetCapture = false;
+            }
+        });
+    }
+
+    // only gets called if we know we have access to LiDAR sensor / scanning capabilities
+    function initServiceInternal() {
         // wait until at least one server is detected
         // wait to see if any world objects are detected on that server
         // wait until camera device pose has been set / tracking is fully initialized
@@ -201,6 +210,11 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
     }
 
     function programmaticallyStartScan(serverIp) {
+        if (!realityEditor.device.environment.variables.supportsAreaTargetCapture) {
+            console.log("Dont start scanning because device has no depth (LiDAR) sensor");
+            return;
+        }
+
         if (typeof serverIp !== 'undefined') {
             createPendingWorldObject(serverIp);
         } else {

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -48,6 +48,9 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                 console.log('No depth sensor - cant support area target capture');
                 realityEditor.device.environment.variables.supportsAreaTargetCapture = false;
             }
+        }).catch(reason => {
+            console.warn('doesDeviceHaveDepthSensor rejected due to ' + reason);
+            realityEditor.device.environment.variables.supportsAreaTargetCapture = false;
         });
     }
 

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -48,9 +48,6 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
                 console.log('No depth sensor - cant support area target capture');
                 realityEditor.device.environment.variables.supportsAreaTargetCapture = false;
             }
-        }).catch(reason => {
-            console.warn('doesDeviceHaveDepthSensor rejected due to ' + reason);
-            realityEditor.device.environment.variables.supportsAreaTargetCapture = false;
         });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ var objects = {}; // TODO: this is a duplicate definition from src/objects.js
 var realityEditor = realityEditor || {
     app: {
         callbacks: {},
+        promises: {},
         targetDownloader: {}
     },
     device: {


### PR DESCRIPTION
While implementing the `doesDeviceHaveDepthSensor` API, it felt about time to make a cleaner way to call them. Tried not to refactor too many APIs at once, but wrapped a few more in this style for now.