### PR TITLE
Improved dragging calculations for 3D tools (and 2D tools if viewing from a non-perpendicular angle)

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -329,8 +329,7 @@ realityEditor.device.postEventIntoIframe = function(event, frameKey, nodeKey) {
         this.cachedOcclusionObject = realityEditor.gui.threejsScene.getObjectForWorldRaycasts(this.cachedWorldObject.objectId);
         if (this.cachedOcclusionObject) {
             this.cachedOcclusionObject.updateMatrixWorld();
-            this.cachedOcclusionObject.children[0].geometry.computeFaceNormals()
-            this.cachedOcclusionObject.children[0].geometry.computeVertexNormals()
+            this.cachedOcclusionObject.children[0].geometry.computeVertexNormals();
         }
     }
 

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -191,6 +191,56 @@ realityEditor.gui.ar.positioning.stopRepositioning = function() {
 // both are working but further investigation is needed to determine if one is always better than the other
 realityEditor.gui.ar.positioning.useWebkitForProjectedCoordinates = true;
 
+realityEditor.gui.ar.positioning.resetVehicleTranslation = function(activeVehicle) {
+    let positionData = this.getPositionData(activeVehicle);
+    positionData.x = 0;
+    positionData.y = 0;
+
+    // flags the sceneNode as dirty so it gets rendered again with the new x/y position
+    realityEditor.sceneGraph.updatePositionData(activeVehicle.uuid);
+
+    // broadcasts this to the realtime system if it's enabled
+    if (!realityEditor.gui.settings.toggleStates.realtimeEnabled) { return; }
+
+    let keys = realityEditor.getKeysFromVehicle(activeVehicle);
+    let propertyPath = activeVehicle.hasOwnProperty('visualization') ? 'ar.x' : 'x';
+    realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, positionData.x);
+    propertyPath = activeVehicle.hasOwnProperty('visualization') ? 'ar.y' : 'y';
+    realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, positionData.y);
+}
+
+realityEditor.gui.ar.positioning.moveVehiclePreservingDistance = function(activeVehicle, screenX, screenY) {
+    let distanceToCamera = realityEditor.sceneGraph.getDistanceToCamera(activeVehicle.uuid);
+    let toolNode = realityEditor.sceneGraph.getSceneNodeById(activeVehicle.uuid);
+    let outputCoordinateSystem = toolNode.parent;
+    let point = realityEditor.sceneGraph.getPointAtDistanceFromCamera(screenX, screenY, distanceToCamera, outputCoordinateSystem);
+
+    let positionData = this.getPositionData(activeVehicle);
+    if (positionData.x !== 0 || positionData.y !== 0) {
+        this.resetVehicleTranslation(activeVehicle);
+    }
+
+    // keep the rotation and scale the same but update the translation elements of the matrix
+    let matrixCopy = realityEditor.gui.ar.utilities.copyMatrix(toolNode.localMatrix);
+    matrixCopy[12] = point.x;
+    matrixCopy[13] = point.y;
+    matrixCopy[14] = point.z;
+    toolNode.setLocalMatrix(matrixCopy);
+}
+
+realityEditor.gui.ar.positioning.shouldPreserveDistanceWhileMoving = function(activeVehicle) {
+    // always move 3D tools
+    if (activeVehicle.fullScreen) return true;
+
+    // preserve distance while moving a 2D tool if the plane that the tool sits on isn't roughly parallel to the camera
+    const DIRECTION_SIMILARITY_THRESHOLD = 0.8;
+    const utils = realityEditor.gui.ar.utilities;
+    let toolDirection = utils.getForwardVector(realityEditor.sceneGraph.getSceneNodeById(activeVehicle.uuid).worldMatrix);
+    let cameraDirection = utils.getForwardVector(realityEditor.sceneGraph.getCameraNode().worldMatrix);
+    let dotProduct = utils.dotProduct(toolDirection, cameraDirection); // 1=parallel, 0=perpendicular
+    return (Math.abs(dotProduct) < DIRECTION_SIMILARITY_THRESHOLD);
+}
+
 /**
  * Primary method to move a transformed frame or node to the (x,y) point on its plane where the (screenX,screenY) ray cast intersects
  * @param {Frame|Node} activeVehicle
@@ -203,7 +253,10 @@ realityEditor.gui.ar.positioning.useWebkitForProjectedCoordinates = true;
  *                                 if true, you are expected to manually call stopRepositioning when done
  */
 realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinate = function(activeVehicle, screenX, screenY, useTouchOffset, isContinuous) {
-    
+    if (this.shouldPreserveDistanceWhileMoving(activeVehicle)) {
+        return this.moveVehiclePreservingDistance(activeVehicle, screenX, screenY);
+    }
+
     var newPosition;
     try {
         // set dummy div transform to iframe without x,y,scale

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -191,6 +191,11 @@ realityEditor.gui.ar.positioning.stopRepositioning = function() {
 // both are working but further investigation is needed to determine if one is always better than the other
 realityEditor.gui.ar.positioning.useWebkitForProjectedCoordinates = true;
 
+/**
+ * Removes the x and y translation offsets from the vehicle so that its position is purely determined by its matrix
+ * This should be done if you want to directly set the position of a tool to a given matrix
+ * @param {Frame|Node} activeVehicle
+ */
 realityEditor.gui.ar.positioning.resetVehicleTranslation = function(activeVehicle) {
     let positionData = this.getPositionData(activeVehicle);
     positionData.x = 0;
@@ -209,6 +214,12 @@ realityEditor.gui.ar.positioning.resetVehicleTranslation = function(activeVehicl
     realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, positionData.y);
 }
 
+/**
+ * Moves the tool to be centered on the screen (x,y) position, keeping it the same distance from the camera as before
+ * @param {Frame|Node} activeVehicle
+ * @param {number} screenX
+ * @param {number} screenY
+ */
 realityEditor.gui.ar.positioning.moveVehiclePreservingDistance = function(activeVehicle, screenX, screenY) {
     let distanceToCamera = realityEditor.sceneGraph.getDistanceToCamera(activeVehicle.uuid);
     let toolNode = realityEditor.sceneGraph.getSceneNodeById(activeVehicle.uuid);
@@ -228,6 +239,11 @@ realityEditor.gui.ar.positioning.moveVehiclePreservingDistance = function(active
     toolNode.setLocalMatrix(matrixCopy);
 }
 
+/**
+ * Determines whether to translate tool along its local plane, or parallel to camera (preserving distance to camera)
+ * @param {Frame|Node} activeVehicle
+ * @returns {boolean}
+ */
 realityEditor.gui.ar.positioning.shouldPreserveDistanceWhileMoving = function(activeVehicle) {
     // always move 3D tools
     if (activeVehicle.fullScreen) return true;

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -1423,7 +1423,7 @@ function polyfillWebkitConvertPointFromPageToNode() {
             dotProduct(negate(u), ev), dotProduct(negate(v), ev), dotProduct(negate(n), ev), 1];
     }
 
-    function _scalarMultiply(A, x) {
+    function scalarMultiply(A, x) {
         return [A[0] * x, A[1] * x, A[2] * x];
     }
 
@@ -1455,5 +1455,27 @@ function polyfillWebkitConvertPointFromPageToNode() {
         return A[0] * B[0] + A[1] * B[1] + A[2] * B[2];
     }
 
+    function getRightVector(M) {
+        return normalize([M[0], M[1], M[2]]);
+    }
+
+    function getUpVector(M) {
+        return normalize([M[4], M[5], M[6]]);
+    }
+
+    function getForwardVector(M) {
+        return normalize([M[8], M[9], M[10]]);
+    }
+
     exports.lookAt = lookAt;
+    exports.scalarMultiply = scalarMultiply;
+    exports.negate = negate;
+    exports.add = add;
+    exports.magnitude = magnitude;
+    exports.normalize = normalize;
+    exports.crossProduct = crossProduct;
+    exports.dotProduct = dotProduct;
+    exports.getRightVector = getRightVector;
+    exports.getUpVector = getUpVector;
+    exports.getForwardVector = getForwardVector;
 })(realityEditor.gui.ar.utilities);

--- a/src/sceneGraph/index.js
+++ b/src/sceneGraph/index.js
@@ -625,7 +625,6 @@ createNameSpace("realityEditor.sceneGraph");
             return { x: output[12]/output[15], y: output[13]/output[15], z: output[14]/output[15] };
         }
     }
-    exports.convertToNewCoordSystem = convertToNewCoordSystem;
 
     /**
      * Returns the 3D coordinate which is [distance] mm in front of the screen pixel coordinates [clientX, clientY]
@@ -633,7 +632,7 @@ createNameSpace("realityEditor.sceneGraph");
      * @param {number} screenY - in screen pixels
      * @param {number} distance - in millimeters
      * @param {SceneNode} coordinateSystem - which coordinate system you want the result calculated relative to
-     * @returns {{x: number, y: number, z: number}} - position in ROOT coordinates
+     * @returns {{x: number, y: number, z: number}} - position in ROOT coordinates, or whatever coordinateSystem is specified
      */
     function getPointAtDistanceFromCamera(screenX, screenY, distance, coordinateSystem = rootNode) {
         let distanceRaycastVector = [
@@ -647,7 +646,6 @@ createNameSpace("realityEditor.sceneGraph");
         let inputPosition = {x: localDistanceVector[0], y: localDistanceVector[1], z: localDistanceVector[2]};
         return convertToNewCoordSystem(inputPosition, cameraNode, coordinateSystem);
     }
-    exports.getPointAtDistanceFromCamera = getPointAtDistanceFromCamera;
 
     // preserves the position and scale of the sceneNode[id] and rotates it to look at sceneNode[idToLookAt]
     // if resulting matrix is looking away from target instead of towards, or is flipped upside-down, use flipX, flipY to correct it
@@ -828,6 +826,8 @@ createNameSpace("realityEditor.sceneGraph");
     exports.isInFrontOfCamera = isInFrontOfCamera;
     exports.getViewMatrix = getViewMatrix;
     exports.getModelMatrixLookingAt = getModelMatrixLookingAt;
+    exports.convertToNewCoordSystem = convertToNewCoordSystem;
+    exports.getPointAtDistanceFromCamera = getPointAtDistanceFromCamera;
 
     // public method to recompute sceneGraph for all visible entities
     exports.calculateFinalMatrices = calculateFinalMatrices;


### PR DESCRIPTION
Dragging now moves tools to the screen (x,y) location while preserving the distance to the camera, rather than translating tools along an imaginary local plane that they sit on, so they move more naturally.

For 2D tools, if you're viewing them from a mostly perpendicular angle, uses the old method to translate them along the plane that they sit on. This way, 2D tools that you've snapped onto a floor or wall will translate precisely along that surface unless you drag them from a fairly different angle.

![drag-tools-preserving-distance 2022-10-26 18_04_09](https://user-images.githubusercontent.com/32580292/198147308-cbd78966-694a-460c-81fc-35e282a31017.gif)
