### PR TITLE
Various Avatar improvements

### DIFF
--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -463,7 +463,7 @@ createNameSpace("realityEditor.avatar.draw");
     }
 
     // Shows an "Establishing Connection..." --> "Connected!" label in the top left
-    function renderConnectionFeedback(isConnected) {
+    function renderConnectionFeedback(isConnected, didFail = false) {
         if (!statusUI) {
             statusUI = document.createElement('div');
             statusUI.id = 'avatarStatus';
@@ -485,7 +485,11 @@ createNameSpace("realityEditor.avatar.draw");
                 }, 2000);
             }, 300);
         } else {
-            statusUI.innerText = 'Establishing Avatar Connection...'
+            if (didFail) {
+                statusUI.innerText = ''; // hide the "Establishing" message on fail or timeout
+            } else {
+                statusUI.innerText = 'Establishing Avatar Connection...';
+            }
         }
     }
 
@@ -518,7 +522,21 @@ createNameSpace("realityEditor.avatar.draw");
             'Did Send? (' + sendText + ').  ' +
             'Did Receive? (' + receiveText + ')' +
             '<br/>' +
+            'Did Fail? (' + debugConnectionStatus.didCreationFail + ')' +
+            '<br/>' +
             'My ID: ' + (myId ? myId : 'null');
+    }
+
+    function deleteAvatarMeshes(objectKey) {
+        if (avatarMeshes[objectKey]) {
+            Object.values(avatarMeshes[objectKey]).forEach(elt => {
+                if (typeof elt.isObject3D !== 'undefined' && elt.isObject3D && typeof elt.removeFromParent !== 'undefined') {
+                    elt.removeFromParent();
+                } else if (elt.tagName !== 'undefined' && typeof elt.parentElement !== 'undefined') {
+                    elt.parentElement.removeChild(elt);
+                }
+            });
+        }
     }
 
     exports.renderOtherAvatars = renderOtherAvatars;
@@ -527,5 +545,6 @@ createNameSpace("realityEditor.avatar.draw");
     exports.renderCursorOverlay = renderCursorOverlay;
     exports.renderConnectionFeedback = renderConnectionFeedback;
     exports.renderConnectionDebugInfo = renderConnectionDebugInfo;
+    exports.deleteAvatarMeshes = deleteAvatarMeshes;
 
 }(realityEditor.avatar.draw));

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -537,6 +537,7 @@ createNameSpace("realityEditor.avatar.draw");
                 }
             });
         }
+        delete avatarMeshes[objectKey];
     }
 
     exports.renderOtherAvatars = renderOtherAvatars;

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -262,36 +262,57 @@ createNameSpace("realityEditor.avatar.draw");
             avatarMeshes[objectKey].device.matrix.copy(avatarObjectMatrixThree);
         }
 
-        if (!touchState.worldIntersectPoint) { return; }
+        // we either draw an "infinite" ray in the specified direction, or draw a line to the specified point
+        if (!touchState.worldIntersectPoint && !touchState.rayDirection) return;
 
-        // worldIntersectPoint was converted to world coordinates. need to convert back to groundPlane coordinates in this system
-        let groundPlaneRelativeToWorldToolbox = worldSceneNode.getMatrixRelativeTo(groundPlaneSceneNode);
-        let groundPlaneRelativeToWorldThree = new realityEditor.gui.threejsScene.THREE.Matrix4();
-        realityEditor.gui.threejsScene.setMatrixFromArray(groundPlaneRelativeToWorldThree, groundPlaneRelativeToWorldToolbox);
-        let convertedEndPosition = new THREE.Vector3(touchState.worldIntersectPoint.x, touchState.worldIntersectPoint.y, touchState.worldIntersectPoint.z);
-        convertedEndPosition.applyMatrix4(groundPlaneRelativeToWorldThree);
-        // move the pointer sphere to the raycast intersect position
-        avatarMeshes[objectKey].pointer.position.set(convertedEndPosition.x, convertedEndPosition.y, convertedEndPosition.z);
+        let convertedEndPosition = new THREE.Vector3();
 
-        // get the 2D screen coordinates of the pointer, and render a text bubble centered on it with the name of the sender
-        let pointerWorldPosition = new THREE.Vector3();
-        avatarMeshes[objectKey].pointer.getWorldPosition(pointerWorldPosition);
-        let screenCoords = realityEditor.gui.threejsScene.getScreenXY(pointerWorldPosition);
-        if (avatarName) {
-            avatarMeshes[objectKey].textLabel.style.display = 'inline';
+        if (touchState.worldIntersectPoint) {
+            // worldIntersectPoint was converted to world coordinates. need to convert back to groundPlane coordinates in this system
+            let groundPlaneRelativeToWorldToolbox = worldSceneNode.getMatrixRelativeTo(groundPlaneSceneNode);
+            let groundPlaneRelativeToWorldThree = new realityEditor.gui.threejsScene.THREE.Matrix4();
+            realityEditor.gui.threejsScene.setMatrixFromArray(groundPlaneRelativeToWorldThree, groundPlaneRelativeToWorldToolbox);
+            // convertedEndPosition = new THREE.Vector3(touchState.worldIntersectPoint.x, touchState.worldIntersectPoint.y, touchState.worldIntersectPoint.z);
+            convertedEndPosition.set(touchState.worldIntersectPoint.x, touchState.worldIntersectPoint.y, touchState.worldIntersectPoint.z);
+            convertedEndPosition.applyMatrix4(groundPlaneRelativeToWorldThree);
+            // move the pointer sphere to the raycast intersect position
+
+            avatarMeshes[objectKey].pointer.visible = true;
+            avatarMeshes[objectKey].pointer.position.set(convertedEndPosition.x, convertedEndPosition.y, convertedEndPosition.z);
+
+            // get the 2D screen coordinates of the pointer, and render a text bubble centered on it with the name of the sender
+            let pointerWorldPosition = new THREE.Vector3();
+            avatarMeshes[objectKey].pointer.getWorldPosition(pointerWorldPosition);
+            let screenCoords = realityEditor.gui.threejsScene.getScreenXY(pointerWorldPosition);
+            if (avatarName) {
+                avatarMeshes[objectKey].textLabel.style.display = 'inline';
+            }
+            // scale the name textLabel based on distance from convertedEndPosition to camera
+            let camPos = realityEditor.sceneGraph.getWorldPosition('CAMERA');
+            let delta = {
+                x: camPos.x - convertedEndPosition.x,
+                y: camPos.y - convertedEndPosition.y,
+                z: camPos.z - convertedEndPosition.z
+            };
+            let distanceToCamera = Math.max(0.001, Math.sqrt(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z));
+            let scale = Math.max(0.5, Math.min(2, 2000 / distanceToCamera)); // biggest when <1m, smallest when >4m
+            avatarMeshes[objectKey].textLabel.style.transform = 'translateX(-50%) translateY(-50%) translateZ(3000px) scale(' + scale + ')';
+            avatarMeshes[objectKey].textLabel.style.left = screenCoords.x + 'px'; // position it centered on the pointer sphere
+            avatarMeshes[objectKey].textLabel.style.top = screenCoords.y + 'px';
+        } else {
+            // hide the pointer and just compute a point along the rayDirection, so we can render the beam
+            avatarMeshes[objectKey].pointer.visible = false;
+            avatarMeshes[objectKey].textLabel.style.display = 'none';
+
+            // rayDirection is relative to world object – convert to relative to groundPlane
+            let rayDirectionRelativeToWorldObject = touchState.rayDirection;
+            const RAY_LENGTH_MM = 100 * 1000; // render it 100 meters long
+            let arUtils = realityEditor.gui.ar.utilities;
+            let rayOriginRelativeToWorldObject = realityEditor.sceneGraph.convertToNewCoordSystem([0, 0, 0], thatAvatarSceneNode, worldSceneNode);
+            let endRelativeToWorldObject = arUtils.add(rayOriginRelativeToWorldObject, arUtils.scalarMultiply(rayDirectionRelativeToWorldObject, RAY_LENGTH_MM));
+            let endRelativeToGroundPlane = realityEditor.sceneGraph.convertToNewCoordSystem(endRelativeToWorldObject, worldSceneNode, groundPlaneSceneNode);
+            convertedEndPosition.set(endRelativeToGroundPlane[0], endRelativeToGroundPlane[1], endRelativeToGroundPlane[2]);
         }
-        // scale the name textLabel based on distance from convertedEndPosition to camera
-        let camPos = realityEditor.sceneGraph.getWorldPosition('CAMERA');
-        let delta = {
-            x: camPos.x - convertedEndPosition.x,
-            y: camPos.y - convertedEndPosition.y,
-            z: camPos.z - convertedEndPosition.z
-        };
-        let distanceToCamera = Math.max(0.001, Math.sqrt(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z));
-        let scale = Math.max(0.5, Math.min(2, 2000 / distanceToCamera)); // biggest when <1m, smallest when >4m
-        avatarMeshes[objectKey].textLabel.style.transform = 'translateX(-50%) translateY(-50%) translateZ(3000px) scale(' + scale + ')';
-        avatarMeshes[objectKey].textLabel.style.left = screenCoords.x + 'px'; // position it centered on the pointer sphere
-        avatarMeshes[objectKey].textLabel.style.top = screenCoords.y + 'px';
 
         // the position of the avatar in space
         let startPosition = new THREE.Vector3(avatarObjectMatrixThree.elements[12], avatarObjectMatrixThree.elements[13], avatarObjectMatrixThree.elements[14]);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -146,7 +146,6 @@ createNameSpace("realityEditor.avatar");
                     if (!needsUpdate) return;
                     setBeamOn(lastPointerState.position.x, lastPointerState.position.y);
                     lastPointerState.viewMatrixChecksum = checksum;
-                    console.log('update from view matrix changing', checksum);
                 }
             } catch (e) {
                 console.warn('error updating my avatar', e);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -13,6 +13,7 @@ createNameSpace("realityEditor.avatar");
     let network, draw, utils; // shortcuts to access realityEditor.avatar._____
 
     const KEEP_ALIVE_HEARTBEAT_INTERVAL = 10000; // once per 10 seconds
+    const RAYCAST_AGAINST_GROUNDPLANE = false;
 
     let myAvatarId = null;
     let myAvatarObject = null;
@@ -77,6 +78,11 @@ createNameSpace("realityEditor.avatar");
                     myAvatarId = data.id;
                     connectionStatus.isMyAvatarCreated = true;
                     refreshStatusUI();
+
+                    // ping the server to discover the object more quickly
+                    for (let i = 0; i < 3; i++) {
+                        setTimeout(() => realityEditor.app.sendUDPMessage({action: 'ping'}), 300 * i * i);
+                    }
                 }, (err) => {
                     console.warn('unable to add avatar object to server', err);
                 });
@@ -232,8 +238,9 @@ createNameSpace("realityEditor.avatar");
                 worldIntersectPoint = raycastIntersects[0].point;
                 
             // if we don't hit against the area target mesh, try colliding with the ground plane
-            } else if (realityEditor.gui.threejsScene.getGroundPlaneCollider()) {
-                raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, [realityEditor.gui.threejsScene.getGroundPlaneCollider()]);
+            } else if (RAYCAST_AGAINST_GROUNDPLANE) {
+                let groundPlane = realityEditor.gui.threejsScene.getGroundPlaneCollider();
+                raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, [groundPlane]);
                 if (raycastIntersects.length > 0) {
                     worldIntersectPoint = raycastIntersects[0].point;
                 }


### PR DESCRIPTION
- Send infinite beam instead of segment if occlusion mesh hasn't loaded or if your tap is outside the scanned area
- Initialize avatar objects more quickly, and begin to handle errors/timeouts with visual feedback
- Send beam more smoothly, not just on pointer move but also if you move the camera around while holding down

Note: updates to draw.js are less drastic than they might appear – mostly just nesting the rendering in an if-statement to handle infinite rays a bit differently.