### PR TITLE
Add tools at the spatial cursor, and snap cursor to overlapping tools

### DIFF
--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -367,6 +367,7 @@ realityEditor.device.onload = function () {
     // realityEditor.device.multiclientUI.initService();
     realityEditor.avatar.initService();
     realityEditor.humanPose.initService();
+    realityEditor.spatialCursor.initService();
 
     realityEditor.app.promises.getDeviceReady().then(deviceName => {
         globalStates.device = deviceName;

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1190,7 +1190,9 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
             finalMatrix = utilities.copyMatrix(realityEditor.sceneGraph.getCSSMatrix(activeKey));
 
             if (activeVehicle.alwaysFaceCamera === true) {
-                let modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrixLookingAt(activeKey, 'CAMERA');
+                let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(activeKey, 'CAMERA');
+                let modelViewMatrix = [];
+                utilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
                 utilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
             }
 
@@ -1321,7 +1323,15 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
 
                     if (activeVehicle.sendMatrix === true) {
                         // TODO ben: send translation iff not three.js fullscreen
-                        thisMsg.modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrix(activeVehicle.uuid);
+                        if (activeVehicle.alwaysFaceCamera) {
+                            // thisMsg.modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrixLookingAt(activeVehicle.uuid, 'CAMERA');
+                            let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(activeVehicle.uuid, 'CAMERA');
+                            let modelViewMatrix = [];
+                            utilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
+                            thisMsg.modelViewMatrix = modelViewMatrix;
+                        } else {
+                            thisMsg.modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrix(activeVehicle.uuid);
+                        }
                     }
 
                     if (sendMatrices.model === true) {
@@ -1650,6 +1660,12 @@ realityEditor.gui.ar.draw.addPocketVehicle = function(pocketContainer) {
     var activeFrameKey = pocketContainer.vehicle.frameId || pocketContainer.vehicle.uuid;
     var activeNodeKey = pocketContainer.vehicle.uuid === activeFrameKey ? null : pocketContainer.vehicle.uuid;
 
+    let spatialCursorMatrix = realityEditor.spatialCursor.getOrientedCursorRelativeToWorldObject();
+    if (spatialCursorMatrix) {
+        this.addPocketVehicleAtCursorPosition(pocketContainer);
+        return;
+    }
+
     let distanceInFrontOfCamera = 400 * realityEditor.device.environment.variables.newFrameDistanceMultiplier;
     realityEditor.gui.ar.positioning.moveFrameToCamera(pocketContainer.vehicle.objectId, activeKey, distanceInFrontOfCamera);
 
@@ -1695,6 +1711,27 @@ realityEditor.gui.ar.draw.addPocketVehicle = function(pocketContainer) {
     //     realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, newMatrixValue);
     // }, 500);
 };
+
+realityEditor.gui.ar.draw.addPocketVehicleAtCursorPosition = function(pocketContainer) {
+    // clear some flags so it gets rendered after this occurs
+    pocketContainer.positionOnLoad = null;
+    pocketContainer.waitingToRender = false;
+
+    realityEditor.device.resetEditingState();
+
+    setTimeout(() => {
+        let newModelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(pocketContainer.vehicle.uuid, 'CAMERA');
+        let inverseObjectModelMatrix = realityEditor.gui.ar.utilities.invertMatrix(realityEditor.sceneGraph.getSceneNodeById(pocketContainer.vehicle.objectId).worldMatrix);
+        let modelRelativeToParent = [];
+        realityEditor.gui.ar.utilities.multiplyMatrix(inverseObjectModelMatrix, newModelMatrix, modelRelativeToParent);
+
+        let vehicleSceneNode = realityEditor.sceneGraph.getSceneNodeById(pocketContainer.vehicle.uuid);
+        vehicleSceneNode.setLocalMatrix(modelRelativeToParent);
+        console.log('set initial model matrix to face the camera');
+    }, 100);
+
+    realityEditor.network.postVehiclePosition(pocketContainer.vehicle);
+}
 
 /**
  * Run an animation on the frame being dropped in from the pocket, performing a smooth tweening of its last matrix element

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -1455,15 +1455,15 @@ function polyfillWebkitConvertPointFromPageToNode() {
         return A[0] * B[0] + A[1] * B[1] + A[2] * B[2];
     }
 
-    function getRight(M) {
+    function getRightVector(M) {
         return normalize([M[0], M[1], M[2]]);
     }
 
-    function getUp(M) {
+    function getUpVector(M) {
         return normalize([M[4], M[5], M[6]]);
     }
 
-    function getForward(M) {
+    function getForwardVector(M) {
         return normalize([M[8], M[9], M[10]]);
     }
 
@@ -1474,7 +1474,7 @@ function polyfillWebkitConvertPointFromPageToNode() {
     exports.normalize = normalize;
     exports.crossProduct = crossProduct;
     exports.dotProduct = dotProduct;
-    exports.getRight = getRight;
-    exports.getUp = getUp;
-    exports.getForward = getForward;
+    exports.getRightVector = getRightVector;
+    exports.getUpVector = getUpVector;
+    exports.getForwardVector = getForwardVector;
 })(realityEditor.gui.ar.utilities);

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -1455,5 +1455,26 @@ function polyfillWebkitConvertPointFromPageToNode() {
         return A[0] * B[0] + A[1] * B[1] + A[2] * B[2];
     }
 
+    function getRight(M) {
+        return normalize([M[0], M[1], M[2]]);
+    }
+
+    function getUp(M) {
+        return normalize([M[4], M[5], M[6]]);
+    }
+
+    function getForward(M) {
+        return normalize([M[8], M[9], M[10]]);
+    }
+
     exports.lookAt = lookAt;
+    exports.negate = negate;
+    exports.add = add;
+    exports.magnitude = magnitude;
+    exports.normalize = normalize;
+    exports.crossProduct = crossProduct;
+    exports.dotProduct = dotProduct;
+    exports.getRight = getRight;
+    exports.getUp = getUp;
+    exports.getForward = getForward;
 })(realityEditor.gui.ar.utilities);

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -1136,6 +1136,11 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
 
             realityEditor.network.toBeInitialized[frameID] = true;
 
+            let spatialCursorMatrix = realityEditor.spatialCursor.getOrientedCursorRelativeToWorldObject();
+            if (spatialCursorMatrix) {
+                frame.ar.matrix = spatialCursorMatrix;
+            }
+
             realityEditor.sceneGraph.addFrame(frame.objectId, frameID, frame, frame.ar.matrix);
             realityEditor.gui.ar.groundPlaneAnchors.sceneNodeAdded(frame.objectId, frameID, frame, frame.ar.matrix);
 

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -3409,9 +3409,9 @@ realityEditor.network.updateGroupings = function(ip, objectKey, frameKey, newGro
 /**
  * Makes a POST request to update the (x,y,scale,matrix) position data of a frame or node on the server
  * @param {Frame|Node} activeVehicle
- * @param {boolean|undefined} ignoreMatrix - include this if you only want to update (x,y,scale) not the transformation matrix
+ * @param {boolean} ignoreMatrix - include this if you only want to update (x,y,scale) not the transformation matrix
  */
-realityEditor.network.postVehiclePosition = function(activeVehicle, ignoreMatrix) {
+realityEditor.network.postVehiclePosition = function(activeVehicle, ignoreMatrix = false) {
     if (activeVehicle) {
         var positionData = realityEditor.gui.ar.positioning.getPositionData(activeVehicle);
         var content = {};

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -176,12 +176,14 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return worldIntersectPoint; // these are relative to the world object
     }
 
+    // gets the position relative to groundplane (common coord system for threejsScene)
     function getToolPosition(toolId) {
         let toolSceneNode = realityEditor.sceneGraph.getSceneNodeById(toolId);
         let groundPlaneNode = realityEditor.sceneGraph.getGroundPlaneNode();
         return realityEditor.sceneGraph.convertToNewCoordSystem({x: 0, y: 0, z: 0}, toolSceneNode, groundPlaneNode);
     }
 
+    // gets the direction the tool is facing, within the coordinate system of the groundplane
     function getToolForwardVector(toolId) {
         let toolSceneNode = realityEditor.sceneGraph.getSceneNodeById(toolId);
         let groundPlaneNode = realityEditor.sceneGraph.getGroundPlaneNode();

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -96,6 +96,12 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             let overlappingDivs = realityEditor.device.utilities.getAllDivsUnderCoordinate(screenX, screenY);
             // console.log(overlappingDivs);
             overlapped = overlappingDivs.some(element => element.tagName === 'IFRAME');
+            if (overlapped) {
+                let overlappingIframe = overlappingDivs.find(element => element.tagName === 'IFRAME');
+                let position = getToolPosition(overlappingIframe.dataset.frameKey);
+                indicator.position.set(position.x, position.y, position.z);
+                indicator.quaternion.setFromUnitVectors(indicatorAxis, getToolForwardVector(overlappingIframe.dataset.frameKey));
+            }
         });
     }
 
@@ -168,6 +174,20 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         }
         // console.log(`%c ${worldIntersectPoint.point}`, 'color: orange');
         return worldIntersectPoint; // these are relative to the world object
+    }
+
+    function getToolPosition(toolId) {
+        let toolSceneNode = realityEditor.sceneGraph.getSceneNodeById(toolId);
+        let groundPlaneNode = realityEditor.sceneGraph.getGroundPlaneNode();
+        return realityEditor.sceneGraph.convertToNewCoordSystem({x: 0, y: 0, z: 0}, toolSceneNode, groundPlaneNode);
+    }
+
+    function getToolForwardVector(toolId) {
+        let toolSceneNode = realityEditor.sceneGraph.getSceneNodeById(toolId);
+        let groundPlaneNode = realityEditor.sceneGraph.getGroundPlaneNode();
+        let toolMatrix = realityEditor.sceneGraph.convertToNewCoordSystem(realityEditor.gui.ar.utilities.newIdentityMatrix(), toolSceneNode, groundPlaneNode);
+        let forwardVector = realityEditor.gui.ar.utilities.getForward(toolMatrix);
+        return new THREE.Vector3(forwardVector[0], forwardVector[1], forwardVector[2]);
     }
 
     function getCursorRelativeToWorldObject() {

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -110,7 +110,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     function updateSpatialCursor() {
         if (typeof worldIntersectPoint.point !== 'undefined') {
             let position = new THREE.Vector3(worldIntersectPoint.point.x, worldIntersectPoint.point.y, worldIntersectPoint.point.z);
-            position.add(worldIntersectPoint.normalVector.multiplyScalar(worldIntersectOffsetDist));
+            // position.add(worldIntersectPoint.normalVector.multiplyScalar(worldIntersectOffsetDist));
             indicator.position.set(position.x, position.y, position.z);
             indicator.quaternion.setFromUnitVectors(indicatorAxis, worldIntersectPoint.normalVector);
         }
@@ -170,5 +170,67 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return worldIntersectPoint; // these are relative to the world object
     }
 
+    function getCursorRelativeToWorldObject() {
+        if (!cachedWorldObject || !cachedOcclusionObject) { return null; }
+
+        let cursorMatrix = indicator.matrixWorld.clone(); // in ROOT coordinates
+        let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
+        return realityEditor.sceneGraph.convertToNewCoordSystem(cursorMatrix, realityEditor.sceneGraph.getSceneNodeById('ROOT'), worldSceneNode);
+    }
+
+    // we need to apply multiple transformations to rotate the spatial cursor so that its local up vector is
+    // best aligned with the global up, it faces towards the camera rather than away, and if it's on a
+    // horizontal surface, it rotates so that its local up vector is in line with the camera forward vector
+    function getOrientedCursorRelativeToWorldObject() {
+        let spatialCursorMatrix = getCursorRelativeToWorldObject();
+        if (spatialCursorMatrix) {
+            const utils = realityEditor.gui.ar.utilities;
+            let rotatedMatrix = utils.copyMatrix(spatialCursorMatrix.elements);
+            let forwardVector = utils.getForward(rotatedMatrix); // utils.normalize([rotatedMatrix[8], rotatedMatrix[9], rotatedMatrix[10]]);
+            // TODO: may need to convert this relative to world object, but for now global up and world up are aligned anyways
+            let globalUpVector = [0, -1, 0];
+
+            // crossing forward vector with desired up vector yields new right vector
+            // then cross new right with forward to get orthogonal local up vector (similar to camera lookAt math)
+
+            let newRightVector = utils.normalize(utils.crossProduct(forwardVector, globalUpVector));
+            // handle co-linear case by reverting to original axis
+            if (isNaN(newRightVector[0])) { newRightVector = utils.getRight(rotatedMatrix); }
+
+            let newUpVector = utils.normalize(utils.crossProduct(newRightVector, forwardVector));
+            if (isNaN(newUpVector[0])) { newUpVector = utils.getUp(rotatedMatrix); }
+
+            let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
+            let cameraRelativeToWorldObject = realityEditor.sceneGraph.convertToNewCoordSystem(utils.newIdentityMatrix(), realityEditor.sceneGraph.getCameraNode(), worldSceneNode);
+
+            // compute dot product of camera forward and new tool forward to see whether it's facing towards or away from you
+            let cameraForward = utils.normalize([cameraRelativeToWorldObject[8], cameraRelativeToWorldObject[9], cameraRelativeToWorldObject[10]]);
+
+            // check if it is upright enough to be considered on a horizontal surface – 0.9 seems to work well
+            if (Math.abs(utils.dotProduct(forwardVector, globalUpVector)) > 0.9) {
+                // math works out same as above, except the camera forward is the desired "up vector" in this case
+                newRightVector = utils.normalize(utils.crossProduct(forwardVector, cameraForward));
+                if (isNaN(newRightVector[0])) { newRightVector = utils.getRight(rotatedMatrix); }
+
+                newUpVector = utils.normalize(utils.crossProduct(newRightVector, forwardVector));
+                if (isNaN(newUpVector[0])) { newUpVector = utils.getUp(rotatedMatrix); }
+            }
+
+            // if normals are inverted and tool ends up facing away from camera instead of towards it, flip it left-right again
+            let dotProduct = utils.dotProduct(cameraForward, forwardVector);
+
+            // assign the new right and up vectors to the tool matrix, keeping its forward the same
+            rotatedMatrix[0] = newRightVector[0] * Math.sign(dotProduct);
+            rotatedMatrix[1] = newRightVector[1] * Math.sign(dotProduct);
+            rotatedMatrix[2] = newRightVector[2] * Math.sign(dotProduct);
+            rotatedMatrix[4] = newUpVector[0];
+            rotatedMatrix[5] = newUpVector[1];
+            rotatedMatrix[6] = newUpVector[2];
+
+            return rotatedMatrix;
+        }
+    }
+
     exports.initService = initService;
+    exports.getOrientedCursorRelativeToWorldObject = getOrientedCursorRelativeToWorldObject;
 }(realityEditor.spatialCursor));

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -17,7 +17,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     };
     
     // offset the spatial cursor with the worldIntersectPoint to avoid clipping plane issues
-    const worldIntersectOffsetDist = 15;
+    // const worldIntersectOffsetDist = 15;
     const indicatorAxis = new THREE.Vector3(0, 0, 1);
     // const normalCursorMaterial = new THREE.ShaderMaterial({
     //     vertexShader: realityEditor.spatialCursor.shader.vertexShader.vertexShaderCode,


### PR DESCRIPTION
1. This adds the ability to add tools at the spatial cursor position. Extra calculations are included to rotate the added tools so that they appear upright relative to the global up vector.
2. I've also added a new helper function, `realityEditor.sceneGraph.convertToNewCoordSystem(point, oldSystem, newSystem)` to help simplify calculations in the future.
3. I also added some functions to the spatialCursor/index.js to snap the position and rotation of the cursor to the overlapping tool iframe.