### PR TITLE
frustum shrinks based on maxDepth and renders wireframe inside frustum

### DIFF
--- a/src/gui/ViewFrustum.js
+++ b/src/gui/ViewFrustum.js
@@ -264,9 +264,9 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
         .replace('#include <dithering_fragment>', `#include <dithering_fragment>
             // make the texture darker if a client connects
             if (numFrustums > 0 && !clipped) {
-                gl_FragColor.r *= 0.5;
-                gl_FragColor.g *= 0.5;
-                gl_FragColor.b *= 0.5;
+                gl_FragColor.r *= 0.8;
+                gl_FragColor.g *= 0.8;
+                gl_FragColor.b *= 0.8;
 
             // render the area inside the frustum as a wireframe
             } else if (clipped) {

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -497,7 +497,9 @@ export class HumanPoseAnalyzer {
     hideLastDisplayedClone(timestamp) {
         if (this.lastDisplayedCloneIndex >= 0) {
             let lastClone = this.clonesAll[this.lastDisplayedCloneIndex];
-            lastClone.poseObject.visible = false;
+            if (lastClone) {
+                lastClone.poseObject.visible = false;
+            }
             if (timestamp >= 0 && lastClone.timestamp > timestamp) {
                 this.lastDisplayedCloneIndex = 0;
             }


### PR DESCRIPTION
This is a visual experiment based on a discussion with @valentinptc. The idea is to darken the gltf when a virtualizer connects, so that the video stands out more, and to render wireframes in the "shadows" cast by the culling frustum so that we preserve a sense of the geometry. In this approach, rather than using the wireMesh underneath, I render a wireframe effect within the culling frustum using a shader.

@hobinjk-ptc I will be out of office so I'll leave this in your hands if you'd like to merge it or further experiment in this direction.

![wireframe-mesh-with-pointcloud-v3 2022-12-12 17_32_07](https://user-images.githubusercontent.com/32580292/207169643-5e2d228f-440d-4d71-ae2b-360f8cd33163.gif)



Requires https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/pull/84