### PR TITLE
adds ability to setCustomTrashZone in an addon

### DIFF
--- a/src/device/index.js
+++ b/src/device/index.js
@@ -928,7 +928,7 @@ realityEditor.device.onElementMultiTouchEnd = function(event) {
     var activeVehicle = this.getEditingVehicle();
     
     var isOverTrash = false;
-    if (event.pageX >= this.layout.getTrashThresholdX()) {
+    if (this.isPointerInTrashZone(event.pageX, event.pageY)) {
         if (globalStates.guiState === "ui" && activeVehicle && activeVehicle.location === "global") {
             isOverTrash = true;
         } else if (activeVehicle && activeVehicle.type === "logic") {
@@ -1133,8 +1133,14 @@ realityEditor.device.onDocumentPointerUp = function(event) {
     cout("onDocumentPointerUp");
 };
 
-realityEditor.device.isPointerInTrashZone = function(pointerX, _pointerY) {
-    return pointerX > realityEditor.device.layout.getTrashThresholdX();
+realityEditor.device.isPointerInTrashZone = function(x, y) {
+    let customTrashZone = realityEditor.device.layout.getCustomTrashZone();
+    if (customTrashZone) {
+        return (x > customTrashZone.x && x < (customTrashZone.x + customTrashZone.width) &&
+            y > customTrashZone.y && y < (customTrashZone.y + customTrashZone.height));
+    } else {
+        return x > realityEditor.device.layout.getTrashThresholdX(); // by default, just uses right edge of screen
+    }
 };
 
 realityEditor.device.tryToDeleteSelectedVehicle = function() {
@@ -1406,7 +1412,7 @@ realityEditor.device.onDocumentMultiTouchMove = function (event) {
             var isDeletableVehicle = activeVehicle.type === 'logic' || (globalStates.guiState === "ui" && activeVehicle && activeVehicle.location === "global");
             
             // visual feedback if you move over the trash
-            if (event.pageX >= this.layout.getTrashThresholdX() && isDeletableVehicle) {
+            if (this.isPointerInTrashZone(event.pageX, event.pageY) && isDeletableVehicle) {
                 overlayDiv.classList.add('overlayNegative');
             } else {
                 overlayDiv.classList.remove('overlayNegative');

--- a/src/device/layout.js
+++ b/src/device/layout.js
@@ -70,6 +70,9 @@ createNameSpace('realityEditor.device.layout');
 
     let knownDeviceName;
 
+    // by default, trash is by right edge of screen, but you can use setTrashZoneRect to define different bounds
+    let customTrashZone = null;
+
     /**
      * Center the menu buttons vertically on screens taller than MENU_HEIGHT.
      * Adjusts the CSS of various UI elements (buttons, pocket, settings menu, crafting board)
@@ -170,6 +173,15 @@ createNameSpace('realityEditor.device.layout');
         }
     }
 
+    function setTrashZoneRect(x, y, width, height) {
+        customTrashZone = {
+            x: x,
+            y: y,
+            width: width,
+            height: height
+        };
+    }
+
     /**
      * Returns the x-coordinate of the edge of the trash drop-zone, adjusted for different screen sizes.
      * @return {number}
@@ -215,5 +227,7 @@ createNameSpace('realityEditor.device.layout');
     exports.getTrashThresholdX = getTrashThresholdX;
     exports.onOrientationChanged = onOrientationChanged;
     exports.adjustForDevice = adjustForDevice;
+    exports.setTrashZoneRect = setTrashZoneRect;
+    exports.getCustomTrashZone = () => { return customTrashZone; }
 
 })(realityEditor.device.layout);


### PR DESCRIPTION
This is necessary to move the trash to the bottom of the screen on the portrait iPhone app, without breaking functionality of the classic app.