### PR TITLE
disable spatial cursor computations while its toggled off; temporarily remove cursor snapping

### DIFF
--- a/src/device/utilities.js
+++ b/src/device/utilities.js
@@ -184,22 +184,9 @@ realityEditor.device.utilities.removeBoundListener = function(element, eventType
  * @return {Array.<HTMLElement>}
  */
 realityEditor.device.utilities.getAllDivsUnderCoordinate = function(x, y) {
-    var res = [];
-    var previousDisplayTypes = [];
-
-    var ele = document.elementFromPoint(x,y);
-    while(ele && ele.tagName !== "BODY" && ele.tagName !== "HTML"){
-        res.push(ele);
-        previousDisplayTypes.push(ele.style.display);
-        ele.style.display = "none";
-        ele = document.elementFromPoint(x,y);
-    }
-
-    for(var i = 0; i < res.length; i++){
-        res[i].style.display = previousDisplayTypes[i];
-    }
-    // console.log(res);
-    return res;
+    return document.elementsFromPoint(x,y).filter(elt => {
+        return elt.tagName !== 'BODY' && elt.tagName !== 'HTML';
+    });
 };
 
 /**

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -4,9 +4,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
 (function(exports) {
 
-    /* TODO: enable this again after fixing getAllDivsUnderCoordinate to not set display:none to all elements
-        otherwise performance takes a big hit and scrolling in the pocket stops working */
-    const SNAP_CURSOR_TO_TOOLS = false;
+    const SNAP_CURSOR_TO_TOOLS = true;
 
     let isCursorEnabled = true;
     let isUpdateLoopRunning = false;


### PR DESCRIPTION
The `getAllDivsUnderCoordinate` function that the cursor uses was breaking pocket scroll and settings menu, and hurting performance – sets display:none and then resets display:inline to all overlapping elements during the calculation. I'm going to update this function to use pointer-events rather than display in the future, but disabling it for now as a temporary fix since the pointer-events way has some complications with conflicting CSS definitions.