### PR TITLE
Human pose analytics - intermittent offset skeletons during replay

### DIFF
--- a/src/sceneGraph/network.js
+++ b/src/sceneGraph/network.js
@@ -38,6 +38,10 @@ createNameSpace("realityEditor.sceneGraph.network");
         if (!realityEditor.sceneGraph.getWorldId())  { return; }
         
         realityEditor.forEachObject(function(object, objectKey) {
+            
+            // don't synchronise pose of human pose objects, it is done through real-time channels
+            if (realityEditor.humanPose.utils.isHumanPoseObject(object)) { return; }
+
             let sceneNode = sceneGraph.getSceneNodeById(objectKey);
             if (doesObjectNeedUpload(sceneNode)) {
                 uploadObjectSceneNode(sceneNode);


### PR DESCRIPTION
Rendering of some skeletons at wrong location during replay comes conflicting HumanPoseObject.matrix saved by recorder on server. There are two competing channels which alter this property of the human object on the server - high-frequency transmission of public data of one node (I introduced this one) and low-frequency synchronisation of spatial locations of all objects ( post('/:objectName/matrix') ). The recorder sometimes catches the update from the second one and the matrix there is 'wrong'.
When I was changing the pose streaming previously, I based it on assumption that the matrix property of human pose object is defined wrt. CS of world object (area target). Normally, this matrix just contains 'nose' 3D position in AT CS (identity matrix for rotation part). 
However, the generic scene graph synchronisation seem to assume that CS of the scene graph root is different to the world object. Therefore, there is an additional transform combined with the 'nose' 3D position before posting new object pose (see relativeMatrix calculation in uploadObjectSceneNode(sceneNode) ). What is the convention for CS of scene graph root node across all clients (toolbox app, remote viewer, a server)?   (I mostly debugged UI code on a device so far)

My simple fix in PR is to disable scene graph synchronization for human pose objects. Their scene nodes are anyway updated through realtime channel using node public data (see updateObjectFromRawPose).

I refrained from fixing the underlying problem because it was tricky to get all these matrices right for rendering on device and remote viewer the last time. But I'm not sure whether it is actually important to tackle for other reasons.  
