### PR TITLE
Fade frustum cutout based on viewing angle; prepare spatial cursor for new features

### DIFF
--- a/src/gui/ViewFrustum.js
+++ b/src/gui/ViewFrustum.js
@@ -243,23 +243,19 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
     }
     let condition = `
     ${loadingConditionString}
+    // we compare the viewing angle to the frustum direction, to show wireframe more if viewing from an off-angle
     float maxViewAngleSimilarity = 0.0;
     
     bool clipped = false;
-    if (numFrustums > 0)
+    for (int i = 0; i < numFrustums; i++)
     {
-        for (int i = 0; i < numFrustums; i++)
-        {
-            bool isInside = isInsideFrustum(frustums[i]);
-            if (isInside) {
-                maxViewAngleSimilarity = max(maxViewAngleSimilarity, abs(frustums[i].cameraIncidence));
-            }
-            clipped = clipped || isInsideFrustum(frustums[i]);
-            if (clipped) {
-                // discard; // uncomment to fully discard all points within frustums instead of wireframing them
-                // break;
-            }
+        bool isInside = isInsideFrustum(frustums[i]);
+        if (isInside) {
+            // by taking the max, we will set the transparency by the most-aligned frustum to this view, ignoring the others
+            maxViewAngleSimilarity = max(maxViewAngleSimilarity, abs(frustums[i].viewAngleSimilarity));
         }
+        clipped = clipped || isInside;
+        // if (clipped) discard; // uncomment to fully discard all points within frustums instead of wireframing them
     }
     `;
     return ShaderChunk.meshphysical_frag
@@ -276,16 +272,15 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
 
             // render the area inside the frustum as a wireframe
             } else if (clipped) {
-                float textureScale = max(0.0, 0.95 - maxViewAngleSimilarity);
-                float wireframeScale = max(0.0, 0.8 - maxViewAngleSimilarity);
+                // mesh fades out if it's cutout by a frustum that is closely aligned with the viewing angle
+                float textureOpacity = 0.3 * (0.1 + max(0.0, 0.95 - maxViewAngleSimilarity));
+                float wireframeOpacity = 0.3 * (0.1 + max(0.0, 0.8 - maxViewAngleSimilarity)); // wireframe fades out earlier
                 
+                // show wireframe by calculating whether this point is very close to any of the three triangle edges
                 float min_dist = min(min(vBarycentric.x, vBarycentric.y), vBarycentric.z);
                 float edgeIntensity = 1.0 - step(0.03, min_dist); // 1 if on edge, 0 otherwise. Adjust 0.03 to make wireframe thicker/thinner.
-    
-                float wireframeOpacity = 0.3 * (0.1 + wireframeScale);
-                float textureOpacity = 0.3 * (0.1 + textureScale);
 
-                if (edgeIntensity > 0.5) { // brighten the edges
+                if (edgeIntensity > 0.5) { // the "wireframe" is rendered by brightening the edges 50%
                     float r = 0.5 + 0.5 * gl_FragColor.r;
                     float g = 0.5 + 0.5 * gl_FragColor.g;
                     float b = 0.5 + 0.5 * gl_FragColor.b;
@@ -293,43 +288,6 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
                 } else {
                     gl_FragColor.a = textureOpacity;
                 }
-            
-                // if (maxViewAngleSimilarity > 0.95) {
-                //     discard; // totally hide if following / viewing from very similar angle
-                // } else if (maxViewAngleSimilarity > 0.8) {
-                //     // don't show wireframes, but show faint mesh if close but not exact
-                //     float opacity = 0.1 + 0.2 * (1.0 - maxViewAngleSimilarity);
-                //     gl_FragColor.a = opacity;
-                // } else {
-                //     // show wireframe by calculating whether this point is very close to any of the three triangle edges
-                //     float min_dist = min(min(vBarycentric.x, vBarycentric.y), vBarycentric.z);
-                //     float edgeIntensity = 1.0 - step(0.03, min_dist); // 1 if on edge, 0 otherwise. Adjust 0.03 to make wireframe thicker/thinner.
-                //
-                //     // uncomment to include texture in between the wireframes
-                //     float opacity = 0.1 + 0.2 * (1.0 - maxViewAngleSimilarity);
-                //     if (edgeIntensity > 0.5) { // brighten the edges
-                //         float r = 0.5 + 0.5 * gl_FragColor.r;
-                //         float g = 0.5 + 0.5 * gl_FragColor.g;
-                //         float b = 0.5 + 0.5 * gl_FragColor.b;                        
-                //         gl_FragColor = edgeIntensity * vec4(r, g, b, opacity);
-                //         // gl_FragColor = edgeIntensity * vec4(1.0, 1.0, 1.0, opacity);
-                //     } else {
-                //         gl_FragColor.a = opacity;
-                //     }
-                //    
-                //     // gl_FragColor.a = 0.3 * (1.0 - maxViewAngleSimilarity);
-                //    
-                //     // vec4 diffuse = texture2D(u_texture, v_texcoord) * vec4(vec3(v_light_intensity), 1.0);
-                //     // gl_FragColor = edgeIntensity * vec4(0.0, 1.0, 1.0, 1.0) + (1.0 - edgeIntensity) * diffuse;
-                //
-                //     // white if on edge, transparent if not. adjust 0.3 to change opacity of lines.
-                //     // gl_FragColor = edgeIntensity * vec4(1.0, 1.0, 1.0, 0.3 * (1.0 - maxViewAngleSimilarity));
-                //
-                //     // to ensure that in between the wireframes is fully transparent, it's easiest to just discard the point
-                //     // if (edgeIntensity < 0.5) {
-                //     //     discard;
-                //     // }
-                // }
             }
             `)
         .replace(`#include <common>`, `
@@ -349,10 +307,9 @@ const frustumFragmentShader = function({useLoadingAnimation, inverted}) {
         float D4;
         float D5;
         float D6;
-        float cameraIncidence; // 1 if camera is pointing in same direction as frustum
+        float viewAngleSimilarity; // 1 if camera is pointing in same direction as frustum
     };
     uniform Frustum frustums[${MAX_VIEW_FRUSTUMS}]; // MAX number of frustums that can cull the geometry
-    uniform vec3 cameraDirection;
     
     varying vec3 vBarycentric;
     varying vec3 vPosition;

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -520,6 +520,11 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
 
         raycaster.firstHitOnly = true; // faster (using three-mesh-bvh)
 
+        // add object layer to raycast layer mask
+        objectsToCheck.forEach(obj => {
+            raycaster.layers.mask = raycaster.layers.mask | obj.layers.mask;
+        });
+
         //3. compute intersections
         let results = raycaster.intersectObjects( objectsToCheck || scene.children, true );
         results.forEach(intersection => {

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -606,10 +606,8 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
         frustum.setCameraDef(cameraPosition, cameraLookAtPosition, cameraUp);
 
         let viewingCameraForwardVector = realityEditor.gui.ar.utilities.getForwardVector(realityEditor.sceneGraph.getCameraNode().worldMatrix);
-        // customMaterials.updateCameraDirection();
-        // let viewingCameraDirection = new THREE.Vector3(viewingCameraForwardVector[0], viewingCameraForwardVector[1], viewingCameraForwardVector[2]);
         let angleOfIncidence = realityEditor.gui.ar.utilities.dotProduct(materialCullingFrustums[id].planes[5].normal, viewingCameraForwardVector);
-        angleOfIncidence = Math.max(0, angleOfIncidence);
+        angleOfIncidence = Math.max(0, angleOfIncidence); // angle can go to -1 if viewing from anti-parallel direction, but limit it to 0
         
         return {
             normal1: array3ToXYZ(materialCullingFrustums[id].planes[0].normal),
@@ -745,8 +743,7 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
                 {
                     maxHeight: {value: maxHeight},
                     numFrustums: {value: 0},
-                    frustums: {value: defaultFrustums},
-                    cameraDirection: {value: new THREE.Vector3(1, 0, 0)}
+                    frustums: {value: defaultFrustums}
                 }
             ]);
 

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -5,8 +5,9 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 (function(exports) {
 
     const SNAP_CURSOR_TO_TOOLS = true;
+    const DEFAULT_SPATIAL_CURSOR_ON = false;
 
-    let isCursorEnabled = true;
+    let isCursorEnabled = DEFAULT_SPATIAL_CURSOR_ON;
     let isUpdateLoopRunning = false;
 
     let cachedWorldObject;
@@ -92,7 +93,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         
         addSpatialCursor();
         addTestSpatialCursor();
-        toggleDisplaySpatialCursor(false);
+        toggleDisplaySpatialCursor(DEFAULT_SPATIAL_CURSOR_ON);
 
         // begin update loop
         update();
@@ -103,7 +104,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             document.addEventListener('pointerdown', (e) => {
                 if (!indicator2 || !indicator2.visible) return;
                 if (realityEditor.device.isMouseEventCameraControl(e)) return;
-                if (e.target.tagName !== 'CANVAS') return; // if clicking on a button, etc, don't trigger this
+                if (!realityEditor.device.utilities.isEventHittingBackground(e)) return; // if clicking on a button, etc, don't trigger this
 
                 // raycast against the spatial cursor
                 let intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.clientX, e.clientY, [indicator2]);
@@ -226,12 +227,6 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         isCursorEnabled = newValue;
         indicator1.visible = newValue;
         indicator2.visible = newValue;
-        
-        if (newValue) {
-            document.getElementById('canvas').style.cursor = 'none';
-        } else {
-            document.getElementById('canvas').style.cursor = 'auto';
-        }
 
         if (isCursorEnabled && !isUpdateLoopRunning) {
             update(); // restart the update loop

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -115,7 +115,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         }
     }
 
-    // copied from pop-up-onboarding addon – should we refactor somewhere convenient to both?
+    // publicly accessible function to add a tool at the spatial cursor position (or floating in front of you)
     function addToolAtScreenCenter(toolName) {
         let touchPosition = {
             x: window.innerWidth / 2,
@@ -128,11 +128,13 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         y = touchPosition.y;
         noUserInteraction = true;
 
+        // automatically adds the tool at the spatial cursor, if the cursor is active
         let addedElement = realityEditor.gui.pocket.createFrame(toolName, startPositionOffset, width, height, nodesList, x, y, noUserInteraction, objectKeyToAddTo);
 
-        if (typeof realityEditor.spatialCursor !== 'undefined' && realityEditor.spatialCursor.getOrientedCursorRelativeToWorldObject()) {
-            realityEditor.device.resetEditingState();
+        if (getOrientedCursorRelativeToWorldObject()) {
+            realityEditor.device.resetEditingState(); // make sure we don't drag the tool after adding
         } else {
+            // if cursor isn't active, default move the tool to be floating .4m in front of the camera
             realityEditor.gui.ar.positioning.moveFrameToCamera(addedElement.objectId, addedElement.uuid, 400);
         }
 
@@ -370,4 +372,5 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     exports.getOrientedCursorRelativeToWorldObject = getOrientedCursorRelativeToWorldObject;
     exports.toggleDisplaySpatialCursor = toggleDisplaySpatialCursor;
     exports.isSpatialCursorEnabled = () => { return isCursorEnabled; }
+    exports.addToolAtScreenCenter = addToolAtScreenCenter;
 }(realityEditor.spatialCursor));


### PR DESCRIPTION
One last update for the area target shader: based on the similarity between the viewing angle and the virtualizer angle, the mesh wireframe fades in and out. Since you mostly want to see the shadows filled in when you're looking at it from different angles. And when you're perfectly aligned with the virtualizer, you only see the live image data. This minimizes distracting visual effects while you're following a virtualizer.

This PR also includes an update for the spatial cursor to make it follow the remote operator mouse, and to allow it to instantiate new tools at its location. But those effects are toggled off now with two flags: DEFAULT_SPATIAL_CURSOR_ON=false and ADD_SEARCH_TOOL_WITH_CURSOR=false

![wireframe-mesh-with-pointcloud-v6 2023-01-11 16_35_29](https://user-images.githubusercontent.com/32580292/211922850-174d409f-0c65-44cc-a392-8c3eb2112611.gif)
