### PR TITLE
Cleanup of various remote operator loading race conditions

### DIFF
--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -19,6 +19,14 @@ createNameSpace("realityEditor.device.environment");
         console.log('Default environment initialized');
     };
 
+    function isDesktop() {
+        const userAgent = window.navigator.userAgent;
+        const isWebView = userAgent.includes('Mobile') && !userAgent.includes('Safari');
+        const isMac = userAgent.includes('Macintosh');
+
+        return (!isWebView) || isMac;
+    }
+
     // initialized with default variables for iPhone environment. add-ons can modify
     let variables = {
         // booleans
@@ -34,7 +42,7 @@ createNameSpace("realityEditor.device.environment");
         shouldDisplayLogicMenuModally: false,
         isSourceOfObjectPositions: true,
         isCameraOrientationFlipped: false,
-        waitForARTracking: true,
+        waitForARTracking: !isDesktop(), // set to false on remote operator
         overrideMenusAndButtons: false,
         listenForDeviceOrientationChanges: true,
         enableViewFrustumCulling: true,

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -252,6 +252,8 @@ realityEditor.device.onload = function () {
 
     let cachedSettings = {};
     const localSettingsHost = `127.0.0.1:${realityEditor.device.environment.getLocalServerPort()}`;
+    // If we're viewing this on localhost we can connect to and read settings
+    // from the local server
     if (window.location.host.split(':')[0] === localSettingsHost.split(':')[0]) {
         setInterval(async () => {
             let settings;
@@ -286,6 +288,7 @@ realityEditor.device.onload = function () {
         }, 1000);
     }
 
+    // Check whether we're offline by adding a cache-busting search parameter
     fetch(window.location + '/?offlineCheck=' + Date.now()).then(res => {
         console.debug('offline check', Array.from(res.headers.entries()));
         if (!res.headers.has('X-Offline-Cache')) {

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -120,14 +120,16 @@ createNameSpace("realityEditor.worldObjects");
      * Tries again repeatedly every 1 second until it succeeds, in case server takes awhile to initialize
      */
     function tryLoadingLocalWorldObject() {
-        console.log('try loading local world object...');
-        let worldObjectBeat = { id: localWorldObjectKey,
+        let worldObjectBeat = {
+            id: localWorldObjectKey,
             ip: '127.0.0.1',
             port: realityEditor.device.environment.getLocalServerPort(),
             vn: 320,
             pr: 'R2',
             tcs: null,
-            zone: '' };
+            zone: '',
+        };
+        console.log('try loading local world object...', worldObjectBeat);
 
         if (!realityEditor.network.state.isCloudInterface) {
             realityEditor.network.addHeartbeatObject(worldObjectBeat);


### PR DESCRIPTION
Fixes an intermittent bug on Safari/Firefox where the remote operator's content scripts could be loaded later than various initService calls that relied on the remote operator's environment overrides. This directly overrides ar tracking to prevent a flash of the popup. It also adjusts the logic of desktopSocket creation to fix a race condition in a way that may be more universally applicable