### PR TITLE
removes preventDefault from keyboard events so that browser shortcuts…

### DIFF
--- a/src/device/keyboardEvents.js
+++ b/src/device/keyboardEvents.js
@@ -40,8 +40,6 @@ createNameSpace("realityEditor.device.keyboardEvents");
      * @param {KeyboardEvent} event
      */
     function keyUpHandler(event) {
-        event.preventDefault();
-        
         callbackHandler.triggerCallbacks('keyUpHandler', {event: event});
     }
 
@@ -50,8 +48,6 @@ createNameSpace("realityEditor.device.keyboardEvents");
      * @param {KeyboardEvent} event
      */
     function keyDownHandler(event) {
-        event.preventDefault();
-        
         callbackHandler.triggerCallbacks('keyDownHandler', {event: event});
     }
 


### PR DESCRIPTION
… still work on remote operator. I don't think this should have side-effects in the AR app?

Remote operator also has a couple `event.preventDefault()`s in its KeyboardListener.js, but the userinterface ones in this PR need to be removed too.