### PR TITLE
Area target frustum culling shader

### DIFF
--- a/src/gui/ViewFrustum.js
+++ b/src/gui/ViewFrustum.js
@@ -277,19 +277,19 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
     //   ... perhaps swapping vPosition to vWorldPosition could fix this?
     // varying vec3 vWorldPosition;
      
-    bool isInside(vec3 normal, float D, vec3 point)
+    bool isInsidePlane(vec3 normal, float D, vec3 point)
     {
         return dot(normal, point) + D > 0.0;
     }
 
     bool isInsideFrustum(Frustum f)
     {
-        bool inside1 = isInside(f.normal1, f.D1, vPosition); // top (when un-rotated)
-        bool inside2 = isInside(f.normal2, f.D2, vPosition); // bottom
-        bool inside3 = isInside(f.normal3, f.D3, vPosition); // left
-        bool inside4 = isInside(f.normal4, f.D4, vPosition); // right (when un-rotated)
-        bool inside5 = isInside(f.normal5, f.D5, vPosition); // near
-        bool inside6 = isInside(f.normal6, f.D6, vPosition); // far
+        bool inside1 = isInsidePlane(f.normal1, f.D1, vPosition); // top (when un-rotated)
+        bool inside2 = isInsidePlane(f.normal2, f.D2, vPosition); // bottom
+        bool inside3 = isInsidePlane(f.normal3, f.D3, vPosition); // left
+        bool inside4 = isInsidePlane(f.normal4, f.D4, vPosition); // right (when un-rotated)
+        bool inside5 = isInsidePlane(f.normal5, f.D5, vPosition); // near
+        bool inside6 = isInsidePlane(f.normal6, f.D6, vPosition); // far
         
         return (inside1 && inside2 && inside3 && inside4 && inside5 && inside6);
     }

--- a/src/gui/ViewFrustum.js
+++ b/src/gui/ViewFrustum.js
@@ -1,0 +1,235 @@
+export const UNIFORMS = Object.freeze({
+    normal1: 'normal1',
+    normal2: 'normal2',
+    normal3: 'normal3',
+    normal4: 'normal4',
+    normal5: 'normal5',
+    normal6: 'normal6',
+    D1: 'D1',
+    D2: 'D2',
+    D3: 'D3',
+    D4: 'D4',
+    D5: 'D5',
+    D6: 'D6'
+});
+
+const GEO = Object.freeze({
+    TOP: 0,
+    BOTTOM: 1,
+    LEFT: 2,
+    RIGHT: 3,
+    NEARP: 4,
+    FARP: 5
+});
+const ANG2RAD = 3.14159265358979323846/180.0;
+
+// http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-implementation/
+export class ViewFrustum {
+    constructor() {
+        this.planes = [];
+    }
+    setCameraInternals(angle, ratio, nearD, farD) {
+        // store the information
+        this.ratio = ratio;
+        this.angle = angle;
+        this.nearD = nearD;
+        this.farD = farD;
+
+        // compute width and height of the near and far plane sections
+        let tang = Math.tan(ANG2RAD * angle * 0.5) ;
+        this.nh = nearD * tang;
+        this.nw = this.nh * ratio;
+        this.fh = farD  * tang;
+        this.fw = this.fh * ratio;
+    }
+    setCameraDef(p, l, u) {
+        let nc,fc,X,Y,Z;
+        let utils = realityEditor.gui.ar.utilities;
+
+        // compute the Z axis of camera
+        // this axis points in the opposite direction from
+        // the looking direction
+        Z = utils.subtract(p, l);
+        Z = utils.normalize(Z);
+
+        // X axis of camera with given "up" vector and Z axis
+        X = utils.crossProduct(u, Z);
+        X = utils.normalize(X);
+
+        // the real "up" vector is the cross product of Z and X
+        Y = utils.crossProduct(Z, X);
+
+        // compute the centers of the near and far planes
+        nc = utils.subtract(p, utils.scalarMultiply(Z, this.nearD));
+        fc = utils.subtract(p, utils.scalarMultiply(Z, this.farD));
+
+        // compute the 4 corners of the frustum on the near plane
+        let nearScaledX = utils.scalarMultiply(X, this.nw);
+        let nearScaledY = utils.scalarMultiply(Y, this.nh);
+        this.ntl = utils.subtract(utils.add(nc, nearScaledY), nearScaledX);
+        this.ntr = utils.add(utils.add(nc, nearScaledY), nearScaledX);
+        this.nbl = utils.subtract(utils.subtract(nc, nearScaledY), nearScaledX);
+        this.nbr = utils.add(utils.subtract(nc, nearScaledY), nearScaledX);
+
+        // compute the 4 corners of the frustum on the far plane
+        let farScaledX = utils.scalarMultiply(X, this.fw);
+        let farScaledY = utils.scalarMultiply(Y, this.fh);
+        this.ftl = utils.subtract(utils.add(fc, farScaledY), farScaledX);
+        this.ftr = utils.add(utils.add(fc, farScaledY), farScaledX);
+        this.fbl = utils.subtract(utils.subtract(fc, farScaledY), farScaledX);
+        this.fbr = utils.add(utils.subtract(fc, farScaledY), farScaledX);
+
+        // compute the six planes
+        // the function set3Points assumes that the points
+        // are given in counter clockwise order
+        this.planes[GEO.TOP] = new PlaneGeo().setPoints(this.ntr, this.ntl, this.ftl);
+        this.planes[GEO.BOTTOM] = new PlaneGeo().setPoints(this.nbl, this.nbr, this.fbr);
+        this.planes[GEO.LEFT] = new PlaneGeo().setPoints(this.ntl, this.nbl, this.fbl);
+        this.planes[GEO.RIGHT] = new PlaneGeo().setPoints(this.nbr, this.ntr, this.fbr);
+        this.planes[GEO.NEARP] = new PlaneGeo().setPoints(this.ntl, this.ntr, this.nbr);
+        this.planes[GEO.FARP] = new PlaneGeo().setPoints(this.ftr, this.ftl, this.fbl);
+
+        // TODO: replace with setNormalAndPoint implementation
+    }
+    isPointInFrustum(p) {
+        for (let i = 0; i < 6; i++) {
+            if (this.planes[i].distance(p) < 0) {
+                return false; // outside
+            }
+        }
+        return true; // inside
+    }
+}
+
+class PlaneGeo {
+    constructor(p1, p2, p3) {
+        if (p1 && p2 && p3) {
+            this.setPoints(p1, p2, p3);
+        }
+    }
+    /**
+     * Assumes points are given in clockwise order
+     * @param p1
+     * @param p2
+     * @param p3
+     */
+    setPoints(p1, p2, p3) {
+        let utils =  realityEditor.gui.ar.utilities;
+        this.p1 = p1;
+        this.p2 = p2;
+        this.p3 = p3;
+
+        // plane is defined by Ax + By + Cz + D = 0
+        // given p1, p2, p3 (three points on the plane) we can compute A, B, C, and D
+        let v = utils.subtract(p2, p1);
+        let u = utils.subtract(p3, p1);
+        this.normal = utils.normalize(utils.crossProduct(v, u));
+        this.A = this.normal[0];
+        this.B = this.normal[1];
+        this.C = this.normal[2];
+        this.D = -1 * utils.dotProduct(this.normal, p1); // signed distance to the origin
+        return this;
+    }
+    // setNormalAndPoint(normal, point) {
+    //     this.normal = normal;
+    //     this.point = point;
+    //     return this;
+    // }
+    // returns signed distance to a point
+    distance(p) {
+        // let distance = this.A * p[0] + this.B * p[1] + this.C * p[2] + D
+        return realityEditor.gui.ar.utilities.dotProduct(this.normal, p) + this.D;
+    }
+}
+
+export const frustumVertexShader = function() {
+    return THREE.ShaderChunk.meshphysical_vert
+        .replace('#define STANDARD', `#define STANDARD
+            // #define USE_TRANSMISSION
+            `)
+        .replace('#include <worldpos_vertex>', `#include <worldpos_vertex>
+            
+            // gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+    // orth_dist = length((position - coneTipPoint) - cone_dist * coneDirection);
+    
+        vPosition = position.xyz;
+            
+    `).replace('#include <common>', `#include <common>
+    // varying float len; // calculates this for initial loading animation
+    // uniform vec3 coneTipPoint; // pass in the position of a camera
+        varying vec3 vPosition;
+
+    `);
+}
+
+export const frustumFragmentShader = function() {
+    let condition = `
+    bool inside1 = isInside(normal1, D1, vPosition); // top (when un-rotated)
+    bool inside2 = isInside(normal2, D2, vPosition); // bottom
+    bool inside3 = isInside(normal3, D3, vPosition); // left
+    bool inside4 = isInside(normal4, D4, vPosition); // right (when un-rotated)
+    bool inside5 = isInside(normal5, D5, vPosition); // near
+    bool inside6 = isInside(normal6, D6, vPosition); // far
+    
+    if (inside1 && inside2 && inside3 && inside4 && inside5 && inside6) discard;
+    // if (inside1 && inside2 && inside3 && inside4 && inside6) discard;
+    `;
+    // 'if (inside > 0.5) discard;'
+    return THREE.ShaderChunk.meshphysical_frag
+        .replace('#include <clipping_planes_fragment>', `
+                         ${condition}
+
+                         #include <clipping_planes_fragment>`)
+        // .replace('vec4 diffuseColor = vec4( diffuse, opacity );', `vec4 diffuseColor = vec4( diffuse, opacity );
+        // if (!inside5) diffuseColor.x = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
+        // if (!inside3) diffuseColor.y = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
+        // if (!inside4) diffuseColor.z = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
+        //
+        // `)
+        .replace('#include <dithering_fragment>', `#include <dithering_fragment>
+            // gl_FragColor = vec4(0.5, 0.5, 0.5, 1.0);
+            // if (inside5 && inside6) gl_FragColor.x = 1.0;
+            // if (inside1 && inside2 && inside3 && inside4) gl_FragColor.y = 1.0;
+            // if (!inside4) gl_FragColor.z = 1.0;
+            `)
+        .replace(`#include <common>`, `
+                         #include <common>
+    
+    uniform int numFrustums;
+    struct Frustum {
+        vec3 normal1;
+        vec3 normal2;
+        vec3 normal3;
+        vec3 normal4;
+        vec3 normal5;
+        vec3 normal6;
+        float D1;
+        float D2;
+        float D3;
+        float D4;
+        float D5;
+        float D6;
+    }
+    uniform Frustum frustums[numFrustums];
+    
+    uniform vec3 normal1;
+    uniform vec3 normal2;
+    uniform vec3 normal3;
+    uniform vec3 normal4;
+    uniform vec3 normal5;
+    uniform vec3 normal6;
+    uniform float D1;
+    uniform float D2;
+    uniform float D3;
+    uniform float D4;
+    uniform float D5;
+    uniform float D6;
+    // varying vec3 vWorldPosition;
+    varying vec3 vPosition;
+    
+    bool isInside(vec3 normal, float D, vec3 point)
+    {
+        return dot(normal, point) + D > 0.0;
+    }
+    `);
+}

--- a/src/gui/ViewFrustum.js
+++ b/src/gui/ViewFrustum.js
@@ -1,7 +1,10 @@
 import { ShaderChunk } from '../../thirdPartyCode/three/three.module.js';
 
+// Set this to how many users can possibly be holding virtualizers at the same time
+// This populates the frustum shader with this many placeholder frustums, since array must compile with fixed length
 const MAX_VIEW_FRUSTUMS = 5;
 
+// names of the uniforms used in the frustum vertex and fragment shaders
 const UNIFORMS = Object.freeze({
     numFrustums: 'numFrustums',
     frustums: 'frustums',
@@ -208,7 +211,7 @@ const frustumVertexShader = function({useLoadingAnimation, center}) {
     return ShaderChunk.meshphysical_vert
         .replace('#include <worldpos_vertex>', `#include <worldpos_vertex>
         ${loadingCalcString}
-        vPosition = position.xyz; // make position accessible in the fragment shader
+        vPosition = position.xyz; // makes position accessible in the fragment shader
     `).replace('#include <common>', `#include <common>
         ${loadingUniformString}
         varying vec3 vPosition;
@@ -268,8 +271,11 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
     };
     uniform Frustum frustums[${MAX_VIEW_FRUSTUMS}]; // MAX number of frustums that can cull the geometry
     
-    // varying vec3 vWorldPosition;
     varying vec3 vPosition;
+    // todo: this shader only works if the mesh is exported with origin at (0,0,0)
+    //   and has identity scale and rotation (1 unit = 1 meter)
+    //   ... perhaps swapping vPosition to vWorldPosition could fix this?
+    // varying vec3 vWorldPosition;
      
     bool isInside(vec3 normal, float D, vec3 point)
     {

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -8,6 +8,7 @@ import { MeshBVH, acceleratedRaycast } from '../../thirdPartyCode/three-mesh-bvh
 import { TransformControls } from '../../thirdPartyCode/three/TransformControls.js';
 import { InfiniteGridHelper } from '../../thirdPartyCode/THREE.InfiniteGridHelper/InfiniteGridHelper.module.js';
 import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.module.js';
+import { ViewFrustum, frustumVertexShader, frustumFragmentShader } from './ViewFrustum.js';
 
 (function(exports) {
 
@@ -511,415 +512,40 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
         return groundPlaneCollider;
     }
 
-    const GEO = Object.freeze({
-        TOP: 0,
-        BOTTOM: 1,
-        LEFT: 2,
-        RIGHT: 3,
-        NEARP: 4,
-        FARP: 5
-    });
-    const ANG2RAD = 3.14159265358979323846/180.0;
+    // let cullingFrustum = new ViewFrustum(); // FrustumGeo();
+    // const iPhoneVerticalFOV = 41.22673; // https://discussions.apple.com/thread/250970597
+    // const widthToHeightRatio = 1920/1080; // 16/9; // window.innerWidth / window.innerHeight;
+    // const MAX_DIST = 5000 + 500; // extend it slightly beyond the extent of the LiDAR sensor
+    // cullingFrustum.setCameraInternals(iPhoneVerticalFOV * 0.95, widthToHeightRatio, 10/1000, MAX_DIST/1000);
+    let cullingFrustums = {};
     
-    class PlaneGeo {
-        constructor() {
-            this.utils = realityEditor.gui.ar.utilities;
-        }
-        /**
-         * Assumes points are given in clockwise order
-         * @param p1
-         * @param p2
-         * @param p3
-         */
-        setPoints(p1, p2, p3) {
-            let utils = this.utils;
-            this.p1 = p1;
-            this.p2 = p2;
-            this.p3 = p3;
-            
-            // plane is defined by Ax + By + Cz + D = 0
-            // given p1, p2, p3 (three points on the plane) we can compute A, B, C, and D
-            let v = utils.subtract(p2, p1);
-            let u = utils.subtract(p3, p1);
-            this.normal = utils.normalize(utils.crossProduct(v, u));
-            this.A = this.normal[0];
-            this.B = this.normal[1];
-            this.C = this.normal[2];
-            this.D = -1 * utils.dotProduct(this.normal, p1);
-            return this;
-        }
-        setNormalAndPoint(normal, point) {
-            this.normal = normal;
-            this.point = point;
-            return this;
-        }
-        // returns signed distance
-        distance(p) {
-            let utils = this.utils;
-            // let distance = this.A * p[0] + this.B * p[1] + this.C * p[2] + D
-            return utils.dotProduct(this.normal, p) + this.D;
-        }
-    }
-
-    const coneVertexShader = function(center) {
-        return THREE.ShaderChunk.meshphysical_vert
-            .replace('#include <worldpos_vertex>', `#include <worldpos_vertex>
-    len = length(position - vec3(${center.x}, ${center.y}, ${center.z})); // is point within loading radius
-    cone_dist = dot(position - coneTipPoint, coneDirection); // is point inside cone: https://stackoverflow.com/a/12826333
-    cone_radius = (cone_dist / coneHeight) * coneBaseRadius;
-    orth_dist = length((position - coneTipPoint) - cone_dist * coneDirection);
-    `).replace('#include <common>', `#include <common>
-    varying float len; // calculates this for initial loading animation
-    varying float cone_dist;
-    varying float cone_radius;
-    varying float orth_dist;
-    uniform vec3 coneTipPoint; // pass in the position of a camera
-    uniform vec3 coneDirection; // pass in the direction of the camera
-    uniform float coneHeight; // how far the cone extends, e.g. LiDAR has 5.0 meter range
-    uniform float coneBaseRadius; // radius in meters at base of cone. radius/height relates to camera FoV
-    `);
+    exports.createCullingFrustum = function(id) {
+        const iPhoneVerticalFOV = 41.22673; // https://discussions.apple.com/thread/250970597
+        const widthToHeightRatio = 1920/1080; // 16/9; // window.innerWidth / window.innerHeight;
+        const MAX_DIST = 5000 + 500; // extend it slightly beyond the extent of the LiDAR sensor
+        cullingFrustums[id] = new ViewFrustum();
+        cullingFrustums[id].setCameraInternals(iPhoneVerticalFOV * 0.95, widthToHeightRatio, 10/1000, MAX_DIST/1000);
     }
     
-    const coneFragmentShader = function(inverted) {
-        let condition = 'if (len > maxHeight) discard;';
-        if (inverted) {
-            // condition = 'if (len < maxHeight || len > (maxHeight + 8.0) / 2.0) discard;';
-            condition = 'if (len < maxHeight) discard;';
-        }
-        condition += `
-            if (cone_dist > 0.0 && cone_dist < coneHeight && orth_dist < cone_radius) discard;`
-        return THREE.ShaderChunk.meshphysical_frag
-            .replace('#include <clipping_planes_fragment>', `
-                         ${condition}
-
-                         #include <clipping_planes_fragment>`)
-            .replace(`#include <common>`, `
-                         #include <common>
-                         varying float len;
-                         uniform float maxHeight;
-                         uniform float coneHeight;
-                         varying float cone_dist;
-                         varying float cone_radius;
-                         varying float orth_dist;
-                         `);
-    }
-    
-    const optimizedCullingVertexShader = function() {
-        return THREE.ShaderChunk.meshphysical_vert
-            .replace('#define STANDARD', `#define STANDARD
-            // #define USE_TRANSMISSION
-            `)
-            .replace('#include <worldpos_vertex>', `#include <worldpos_vertex>
-            
-            // gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-    // orth_dist = length((position - coneTipPoint) - cone_dist * coneDirection);
-    
-        vPosition = position.xyz;
-            
-    `).replace('#include <common>', `#include <common>
-    // varying float len; // calculates this for initial loading animation
-    // uniform vec3 coneTipPoint; // pass in the position of a camera
-        varying vec3 vPosition;
-
-    `);
-    }
-    
-    const optimizedCullingFragmentShader = function() {
-        let condition = `
-    bool inside1 = isInside(normal1, D1, vPosition); // top (when un-rotated)
-    bool inside2 = isInside(normal2, D2, vPosition); // bottom
-    bool inside3 = isInside(normal3, D3, vPosition); // left
-    bool inside4 = isInside(normal4, D4, vPosition); // right (when un-rotated)
-    bool inside5 = isInside(normal5, D5, vPosition); // near
-    bool inside6 = isInside(normal6, D6, vPosition); // far
-    
-    if (inside1 && inside2 && inside3 && inside4 && inside5 && inside6) discard;
-    // if (inside1 && inside2 && inside3 && inside4 && inside6) discard;
-    `;
-        // 'if (inside > 0.5) discard;'
-        return THREE.ShaderChunk.meshphysical_frag
-            .replace('#include <clipping_planes_fragment>', `
-                         ${condition}
-
-                         #include <clipping_planes_fragment>`)
-            // .replace('vec4 diffuseColor = vec4( diffuse, opacity );', `vec4 diffuseColor = vec4( diffuse, opacity );
-            // if (!inside5) diffuseColor.x = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
-            // if (!inside3) diffuseColor.y = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
-            // if (!inside4) diffuseColor.z = 1.0; //vec4(1.0, 0.0, 0.0, 1.0);
-            //
-            // `)
-            .replace('#include <dithering_fragment>', `#include <dithering_fragment>
-            // gl_FragColor = vec4(0.5, 0.5, 0.5, 1.0);
-            // if (inside5 && inside6) gl_FragColor.x = 1.0;
-            // if (inside1 && inside2 && inside3 && inside4) gl_FragColor.y = 1.0;
-            // if (!inside4) gl_FragColor.z = 1.0;
-            `)
-            .replace(`#include <common>`, `
-                         #include <common>
-    
-    uniform vec3 normal1;
-    uniform vec3 normal2;
-    uniform vec3 normal3;
-    uniform vec3 normal4;
-    uniform vec3 normal5;
-    uniform vec3 normal6;
-    uniform float D1;
-    uniform float D2;
-    uniform float D3;
-    uniform float D4;
-    uniform float D5;
-    uniform float D6;
-    // varying vec3 vWorldPosition;
-    varying vec3 vPosition;
-    
-    bool isInside(vec3 normal, float D, vec3 point)
-    {
-        return dot(normal, point) + D > 0.0;
-    }
-    `);
-    }
-
-    const cullingVertexShader = function() {
-        return THREE.ShaderChunk.meshphysical_vert
-            .replace('#include <worldpos_vertex>', `#include <worldpos_vertex>
-            
-    #define ANG2RAD 3.14159265358979323846/180.0
-    // vec3 getPlaneNormal(vec3 p0, vec3 p1, vec3 p2);
-    
-    // compute width and height of the near and far plane sections
-    float tang = tan(ANG2RAD * angle * 0.5);
-    nh = nearD * tang;
-    nw = nh * ratio;
-    fh = farD * tang;
-    fw = fh * ratio;
-    
-    // compute the Z axis of camera
-    vec3 Z = normalize(p - l);
-    // X axis of camera with given "up" vector and Z axis
-    vec3 X = normalize(cross(u, Z));
-    // the real "up" vector is the cross product of Z and X
-    vec3 Y = cross(Z, X);
-    
-    // compute the centers of the near and far planes
-    vec3 nc = p - Z * nearD;
-    vec3 fc = p - Z * farD;
-    
-    // compute the 4 corners of the frustum on the near plane
-    vec3 ntl = nc + Y * nh - X * nw;
-    vec3 ntr = nc + Y * nh + X * nw;
-    vec3 nbl = nc - Y * nh - X * nw;
-    vec3 nbr = nc - Y * nh + X * nw;
-
-    // compute the 4 corners of the frustum on the far plane
-    vec3 ftl = fc + Y * fh - X * fw;
-    vec3 ftr = fc + Y * fh + X * fw;
-    vec3 fbl = fc - Y * fh - X * fw;
-    vec3 fbr = fc - Y * fh + X * fw;
-    
-    // compute the six planes
-    
-    vec3 normal1 = getPlaneNormal(ntr, ntl, ftl);
-    vec3 normal2 = getPlaneNormal(nbl, nbr, fbr);
-    vec3 normal3 = getPlaneNormal(ntl, nbl, fbl);
-    vec3 normal4 = getPlaneNormal(nbr, ntr, fbr);
-    vec3 normal5 = getPlaneNormal(ntl, ntr, nbr);
-    vec3 normal6 = getPlaneNormal(ftr, ftl, fbl);
-    
-    float D1 = getPlaneD(normal1, ntr);
-    float D2 = getPlaneD(normal2, nbl);
-    float D3 = getPlaneD(normal3, ntl);
-    float D4 = getPlaneD(normal4, nbr);
-    float D5 = getPlaneD(normal5, ntl);
-    float D6 = getPlaneD(normal6, ftr);
-    
-    bool inside1 = isInside(normal1, D1, position);
-    bool inside2 = isInside(normal2, D2, position);
-    bool inside3 = isInside(normal3, D3, position);
-    bool inside4 = isInside(normal4, D4, position);
-    bool inside5 = isInside(normal5, D5, position);
-    bool inside6 = isInside(normal6, D6, position);
-    
-    inside = 0.0;
-    if (inside1 && inside2 && inside3 && inside4 && inside5 && inside6) inside = 1.0;
-     
-    `).replace('#include <common>', `#include <common>
-    
-    uniform float angle; // vertical FoV
-    uniform float ratio; // width/height
-    uniform float nearD; // near plane distance
-    uniform float farD; // far plane distance
-    uniform vec3 p; // camera origin
-    uniform vec3 l; // camera forward vector
-    uniform vec3 u; // camera up vector
-    varying float nh;
-    varying float nw;
-    varying float fh;
-    varying float fw;
-    varying float inside;
-    
-    vec3 getPlaneNormal(vec3 p0, vec3 p1, vec3 p2)
-    {
-        vec3 v = p1 - p0;
-        vec3 u = p2 - p0;
-        return normalize(cross(v, u));
-    }
-    
-    float getPlaneD(vec3 normal, vec3 p0)
-    {
-        return -1.0 * dot(normal, p0);
-    }
-        
-    bool isInside(vec3 normal, float D, vec3 point)
-    {
-        return dot(normal, point) + D > 0.0;
-    }
-    
-    `);
-    }
-    
-    const cullingFragmentShader = function() {
-        let condition = 'if (inside > 0.5) discard;'
-        return THREE.ShaderChunk.meshphysical_frag
-            .replace('#include <clipping_planes_fragment>', `
-                         ${condition}
-
-                         #include <clipping_planes_fragment>`)
-            .replace(`#include <common>`, `
-                         #include <common>
-    uniform float angle; // vertical FoV
-    uniform float ratio; // width/height
-    uniform float nearD; // near plane distance
-    uniform float farD; // far plane distance
-    uniform vec3 p; // camera origin
-    uniform vec3 l; // camera forward vector
-    uniform vec3 u; // camera up vector
-    varying float nh;
-    varying float nw;
-    varying float fh;
-    varying float fw;
-    varying float inside;
-                         `);
-    }
-    
-    // http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-implementation/
-    class FrustumGeo {
-        constructor() {
-            this.utils = realityEditor.gui.ar.utilities;
-            this.planes = [];
-        }
-        setCameraInternals(angle, ratio, nearD, farD) {
-            // store the information
-            this.ratio = ratio;
-            this.angle = angle;
-            this.nearD = nearD;
-            this.farD = farD;
-
-            // compute width and height of the near and far plane sections
-            let tang = Math.tan(ANG2RAD * angle * 0.5) ;
-            this.nh = nearD * tang;
-            this.nw = this.nh * ratio;
-            this.fh = farD  * tang;
-            this.fw = this.fh * ratio;
-        }
-        setCameraDef(p, l, u) {
-            let dir,nc,fc,X,Y,Z;
-            let utils = this.utils;
-
-            // compute the Z axis of camera
-            // this axis points in the opposite direction from
-            // the looking direction
-            Z = utils.subtract(p, l);
-            Z = utils.normalize(Z);
-
-            // X axis of camera with given "up" vector and Z axis
-            X = utils.crossProduct(u, Z);
-            X = utils.normalize(X);
-
-            // the real "up" vector is the cross product of Z and X
-            Y = utils.crossProduct(Z, X);
-
-            // compute the centers of the near and far planes
-            nc = utils.subtract(p, utils.scalarMultiply(Z, this.nearD));
-            fc = utils.subtract(p, utils.scalarMultiply(Z, this.farD));
-
-            // compute the 4 corners of the frustum on the near plane
-            let nearScaledX = utils.scalarMultiply(X, this.nw);
-            let nearScaledY = utils.scalarMultiply(Y, this.nh);
-            this.ntl = utils.subtract(utils.add(nc, nearScaledY), nearScaledX);
-            this.ntr = utils.add(utils.add(nc, nearScaledY), nearScaledX);
-            this.nbl = utils.subtract(utils.subtract(nc, nearScaledY), nearScaledX);
-            this.nbr = utils.add(utils.subtract(nc, nearScaledY), nearScaledX);
-
-            // compute the 4 corners of the frustum on the far plane
-            let farScaledX = utils.scalarMultiply(X, this.fw);
-            let farScaledY = utils.scalarMultiply(Y, this.fh);
-            this.ftl = utils.subtract(utils.add(fc, farScaledY), farScaledX);
-            this.ftr = utils.add(utils.add(fc, farScaledY), farScaledX);
-            this.fbl = utils.subtract(utils.subtract(fc, farScaledY), farScaledX);
-            this.fbr = utils.add(utils.subtract(fc, farScaledY), farScaledX);
-
-            // compute the six planes
-            // the function set3Points assumes that the points
-            // are given in counter clockwise order
-            this.planes[GEO.TOP] = new PlaneGeo().setPoints(this.ntr, this.ntl, this.ftl);
-            this.planes[GEO.BOTTOM] = new PlaneGeo().setPoints(this.nbl, this.nbr, this.fbr);
-            this.planes[GEO.LEFT] = new PlaneGeo().setPoints(this.ntl, this.nbl, this.fbl);
-            this.planes[GEO.RIGHT] = new PlaneGeo().setPoints(this.nbr, this.ntr, this.fbr);
-            this.planes[GEO.NEARP] = new PlaneGeo().setPoints(this.ntl, this.ntr, this.nbr);
-            this.planes[GEO.FARP] = new PlaneGeo().setPoints(this.ftr, this.ftl, this.fbl);
-            
-            // TODO: replace with setNormalAndPoint implementation
-        }
-        isPointInFrustum(p) {
-            for (let i = 0; i < 6; i++) {
-                if (this.planes[i].distance(p) < 0) {
-                    return false; // outside
-                }
-            }
-            return true; // inside
-        }
-    }
-
-    let cullingFrustum = new FrustumGeo();
-    const iPhoneHorizontalFOX = 73.29196; // https://discussions.apple.com/thread/250970597
-    const iPhoneVerticalFOV = 41.22673; // https://discussions.apple.com/thread/250970597
-    const widthToHeightRatio = 1920/1080; // 16/9; // window.innerWidth / window.innerHeight;
-    const MAX_DIST = 5500;
-    cullingFrustum.setCameraInternals(iPhoneVerticalFOV * 0.95, widthToHeightRatio, 10/1000, MAX_DIST/1000);
-
-    let cameraPosition = [0.05608870697021484, 0.38426324701309217, 0.4168415222167969]; // [0, 0, 0];
-    let cameraForward = [-0.05006729596487764, -0.10317421216363985, 0.9934024098114408]; // [1, 0, 0];
-    let cameraUp = [-0.9983388996355061, 0.033561153354058376, -0.04683044373174655]; // [0, 1, 0];
-    cullingFrustum.setCameraDef(cameraPosition, cameraForward, cameraUp);
-
-    window.cullingFrustum = cullingFrustum;
-    
-    exports.updateFrustum = function(cameraPosition, cameraForward, cameraUp) {
-        // let posVec = [cameraPosition.x, cameraPosition.y, cameraPosition.z];
-        // let forwardVec = [cameraForward.x, cameraForward.y, cameraForward.z];
-        // let upVec = [cameraUp.x, cameraUp.y, cameraUp.z];
-        // cullingFrustum.setCameraDef(posVec, forwardVec, upVec);
-        cullingFrustum.setCameraDef(cameraPosition, cameraForward, cameraUp);
+    exports.updateFrustum = function(id, cameraPosition, cameraForward, cameraUp) {
+        cullingFrustums[id].setCameraDef(cameraPosition, cameraForward, cameraUp);
         return {
-            normal1: cullingFrustum.planes[0].normal,
-            normal2: cullingFrustum.planes[1].normal,
-            normal3: cullingFrustum.planes[2].normal,
-            normal4: cullingFrustum.planes[3].normal,
-            normal5: cullingFrustum.planes[4].normal,
-            normal6: cullingFrustum.planes[5].normal,
-            D1: cullingFrustum.planes[0].D,
-            D2: cullingFrustum.planes[1].D,
-            D3: cullingFrustum.planes[2].D,
-            D4: cullingFrustum.planes[3].D,
-            D5: cullingFrustum.planes[4].D,
-            D6: cullingFrustum.planes[5].D,
+            normal1: cullingFrustums[id].planes[0].normal,
+            normal2: cullingFrustums[id].planes[1].normal,
+            normal3: cullingFrustums[id].planes[2].normal,
+            normal4: cullingFrustums[id].planes[3].normal,
+            normal5: cullingFrustums[id].planes[4].normal,
+            normal6: cullingFrustums[id].planes[5].normal,
+            D1: cullingFrustums[id].planes[0].D,
+            D2: cullingFrustums[id].planes[1].D,
+            D3: cullingFrustums[id].planes[2].D,
+            D4: cullingFrustums[id].planes[3].D,
+            D5: cullingFrustums[id].planes[4].D,
+            D6: cullingFrustums[id].planes[5].D,
         }
     }
     
     const startTime = Date.now();
-    window.dx = 0;
-    window.dy = 0;
-    window.dz = 0;
 
     class CustomMaterials {
         constructor() {
@@ -927,18 +553,10 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
             this.lastUpdate = -1;
         }
         areaTargetVertexShader(_center) {
-            // return coneVertexShader();
-            // return cullingVertexShader(); 
-            let shader = optimizedCullingVertexShader();
-            console.log(shader);
-            return shader;
+            return frustumVertexShader();
         }
         areaTargetFragmentShader(_inverted) {
-            // return coneFragmentShader();
-            // return cullingFragmentShader();
-            let shader = optimizedCullingFragmentShader();
-            console.log(shader);
-            return shader;
+            return frustumFragmentShader();
         }
         areaTargetMaterialWithTextureAndHeight(sourceMaterial, maxHeight, center, animateOnLoad, inverted) {
             let material = sourceMaterial.clone();
@@ -947,19 +565,23 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
                 {
                     maxHeight: {value: maxHeight},
                     
-                    // coneHeight: {value: 0.0}, // set height >0 and radius >0 when a virtualizer connects to begin the effect
-                    // coneBaseRadius: {value: 0.0},
-                    // coneTipPoint: {value: new THREE.Vector3(0, 0, 0)},
-                    // coneDirection: {value: new THREE.Vector3(1, 0, 0)}
-
-                    // angle: {value: 41.22673},
-                    // ratio: {value: 9/16},
-                    // nearD: {value: 0.1},
-                    // farD: {value: 5},
-                    // p: {value: new THREE.Vector3(0, 0, 0)},
-                    // l: {value: new THREE.Vector3(1, 0, 0)},
-                    // u: {value: new THREE.Vector3(0, 1, 0)}
-
+                    frustums: {
+                        value: [],
+                        properties: {
+                            normal1: {x: 1, y: 0, z: 0},
+                            normal2: {x: 1, y: 0, z: 0},
+                            normal3: {x: 1, y: 0, z: 0},
+                            normal4: {x: 1, y: 0, z: 0},
+                            normal5: {x: 1, y: 0, z: 0},
+                            normal6: {x: 1, y: 0, z: 0},
+                            D1: 0,
+                            D2: 0,
+                            D3: 0,
+                            D4: 0,
+                            D5: 0,
+                            D6: 0
+                        }
+                    },
                     
                     normal1: {value: {x: -0.180438255839729, y: -0.15260992462598252, z: -0.971674969696744}}, //{value: new THREE.Vector3(1, 0, 0)},
                     normal2: {value: {x: 0.7361757787476327, y: -0.14757905544534186, z: 0.6605040841502627}}, //{value: new THREE.Vector3(1, 0, 0)},
@@ -973,14 +595,6 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
                     D4: {value: 0.004798679055097274},
                     D5: {value: 0.534052103220726},
                     D6: {value: 4.455947896779274}
-
-                    // uniform float angle; // vertical FoV
-                    // uniform float ratio; // width/height
-                    // uniform float nearD; // near plane distance
-                    // uniform float farD; // far plane distance
-                    // uniform vec3 p; // camera origin
-                    // uniform vec3 l; // camera forward vector
-                    // uniform vec3 u; // camera up vector
                 }
             ]);
 
@@ -1019,74 +633,8 @@ import { RoomEnvironment } from '../../thirdPartyCode/three/RoomEnvironment.modu
                     entry.currentHeight += entry.animationSpeed * dt;
                     material.uniforms['maxHeight'].value = entry.currentHeight;
                 } else {
-                    // indicesToRemove.push(index);
+                    indicesToRemove.push(index);
                 }
-                
-                // material.uniforms['p'].value.y = Math.sin(now / 1000);
-                
-                window.DO_ANIMATE = false;
-                
-                if (window.DO_ANIMATE) {
-
-                    // let cameraPos = [now / 5000, 0, 0];
-                    // let cameraDirection = [1, 0, 0];
-                    // let cameraUp = [0, 1, 0];
-                    let cosT = Math.cos(now / 1000);
-                    let sinT = Math.sin(now / 1000);
-
-                    // let cameraPosition = [0.05608870697021484, 0, 0.4168415222167969]; // [0, 0, 0];
-                    // let cameraPosition = [0.05608870697021484 + window.dx, window.dy, 0.4168415222167969 + window.dz]; // [0, 0, 0];
-                    let cameraPosition = [0, 0, (Date.now()-startTime)/3000]; // [0, 0, 0];
-                    
-                    let cameraForward = realityEditor.gui.ar.utilities.add(cameraPosition, [cosT, 0, sinT]); //[-0.05006729596487764, -0.10317421216363985, 0.9934024098114408]; // [1, 0, 0];
-                    
-                    let cameraUp = [-1, 0, 0]; //[-0.9983388996355061, 0.033561153354058376, -0.04683044373174655]; // [0, 1, 0];
-                    // cullingFrustum.setCameraDef(cameraPosition, cameraForward, cameraUp);
-
-                    let frustumPlanes = realityEditor.gui.threejsScene.updateFrustum(cameraPosition, cameraForward, cameraUp);
-
-                    const UNIFORMS = Object.freeze({
-                        coneTipPoint: 'coneTipPoint',
-                        coneDirection: 'coneDirection',
-                        coneHeight: 'coneHeight',
-                        coneBaseRadius: 'coneBaseRadius',
-                        p: 'p',
-                        l: 'l',
-                        u: 'u',
-                        normal1: 'normal1',
-                        normal2: 'normal2',
-                        normal3: 'normal3',
-                        normal4: 'normal4',
-                        normal5: 'normal5',
-                        normal6: 'normal6',
-                        D1: 'D1',
-                        D2: 'D2',
-                        D3: 'D3',
-                        D4: 'D4',
-                        D5: 'D5',
-                        D6: 'D6'
-                    });
-                    const SCALE = 1000;
-
-                    function array3ToXYZ(arr3) {
-                        return new THREE.Vector3(arr3[0], arr3[1], arr3[2]);
-                    }
-
-                    material.uniforms[UNIFORMS.normal1].value = array3ToXYZ(frustumPlanes.normal1);
-                    material.uniforms[UNIFORMS.normal2].value = array3ToXYZ(frustumPlanes.normal2);
-                    material.uniforms[UNIFORMS.normal3].value = array3ToXYZ(frustumPlanes.normal3);
-                    material.uniforms[UNIFORMS.normal4].value = array3ToXYZ(frustumPlanes.normal4);
-                    material.uniforms[UNIFORMS.normal5].value = array3ToXYZ(frustumPlanes.normal5);
-                    material.uniforms[UNIFORMS.normal6].value = array3ToXYZ(frustumPlanes.normal6);
-
-                    material.uniforms[UNIFORMS.D1].value = frustumPlanes.D1;
-                    material.uniforms[UNIFORMS.D2].value = frustumPlanes.D2;
-                    material.uniforms[UNIFORMS.D3].value = frustumPlanes.D3;
-                    material.uniforms[UNIFORMS.D4].value = frustumPlanes.D4;
-                    material.uniforms[UNIFORMS.D5].value = frustumPlanes.D5;
-                    material.uniforms[UNIFORMS.D6].value = frustumPlanes.D6;
-                }
-
             });
 
             for (let i = indicesToRemove.length-1; i > 0; i--) {


### PR DESCRIPTION
Instantiates a ViewFrustum for each virtualizer that sends an update message to the threejsInterface. Discards points that fall within the volume of any of the frustums. Supports up to MAX_VIEW_FRUSTUMS clients at a time, which I currently set to 5.