### PR TITLE
Tool dragging improvements

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -411,14 +411,20 @@ realityEditor.device.resetEditingState = function() {
     // gets triggered before state gets reset, so that subscribed modules can respond based on what is about to be reset
     this.callbackHandler.triggerCallbacks('resetEditingState');
     
+    // properly write the vehicle position to the server if it's been moved relative to another parent
     if (this.getEditingVehicle() && this.isEditingUnconstrained(this.getEditingVehicle())) {
         let activeVehicle = this.getEditingVehicle();
+        let vehicleParentId = realityEditor.isVehicleAFrame(activeVehicle) ? activeVehicle.objectId : activeVehicle.frameId;
         let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeVehicle.uuid);
-        if (sceneNode.parent && sceneNode.parent.id === 'CAMERA') {
+        if (sceneNode.parent && sceneNode.parent.id !== vehicleParentId) {
             let parentId = realityEditor.isVehicleAFrame(activeVehicle) ? activeVehicle.objectId : activeVehicle.frameId;
             realityEditor.sceneGraph.changeParent(sceneNode, parentId, true);
+            realityEditor.gui.ar.positioning.setPositionDataMatrix(this.getEditingVehicle(), sceneNode.localMatrix, false);
+            sceneNode.needsUploadToServer = true;
         }
     }
+
+    midwayMovingAlongPlane = false;
 
     this.editingState.object = null;
     this.editingState.frame = null;

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -410,6 +410,15 @@ realityEditor.device.resetEditingState = function() {
 
     // gets triggered before state gets reset, so that subscribed modules can respond based on what is about to be reset
     this.callbackHandler.triggerCallbacks('resetEditingState');
+    
+    if (this.getEditingVehicle() && this.isEditingUnconstrained(this.getEditingVehicle())) {
+        let activeVehicle = this.getEditingVehicle();
+        let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeVehicle.uuid);
+        if (sceneNode.parent && sceneNode.parent.id === 'CAMERA') {
+            let parentId = realityEditor.isVehicleAFrame(activeVehicle) ? activeVehicle.objectId : activeVehicle.frameId;
+            realityEditor.sceneGraph.changeParent(sceneNode, parentId, true);
+        }
+    }
 
     this.editingState.object = null;
     this.editingState.frame = null;

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -95,7 +95,7 @@ realityEditor.device.cachedWorldObject = null;
  * @property {string|null} object - objectId of the selected vehicle
  * @property {string|null} frame - frameId of the selected vehicle
  * @property {string|null} node - nodeIf of the selected node (null if vehicle is a frame, not a node)
- * @property {{x: number, y: number}|null} touchOffset - relative position of the touch to the vehicle when you start repositioning
+ * @property {{x: number, y: number, z: number}|null} touchOffset - relative position of the touch to the vehicle when you start repositioning
  * @property {boolean} unconstrained - iff the current reposition is temporarily unconstrained (globalStates.unconstrainedEditing is used for permanent unconstrained repositioning)
  * @property {number|null} initialCameraPosition - initial camera position used for calculating popping into unconstrained
  * @property {Array.<number>|null} startingMatrix - stores the previous vehicle matrix while unconstrained editing, so that it can be returned to its original position if dropped in an invalid location
@@ -415,6 +415,8 @@ realityEditor.device.resetEditingState = function() {
     this.editingState.frame = null;
     this.editingState.node = null;
     this.editingState.touchOffset = null;
+    storedOffset = null;
+    storedDistance = null;
     this.editingState.unconstrained = false;
     this.editingState.initialCameraPosition = null;
     this.editingState.startingMatrix = null;
@@ -426,8 +428,6 @@ realityEditor.device.resetEditingState = function() {
     globalStates.inTransitionObject = null;
     globalStates.inTransitionFrame = null;
     pocketFrame.vehicle = null;
-    
-    realityEditor.gui.ar.positioning.stopRepositioning();
 };
 
 /**
@@ -1386,7 +1386,7 @@ realityEditor.device.onDocumentMultiTouchMove = function (event) {
 
             realityEditor.gui.ar.positioning.y =event.touches[0].pageY;
                 realityEditor.gui.ar.positioning.x =   event.touches[0].pageX;
-            realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinate(activeVehicle, event.touches[0].pageX, event.touches[0].pageY, true, true);
+            realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinate(activeVehicle, event.touches[0].pageX, event.touches[0].pageY, true);
             
             var isDeletableVehicle = activeVehicle.type === 'logic' || (globalStates.guiState === "ui" && activeVehicle && activeVehicle.location === "global");
             
@@ -1579,6 +1579,8 @@ realityEditor.device.onDocumentMultiTouchEnd = function (event) {
         } else {
             // if there's still a touch on it (it was being scaled), reset touch offset so vehicle doesn't jump
             this.editingState.touchOffset = null;
+            storedOffset = null;
+            storedDistance = null;
             realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinate(activeVehicle, event.touches[0].pageX, event.touches[0].pageY, true);
 
         }

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -424,14 +424,10 @@ realityEditor.device.resetEditingState = function() {
         }
     }
 
-    midwayMovingAlongPlane = false;
-
     this.editingState.object = null;
     this.editingState.frame = null;
     this.editingState.node = null;
     this.editingState.touchOffset = null;
-    storedOffset = null;
-    storedDistance = null;
     this.editingState.unconstrained = false;
     this.editingState.initialCameraPosition = null;
     this.editingState.startingMatrix = null;
@@ -443,6 +439,8 @@ realityEditor.device.resetEditingState = function() {
     globalStates.inTransitionObject = null;
     globalStates.inTransitionFrame = null;
     pocketFrame.vehicle = null;
+
+    realityEditor.gui.ar.positioning.stopRepositioning();
 };
 
 /**
@@ -1594,8 +1592,6 @@ realityEditor.device.onDocumentMultiTouchEnd = function (event) {
         } else {
             // if there's still a touch on it (it was being scaled), reset touch offset so vehicle doesn't jump
             this.editingState.touchOffset = null;
-            storedOffset = null;
-            storedDistance = null;
             realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinate(activeVehicle, event.touches[0].pageX, event.touches[0].pageY, true);
 
         }

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1168,6 +1168,9 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                         // if this isn't the first frame of unconstrained editing, just use the previously stored matrices
                     } // else {
 
+                    // this forces it to broadcast its position in realtime to other clients
+                    sceneNode.setLocalMatrix(sceneNode.localMatrix);
+
                     // // if (doMove) {
                     //     // TODO: decide whether to do this the mathematical way, or fake it like before for performance
                     //     // multiply camera's worldMatrix by the activeVehicle.begin to get activeVehicle's

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1142,50 +1142,62 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
 
                 if (realityEditor.device.isEditingUnconstrained(activeVehicle)) {
                     
-                    let lastPointerPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
-                    realityEditor.gui.ar.positioning.moveVehiclePreservingDistance(activeVehicle, lastPointerPosition.x, lastPointerPosition.y, true);
+                    // let lastPointerPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
+                    // realityEditor.gui.ar.positioning.moveVehiclePreservingDistance(activeVehicle, lastPointerPosition.x, lastPointerPosition.y, true);
 
                     let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeKey);
                     let cameraNode = realityEditor.sceneGraph.getSceneNodeById('CAMERA');
                     
                     // TODO: also show "shadow" on ground plane on remote operator while moving, to help position it
 
-                    let doMove = true;
+                    // let doMove = true;
                     // do this one time when you first tap down on something unconstrained, to preserve its current matrix
-                    if (matrix.copyStillFromMatrixSwitch || matrix.recomputeUnconstrainedMatrix) {
-                        if (matrix.copyStillFromMatrixSwitch && !matrix.recomputeUnconstrainedMatrix) {
-                            doMove = false;
-                        }
+                    if (matrix.copyStillFromMatrixSwitch) { // || matrix.recomputeUnconstrainedMatrix) {
+                        // if (matrix.copyStillFromMatrixSwitch && !matrix.recomputeUnconstrainedMatrix) {
+                        //     doMove = false;
+                        // }
 
                         let relativeMatrix = sceneNode.getMatrixRelativeTo(cameraNode);
                         activeVehicle.begin = utilities.copyMatrix(relativeMatrix);
                         matrix.copyStillFromMatrixSwitch = false;
                         matrix.recomputeUnconstrainedMatrix = false;
+                        
+                        realityEditor.sceneGraph.changeParent(sceneNode, 'CAMERA', true);
+                        console.log('move unconstrained to camera node');
 
                         // if this isn't the first frame of unconstrained editing, just use the previously stored matrices
                     } // else {
 
-                    if (doMove) {
-                        // TODO: decide whether to do this the mathematical way, or fake it like before for performance
-                        // multiply camera's worldMatrix by the activeVehicle.begin to get activeVehicle's
-                        // worldMatrix... then convert to local
-                        let requiredWorldMatrix = [];
-                        utilities.multiplyMatrix(activeVehicle.begin, cameraNode.worldMatrix, requiredWorldMatrix);
-                        let requiredLocalMatrix = sceneNode.calculateLocalMatrix(requiredWorldMatrix);
-
-                        // cancel out the initial transform (x,y,scale) of when the vehicle's matrix.begin was stored,
-                        // otherwise they will be double-applied to the resulting sceneNode
-                        let startingTransform = realityEditor.device.editingState.startingTransform || realityEditor.gui.ar.utilities.newIdentityMatrix();
-                        let inverseTransform = realityEditor.gui.ar.utilities.invertMatrix(startingTransform);
-                        let untransformed = [];
-                        realityEditor.gui.ar.utilities.multiplyMatrix(inverseTransform, requiredLocalMatrix, untransformed);
-
-                        sceneNode.setLocalMatrix(untransformed);
-                    }
-
+                    // // if (doMove) {
+                    //     // TODO: decide whether to do this the mathematical way, or fake it like before for performance
+                    //     // multiply camera's worldMatrix by the activeVehicle.begin to get activeVehicle's
+                    //     // worldMatrix... then convert to local
+                    //     let requiredWorldMatrix = [];
+                    //     utilities.multiplyMatrix(activeVehicle.begin, cameraNode.worldMatrix, requiredWorldMatrix);
+                    //     let requiredLocalMatrix = sceneNode.calculateLocalMatrix(requiredWorldMatrix);
+                    //
+                    //     // cancel out the initial transform (x,y,scale) of when the vehicle's matrix.begin was stored,
+                    //     // otherwise they will be double-applied to the resulting sceneNode
+                    //     let startingTransform = realityEditor.device.editingState.startingTransform || realityEditor.gui.ar.utilities.newIdentityMatrix();
+                    //     let inverseTransform = realityEditor.gui.ar.utilities.invertMatrix(startingTransform);
+                    //     let untransformed = [];
+                    //     realityEditor.gui.ar.utilities.multiplyMatrix(inverseTransform, requiredLocalMatrix, untransformed);
+                    //
+                    //     sceneNode.setLocalMatrix(untransformed);
+                    // }
+                    // console.log('draw needs rerender? ' + sceneNode.needsRerender);
+                    console.log('draw: ' + sceneNode.worldMatrix[12].toFixed(0) + ', ' + sceneNode.worldMatrix[13].toFixed(0) + ', ' + sceneNode.worldMatrix[14].toFixed(0));
                 }
-                
             }
+
+            // // set parent back to object if necessary
+            // if (!realityEditor.device.isEditingUnconstrained(activeVehicle)) {
+            //     let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeKey);
+            //     if (sceneNode.parent && sceneNode.parent.id === 'CAMERA') {
+            //         let parentId = realityEditor.isVehicleAFrame(activeVehicle) ? activeVehicle.objectId : activeVehicle.frameId;
+            //         realityEditor.sceneGraph.changeParent(sceneNode, parentId, true);
+            //     }
+            // }
             
             // TODO ben: add in animation matrix
             // multiply in the animation matrix if you are editing this frame in unconstrained mode.

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -82,7 +82,6 @@ realityEditor.gui.ar.draw.rotateX = rotateX;
  * @type {{temp: number[], begin: number[], end: number[], r: number[], r2: number[], r3: number[]}}
  */
 realityEditor.gui.ar.draw.matrix = {
-    recomputeUnconstrainedMatrix: false,
     worldReference: null,
     temp: [
         1, 0, 0, 0,
@@ -1141,66 +1140,25 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                 // }
 
                 if (realityEditor.device.isEditingUnconstrained(activeVehicle)) {
-                    
-                    // let lastPointerPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
-                    // realityEditor.gui.ar.positioning.moveVehiclePreservingDistance(activeVehicle, lastPointerPosition.x, lastPointerPosition.y, true);
 
                     let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeKey);
                     let cameraNode = realityEditor.sceneGraph.getSceneNodeById('CAMERA');
                     
                     // TODO: also show "shadow" on ground plane on remote operator while moving, to help position it
 
-                    // let doMove = true;
-                    // do this one time when you first tap down on something unconstrained, to preserve its current matrix
-                    if (matrix.copyStillFromMatrixSwitch) { // || matrix.recomputeUnconstrainedMatrix) {
-                        // if (matrix.copyStillFromMatrixSwitch && !matrix.recomputeUnconstrainedMatrix) {
-                        //     doMove = false;
-                        // }
-
+                    // when you first trigger unconstrained repositioning, attach the tool to the camera so that its
+                    // matrix gets stored "frozen" relative to the camera and moves with it
+                    if (matrix.copyStillFromMatrixSwitch) {
                         let relativeMatrix = sceneNode.getMatrixRelativeTo(cameraNode);
-                        activeVehicle.begin = utilities.copyMatrix(relativeMatrix);
+                        activeVehicle.begin = utilities.copyMatrix(relativeMatrix); // todo: do we still need the .begin matrix?
                         matrix.copyStillFromMatrixSwitch = false;
-                        matrix.recomputeUnconstrainedMatrix = false;
-                        
                         realityEditor.sceneGraph.changeParent(sceneNode, 'CAMERA', true);
-                        console.log('move unconstrained to camera node');
-
-                        // if this isn't the first frame of unconstrained editing, just use the previously stored matrices
-                    } // else {
+                    }
 
                     // this forces it to broadcast its position in realtime to other clients
                     sceneNode.setLocalMatrix(sceneNode.localMatrix);
-
-                    // // if (doMove) {
-                    //     // TODO: decide whether to do this the mathematical way, or fake it like before for performance
-                    //     // multiply camera's worldMatrix by the activeVehicle.begin to get activeVehicle's
-                    //     // worldMatrix... then convert to local
-                    //     let requiredWorldMatrix = [];
-                    //     utilities.multiplyMatrix(activeVehicle.begin, cameraNode.worldMatrix, requiredWorldMatrix);
-                    //     let requiredLocalMatrix = sceneNode.calculateLocalMatrix(requiredWorldMatrix);
-                    //
-                    //     // cancel out the initial transform (x,y,scale) of when the vehicle's matrix.begin was stored,
-                    //     // otherwise they will be double-applied to the resulting sceneNode
-                    //     let startingTransform = realityEditor.device.editingState.startingTransform || realityEditor.gui.ar.utilities.newIdentityMatrix();
-                    //     let inverseTransform = realityEditor.gui.ar.utilities.invertMatrix(startingTransform);
-                    //     let untransformed = [];
-                    //     realityEditor.gui.ar.utilities.multiplyMatrix(inverseTransform, requiredLocalMatrix, untransformed);
-                    //
-                    //     sceneNode.setLocalMatrix(untransformed);
-                    // }
-                    // console.log('draw needs rerender? ' + sceneNode.needsRerender);
-                    console.log('draw: ' + sceneNode.worldMatrix[12].toFixed(0) + ', ' + sceneNode.worldMatrix[13].toFixed(0) + ', ' + sceneNode.worldMatrix[14].toFixed(0));
                 }
             }
-
-            // // set parent back to object if necessary
-            // if (!realityEditor.device.isEditingUnconstrained(activeVehicle)) {
-            //     let sceneNode = realityEditor.sceneGraph.getSceneNodeById(activeKey);
-            //     if (sceneNode.parent && sceneNode.parent.id === 'CAMERA') {
-            //         let parentId = realityEditor.isVehicleAFrame(activeVehicle) ? activeVehicle.objectId : activeVehicle.frameId;
-            //         realityEditor.sceneGraph.changeParent(sceneNode, parentId, true);
-            //     }
-            // }
             
             // TODO ben: add in animation matrix
             // multiply in the animation matrix if you are editing this frame in unconstrained mode.
@@ -1783,11 +1741,13 @@ realityEditor.gui.ar.draw.startPocketDropAnimation = function(timeInMilliseconds
             editingAnimationsMatrix[12] = 0;
             editingAnimationsMatrix[13] = 0;
             editingAnimationsMatrix[14] = 0;
+            realityEditor.gui.ar.positioning.stopRepositioning(); // trigger drag matrix to be recomputed
             pocketDropAnimation = null;
         }).onStop(function() {
             editingAnimationsMatrix[12] = 0;
             editingAnimationsMatrix[13] = 0;
             editingAnimationsMatrix[14] = 0;
+            realityEditor.gui.ar.positioning.stopRepositioning();
             pocketDropAnimation = null;
         })
         .start();

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -334,7 +334,7 @@ realityEditor.gui.ar.positioning.moveVehicleAlongPlane = function(activeVehicle,
     let localPoint = getLocalPointAtScreenXY(activeVehicle, screenX, screenY);
 
     // this makes it so the center of the tool doesn't snap to the pointer location
-    let offset = this.computeTouchOffset(toolNode, localPoint, useTouchOffset);
+    let offset = {x: 0, y: 0, z: 0}; // this.computeTouchOffset(toolNode, localPoint, useTouchOffset);
 
     // we don't need the separate x and y components anymore
     let positionData = this.getPositionData(activeVehicle);
@@ -348,6 +348,9 @@ realityEditor.gui.ar.positioning.moveVehicleAlongPlane = function(activeVehicle,
     matrixCopy[13] = localPoint.y - offset.y;
     matrixCopy[14] = localPoint.z - offset.z;
     toolNode.setLocalMatrix(matrixCopy);
+    toolNode.updateWorldMatrix(toolNode.parent.worldMatrix);
+
+    console.log('move: ' + toolNode.localMatrix[12].toFixed(0) + ', ' + toolNode.localMatrix[13].toFixed(0) + ', ' + toolNode.localMatrix[14].toFixed(0));
 }
 
 /**

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -730,91 +730,7 @@ realityEditor.gui.ar.utilities.screenCoordinatesToTargetXY = function(objectKey,
 /**********************************************************************************************************************
  **********************************************************************************************************************/
 
-/**
- * private helper functions for realityEditor.gui.ar.utilities.screenCoordinatesToMatrixXY and realityEditor.gui.ar.utilities.screenCoordinatesToMatrixXY (which is used by moveVehicleToScreenCoordinate)
- * @author Ben Reynolds
- * @todo: simplify and then document individually
- */
 (function(exports) {
-
-    function solveProjectedCoordinatesInVehicle(thisVehicle, screenX, screenY, cssMatrixToUse) {
-
-        var elementUuid = thisVehicle.uuid || thisVehicle.frameId + thisVehicle.name;
-        var overlayDomElement = globalDOMCache[elementUuid];
-
-        // we are looking for the x, y coordinates at z = 0 on the frame
-        var point = solveProjectedCoordinates(overlayDomElement, screenX, screenY, 0, cssMatrixToUse);
-
-        return {
-            x: point.x,
-            y: point.y
-        }
-    }
-
-    function solveProjectedCoordinates(childDiv, screenX, screenY, projectedZ, cssMatrixToUse) {
-
-        // projectedZ lets you find the projected x,y coordinates that occur on the frame at screenX, screenZ, and that z coordinate
-        if (projectedZ === undefined) {
-            projectedZ = 0;
-        }
-
-        // raycast isn't perfect, so project two rays from screenX, screenY. project from a different Z each time, because they will land on the same line. 
-        var dt = 0.1;
-        var p0 = convertScreenPointToLocalCoordinatesRelativeToDivParent(childDiv, childDiv.parentElement, screenX, screenY, projectedZ, cssMatrixToUse);
-        var p2 = convertScreenPointToLocalCoordinatesRelativeToDivParent(childDiv, childDiv.parentElement, screenX, screenY, (projectedZ + dt), cssMatrixToUse);
-
-        // interpolate to calculate the x,y coordinate that corresponds to z = 0 on the projected plane, based on the two samples
-
-        var dx = (p2[0] - p0[0]) / dt;
-        var dy = (p2[1] - p0[1]) / dt;
-        var dz = (p2[2] - p0[2]) / dt;
-        var neededDt = (p0[2]) / dz;
-
-        return {
-            x: p0[0] - dx * neededDt,
-            y: p0[1] - dy * neededDt,
-            z: p0[2] - dz * neededDt
-        }
-    }
-
-    function convertScreenPointToLocalCoordinatesRelativeToDivParent(childDiv, transformedDiv, screenX, screenY, screenZ, cssMatrixToUse) {
-
-        // it can either use the hard-coded css 3d matrix provided in the last parameter, or extract one from the transformedDiv element  // TODO: just pass around matrices, not the full css transform... then we can just use the mostRecentFinalMatrix from the frame, or compute based on a matrix without a corresponding DOM element
-        if (!cssMatrixToUse) {
-            cssMatrixToUse = getTransform(transformedDiv);
-        }
-
-        // translation matrix if the element has a different transform origin
-        var originTranslationVector = getTransformOrigin(transformedDiv);
-
-        // compute a matrix that fully describes the transformation, including a nonzero origin translation // TODO: learn why this works
-        // var fullTx = computeTransformationData(cssMatrixToUse, originTranslationVector);
-        var fullTx = computeTransformMatrix(cssMatrixToUse, originTranslationVector);
-
-        // invert and normalize the matrix
-        var fullTx_inverse = realityEditor.gui.ar.utilities.invertMatrix(fullTx);
-        var fullTx_normalized_inverse = realityEditor.gui.ar.utilities.perspectiveDivide(fullTx_inverse);
-
-        var screenPoint = [screenX, screenY, screenZ, 1];
-
-        // multiply the screen point by the inverse matrix, and divide by the W coordinate to get the real position
-        return realityEditor.gui.ar.utilities.perspectiveDivide(transformVertex(fullTx_normalized_inverse, screenPoint));
-    }
-
-    // TODO: find out why we need to compute N = T^{-1}MT
-    function computeTransformMatrix(transformationMatrix, originTranslationVector)
-    {
-        var x = originTranslationVector[0];
-        var y = originTranslationVector[1];
-        var z = originTranslationVector[2];
-        var undoTranslationMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -x, -y, -z, 1];
-        var redoTranslationMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
-        var temp1 = [];
-        var out = [];
-        realityEditor.gui.ar.utilities.multiplyMatrix(undoTranslationMatrix, transformationMatrix, temp1);
-        realityEditor.gui.ar.utilities.multiplyMatrix(temp1, redoTranslationMatrix, out);
-        return out;
-    }
 
     /**
      * Helper function that extracts a 4x4 matrix from the element's CSS matrix3d
@@ -844,48 +760,7 @@ realityEditor.gui.ar.utilities.screenCoordinatesToTargetXY = function(objectKey,
         return out;
     }
 
-    function getTransformOrigin(element) {
-
-        var out = [ 0, 0, 0, 1 ];
-
-        // this is a speedup that works for the frames we currently use. might need to remove in the future if it messes anything up
-        if (element.style.transformOrigin) {
-            var st = window.getComputedStyle(element, null);
-            var tr = st.getPropertyValue("-webkit-transform-origin") ||
-                st.getPropertyValue("-moz-transform-origin") ||
-                st.getPropertyValue("-ms-transform-origin") ||
-                st.getPropertyValue("-o-transform-origin") ||
-                st.getPropertyValue("transform-origin");
-
-            var values = tr.split(' ');
-
-            for (var i = 0; i < values.length; ++i) {
-                out[i] = parseInt(values[i]);
-            }
-        } else {
-            out[0] = parseInt(element.style.width)/2;
-            out[1] = parseInt(element.style.height)/2;
-        }
-
-        return out;
-    }
-
-    function transformVertex(mat, ver) {
-        var out = [0,0,0,0];
-
-        for (var i = 0; i < 4; i++) {
-            var sum = 0;
-            for (var j = 0; j < 4; j++) {
-                sum += mat[i + j * 4] * ver[j];
-            }
-            out[i] = sum;
-        }
-
-        return out;
-    }
-
     exports.getTransform = getTransform;
-    exports.solveProjectedCoordinatesInVehicle = solveProjectedCoordinatesInVehicle;
 
 }(realityEditor.gui.ar.utilities));
 
@@ -1471,6 +1346,18 @@ function polyfillWebkitConvertPointFromPageToNode() {
         return normalize([M[8], M[9], M[10]]);
     }
 
+    // see https://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-plane-and-ray-disk-intersection
+    function rayPlaneIntersect(planeOrigin, planeNormal, rayOrigin, rayDirection) {
+        let denom = dotProduct(planeNormal, rayDirection);
+        if (Math.abs(denom) < 0.0001) return null; // plane and ray are ~parallel, so either 0 or infinite intersections
+
+        // solve for parametric variable, t, to figure out where on the ray is the plane intersection
+        let vector = subtract(planeOrigin, rayOrigin);
+        let t = dotProduct(vector, planeNormal) / denom;
+
+        return add(rayOrigin, scalarMultiply(rayDirection, t));
+    }
+
     exports.lookAt = lookAt;
     exports.scalarMultiply = scalarMultiply;
     exports.negate = negate;
@@ -1483,4 +1370,5 @@ function polyfillWebkitConvertPointFromPageToNode() {
     exports.getRightVector = getRightVector;
     exports.getUpVector = getUpVector;
     exports.getForwardVector = getForwardVector;
+    exports.rayPlaneIntersect = rayPlaneIntersect;
 })(realityEditor.gui.ar.utilities);

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -1435,6 +1435,10 @@ function polyfillWebkitConvertPointFromPageToNode() {
         return [A[0] + B[0], A[1] + B[1], A[2] + B[2]];
     }
 
+    function subtract(A, B) {
+        return [A[0] - B[0], A[1] - B[1], A[2] - B[2]];
+    }
+
     function magnitude(A) {
         return Math.sqrt(A[0] * A[0] + A[1] * A[1] + A[2] * A[2]);
     }
@@ -1471,6 +1475,7 @@ function polyfillWebkitConvertPointFromPageToNode() {
     exports.scalarMultiply = scalarMultiply;
     exports.negate = negate;
     exports.add = add;
+    exports.subtract = subtract;
     exports.magnitude = magnitude;
     exports.normalize = normalize;
     exports.crossProduct = crossProduct;

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -303,6 +303,7 @@ createNameSpace("realityEditor.network.realtime");
         if (Object.keys(batchedUpdates).length === 0) { return; }
 
         for (let objectKey in batchedUpdates) {
+            if (!objects[objectKey]) continue;
             let serverSocket = getServerSocketForObject(objectKey);
             if (!serverSocket) { continue; }
 

--- a/src/sceneGraph/index.js
+++ b/src/sceneGraph/index.js
@@ -748,11 +748,6 @@ createNameSpace("realityEditor.sceneGraph");
         }
         if (cameraNode) {
             cameraNode.updateWorldMatrix();
-
-            // update children of camera
-            cameraNode.children.forEach(childNode => {
-                childNode.updateWorldMatrix();
-            });
         }
 
         // this might become a child of a world object but still safe to call update multiple times

--- a/src/sceneGraph/index.js
+++ b/src/sceneGraph/index.js
@@ -298,6 +298,16 @@ createNameSpace("realityEditor.sceneGraph");
             objectSceneNode.anythingInSubtreeNeedsRerender = false;
         });
 
+        if (cameraNode.anythingInSubtreeNeedsRerender) {
+            cameraNode.children.forEach(childNode => {
+                relativeToCamera[childNode.id] = childNode.getMatrixRelativeTo(cameraNode);
+                finalCSSMatrices[childNode.id] = [];
+                utils.multiplyMatrix(relativeToCamera[childNode.id], globalStates.projectionMatrix, finalCSSMatrices[childNode.id]);
+                childNode.needsRerender = false;
+            });
+            cameraNode.anythingInSubtreeNeedsRerender = false;
+        }
+
         // process additional visual elements at the end, in case they are relative to groundPlane/frames/nodes
         for (let elementId in visualElements) {
             let miscellaneousElementNode = visualElements[elementId];
@@ -738,6 +748,11 @@ createNameSpace("realityEditor.sceneGraph");
         }
         if (cameraNode) {
             cameraNode.updateWorldMatrix();
+
+            // update children of camera
+            cameraNode.children.forEach(childNode => {
+                childNode.updateWorldMatrix();
+            });
         }
 
         // this might become a child of a world object but still safe to call update multiple times

--- a/src/sceneGraph/sceneNode.js
+++ b/src/sceneGraph/sceneNode.js
@@ -181,15 +181,17 @@ createNameSpace("realityEditor.sceneGraph");
             let vehicleParentId = realityEditor.isVehicleAFrame(this.linkedVehicle) ? this.linkedVehicle.objectId : this.linkedVehicle.frameId;
             if (this.parent.id === vehicleParentId) {
                 realityEditor.gui.ar.positioning.setPositionDataMatrix(this.linkedVehicle, matrix, this.dontBroadcastNext);
-                this.dontBroadcastNext = false;
             } else {
                 // if tool is parented to CAMERA or other, broadcast its matrix relative to its linkedVehicle's parent
                 let objectSceneNode = realityEditor.sceneGraph.getSceneNodeById(vehicleParentId);
                 let matrixRelativeToObject = realityEditor.sceneGraph.convertToNewCoordSystem(matrix, this.parent, objectSceneNode);
-                let keys = realityEditor.getKeysFromVehicle(this.linkedVehicle);
-                let propertyPath = this.linkedVehicle.hasOwnProperty('visualization') ? 'ar.matrix' : 'matrix';
-                realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, matrixRelativeToObject);
+                if (!this.dontBroadcastNext) {
+                    let keys = realityEditor.getKeysFromVehicle(this.linkedVehicle);
+                    let propertyPath = this.linkedVehicle.hasOwnProperty('visualization') ? 'ar.matrix' : 'matrix';
+                    realityEditor.network.realtime.broadcastUpdate(keys.objectKey, keys.frameKey, keys.nodeKey, propertyPath, matrixRelativeToObject);
+                }
             }
+            this.dontBroadcastNext = false; // gets set true when receiving an update from another client
         }
 
         // flagging this will eventually set the other necessary flags for this and parent/children nodes


### PR DESCRIPTION
PR #302, which improved the dragging of 3D tools, had a couple issues:
1) when physically moving the phone around while holding a tool (in "unconstrained editing mode") the new repositioning method would fight with the old unconstrained method and the tool would flicker.
2) it was still using old calculations for moving 2D tools along their local XY plane, which was using some hacky browser/CSS tricks to do the calculations

This PR adds the following:
1) "unconstrained editing" simply makes the tool a child of the camera instead of freezing its relative matrix, which causes it to move with the camera without fighting with new local matrix values provided by the dragging mechanism
2) new `realityEditor.gui.ar.positioning.moveVehicleAlongPlane` function uses more elegant ray-plane intersection function to calculate dragging the 2D tools along their XY plane instead of webkit/CSS-dependent hacks
3) some (messier than ideal) adjustments in order to still realtime sync and upload the position of the tool relative to the object even if its sceneNode is parented to the camera

![new-2d-repositioning](https://user-images.githubusercontent.com/32580292/199298548-86149293-a5c8-452e-a177-0a5a3dba00d2.gif)

![new-3d-repositioning](https://user-images.githubusercontent.com/32580292/199298583-0c095fe4-7d54-4286-bfad-b0e0e2929a85.gif)
