### PR TITLE
Refactor createFrame; addToolAtScreenCenter works properly

### DIFF
--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -460,7 +460,14 @@ createNameSpace("realityEditor.envelopeManager");
                 };
 
                 if (envelopeData) {
-                    let addedElement = realityEditor.gui.pocket.createFrame(envelopeData.name, JSON.stringify(envelopeData.startPositionOffset), JSON.stringify(envelopeData.width), JSON.stringify(envelopeData.height), JSON.stringify(envelopeData.nodes), touchPosition.x, touchPosition.y, true);
+                    let addedElement = realityEditor.gui.pocket.createFrame(envelopeData.name, {
+                        startPositionOffset: envelopeData.startPositionOffset,
+                        width: envelopeData.width,
+                        height: envelopeData.height,
+                        pageX: touchPosition.x,
+                        pageY: touchPosition.y,
+                        noUserInteraction: true
+                    });
 
                     console.log('added an envelope (maybe in time?)', addedElement);
 

--- a/src/gui/pocket.js
+++ b/src/gui/pocket.js
@@ -318,8 +318,10 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
             if (!evt.target.classList.contains('element-template')) {
                 return;
             }
-            
-            if (evt.target.dataset.src === '_PLACEHOLDER_') {
+
+            let dataset = evt.target.dataset;
+
+            if (dataset.src === '_PLACEHOLDER_') {
                 console.log('dont add frame from placeholder!');
                 return;
             }
@@ -329,10 +331,7 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
                 return;
             }
             
-            if (selectedElement && selectedElement.dataset.name === evt.target.dataset.name) {
-                // createFrame(evt.target.dataset.name, evt.target.dataset.startPositionOffset, evt.target.dataset.width, evt.target.dataset.height, evt.target.dataset.nodes, evt.pageX, evt.pageY);
-                
-                let dataset = evt.target.dataset;
+            if (selectedElement && selectedElement.dataset.name === dataset.name) {
 
                 createFrame(dataset.name, {
                     startPositionOffset: dataset.startPositionOffset,
@@ -347,7 +346,7 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
                 pocketHide();
             } else {
                 pointerDownOnElement = evt.target;
-                console.log('target = ' + evt.target.dataset.name);
+                console.log('target = ' + dataset.name);
                 evt.target.classList.add('hoverPocketElement');
                 if (selectedElement) {
                     deselectElement(selectedElement);
@@ -978,8 +977,6 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
      * @param {string} objectKey - object to add the tutorial to (should be the _WORLD_local object)
      */
     function addTutorialFrame(objectKey) {
-        // let addedElement = createFrame('uiTutorial', JSON.stringify({x: 0, y: 0}), JSON.stringify(568), JSON.stringify(420), JSON.stringify([]), globalStates.height/2, globalStates.width/2, undefined, objectKey);
-        
         try {
             let addedElement = createFrame('uiTutorial', {
                 startPositionOffset: JSON.stringify({x: 0, y: 0}),
@@ -989,11 +986,9 @@ realityEditor.gui.pocket.createLogicNode = function(logicNodeMemory) {
                 pageY: window.innerHeight / 2,
                 objectKey: objectKey
             });
-
             console.log('added tutorial frame', addedElement);
-
         } catch (e) {
-            // TODO: ensure that it fails safely if the corresponding server doesn't have a frame named uiTutorial
+            // ensure that it fails safely if the corresponding server doesn't have a frame named uiTutorial
             console.warn(e);
         }
     }

--- a/src/network/availableFrames.js
+++ b/src/network/availableFrames.js
@@ -181,17 +181,20 @@ createNameSpace("realityEditor.network.availableFrames");
      * @return {string|null}
      */
     function getBestObjectInfoForFrame(frameName) {
-        var possibleObjectKeys = getPossibleObjectsForFrame(frameName);
-        
+        let possibleObjectKeys = getPossibleObjectsForFrame(frameName);
+
+        if (possibleObjectKeys.length === 0) return null;
+
         // this works now that world objects have a sense of distance just like regular objects
         return realityEditor.gui.ar.getClosestObject(function(objectKey) {
             return possibleObjectKeys.indexOf(objectKey) > -1;
-        })[0];
+        })[0]; // getClosestObject returns [objectKey, frameKey, nodeKey], so result[0] is the objectKey
     }
 
     /**
      * Out of the current visible objects, figures out which subset of them could support having this type of frame attached.
      * @param {string} frameName - the type of the frame (e.g. graphUI, slider, switch)
+     * @param {boolean?} useAttachesTo - if true, filter down possible object based on frame's attachesTo property
      * @return {Array.<string>} - list of compatible objectKeys
      */
     function getPossibleObjectsForFrame(frameName, useAttachesTo) {

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -201,7 +201,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         await getMyAvatarColor();
         uniforms2['avatarColor'].value = finalColor;
 
-        const ADD_SEARCH_TOOL_WITH_CURSOR = true;
+        const ADD_SEARCH_TOOL_WITH_CURSOR = false;
 
         if (ADD_SEARCH_TOOL_WITH_CURSOR) {
             document.addEventListener('pointerdown', (e) => {
@@ -225,7 +225,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         if (moveToCursor) {
             spatialCursorMatrix = realityEditor.spatialCursor.getOrientedCursorRelativeToWorldObject();
         } else {
-            spatialCursorMatrix = realityEditor.spatialCursor.getOrientedScreenCenterCoordinate();
+            spatialCursorMatrix = realityEditor.spatialCursor.getOrientedCursorIfItWereAtScreenCenter();
         }
 
         let addedElement = realityEditor.gui.pocket.createFrame(toolName, {
@@ -463,14 +463,12 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         return realityEditor.sceneGraph.convertToNewCoordSystem(cursorMatrix, realityEditor.sceneGraph.getSceneNodeById('ROOT'), worldSceneNode);
     }
 
-    function getOrientedScreenCenterCoordinate() {
-        // move cursor to center, then add the tool, then move the cursor back to where it was
+    function getOrientedCursorIfItWereAtScreenCenter() {
+        // move cursor to center, then get the matrix, then move the cursor back to where it was
         let worldIntersectPoint = getRaycastCoordinates(window.innerWidth / 2, window.innerHeight / 2);
         updateSpatialCursor(worldIntersectPoint);
         updateTestSpatialCursor(worldIntersectPoint);
-        
-        // update immediately move it to do the calculations
-        indicator1.updateMatrixWorld();
+        indicator1.updateMatrixWorld(); // update immediately before doing the calculations
 
         let result = getOrientedCursorRelativeToWorldObject();
 
@@ -544,7 +542,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     exports.initService = initService;
     exports.getCursorRelativeToWorldObject = getCursorRelativeToWorldObject;
     exports.getOrientedCursorRelativeToWorldObject = getOrientedCursorRelativeToWorldObject;
-    exports.getOrientedScreenCenterCoordinate = getOrientedScreenCenterCoordinate;
+    exports.getOrientedCursorIfItWereAtScreenCenter = getOrientedCursorIfItWereAtScreenCenter;
     exports.toggleDisplaySpatialCursor = toggleDisplaySpatialCursor;
     exports.isSpatialCursorEnabled = () => { return isCursorEnabled; }
     exports.addToolAtScreenCenter = addToolAtScreenCenter;


### PR DESCRIPTION
`spatialCursor.addToolAtScreenCenter` adds the tool projected onto the surface of the area target, but at the center of the screen, unless the option `{ moveToCursor: true }` is provided, in which case it will position it at the cursor's position. If the center of the screen doesn't raycast against the area target mesh, it will add it floating in the middle of the screen in front of the camera.

Also cleans up/refactors the pocket.createFrame function to use an options object instead of a million optional parameters, and to remove some deprecated functionality.