### PR TITLE
Fixed a bug in remote viewer

### DIFF
--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -707,12 +707,6 @@ function updateJointsHistorical(poseRenderer, poseObject) {
 function updateJoints(poseRenderer, poseObject) {
     let groundPlaneRelativeMatrix = getGroundPlaneRelativeMatrix();
 
-    if (poseObject.matrix && poseObject.matrix.length > 0) {
-        let objectRootMatrix = new THREE.Matrix4();
-        setMatrixFromArray(objectRootMatrix, poseObject.matrix);
-        groundPlaneRelativeMatrix.multiply(objectRootMatrix);
-    }
-
     for (const [i, jointId] of Object.values(JOINTS).entries()) {
         // assume that all sub-objects are of the form poseObject.id + joint name
         let sceneNode = realityEditor.sceneGraph.getSceneNodeById(`${poseObject.uuid}${jointId}`);


### PR DESCRIPTION
Fixed a bug in remote viewer when sometimes skeleton is rendered with arbitrary offset (eg. remote viewer is refreshed while an app tracks a person).