### PR TITLE
adds a flag that remote operator can use to disable the creation of memories

### DIFF
--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -40,6 +40,7 @@ createNameSpace("realityEditor.device.environment");
         enableViewFrustumCulling: true,
         layoutUIForPortrait: false,
         defaultShowGroundPlane: false,
+        supportsMemoryCreation: true,
         // numbers
         lineWidthMultiplier: 1, // 5
         distanceScaleFactor: 1, // 10

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -1261,8 +1261,10 @@ realityEditor.device.onDocumentMultiTouchStart = function (event) {
                             this.isDoubleTap = false;
                         }.bind(this), 300);
                     } else { // registered double tap and create memory
-                        realityEditor.gui.menus.switchToMenu("bigPocket");
-                        realityEditor.gui.memory.createMemory();
+                        if (realityEditor.device.environment.variables.supportsMemoryCreation) {
+                            realityEditor.gui.menus.switchToMenu("bigPocket");
+                            realityEditor.gui.memory.createMemory();
+                        }
                     }
 
                 }


### PR DESCRIPTION
(memories don't really work anymore but creation is currently available by double clicking the background).
We could bring it back with a little bit of work, but pop-up-addon can disable it too for now, since it doesn't include the memory pocket in the new UI.