### PR TITLE
Fix bug where frames were not appearing on other client; tighter avatar synchronization

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -12,7 +12,7 @@ createNameSpace("realityEditor.avatar");
 
     let network, draw, utils; // shortcuts to access realityEditor.avatar._____
 
-    const KEEP_ALIVE_HEARTBEAT_INTERVAL = 10 * 1000; // once per 10 seconds
+    const KEEP_ALIVE_HEARTBEAT_INTERVAL = 1000; // once per 1 second
     const AVATAR_CREATION_TIMEOUT_LENGTH = 10 * 1000; // handle if avatar takes longer than 10 seconds to load
     const RAYCAST_AGAINST_GROUNDPLANE = false;
 
@@ -193,6 +193,14 @@ createNameSpace("realityEditor.avatar");
     // initialize the avatar object representing my own device, and those representing other devices
     function handleDiscoveredObject(object, objectKey) {
         if (!utils.isAvatarObject(object)) { return; }
+
+        // ignore objects from other worlds if we have a primaryWorld set
+        let primaryWorldInfo = realityEditor.network.discovery.getPrimaryWorldInfo();
+        if (primaryWorldInfo && primaryWorldInfo.id &&
+            object.worldId && object.worldId !== primaryWorldInfo.id) {
+            return;
+        }
+
         if (typeof avatarObjects[objectKey] !== 'undefined') { return; }
         avatarObjects[objectKey] = object; // keep track of which avatar objects we've processed so far
         connectedAvatarNames[objectKey] = { name: null };


### PR DESCRIPTION
Problem:
---

In order for frames added by another client to initialize correctly, the reloadObject action message must instantiate them. This adds them to the scene graph, etc.

There was a competing action method, reloadFrame, triggered in response to posting the position of the tool to the server, that might reach the other client before the original reloadObject message was processed that initializes the tool on the other client.

reloadFrame, for some outdated reason, was instantiating an empty Frame() object if the frame didn't exist yet. This would cause reloadObject to not initialize the frame, as it appeared to already exist. Thus the scene node never got added to the sceneGraph, and the tool wouldn't appear on the other client.

I believe this appeared more often more recently because of the change in adding tools at the spatial cursor position, which immediately posts their matrix to the server after creating them on the server, rather than dragging them in from the pocket, in which their position is set by the user some time after the tool is initialized.

Hacky solution:
---

I removed the ability for reloadFrame to create the new frame, and added a somewhat hacky fix to delay processing the message by 500ms if the frame doesn't exist yet, as it likely will exist at that time. Otherwise the message is ignored.

This seems sufficient for now, but if you have suggestions or if we run into further issues, I can try to fix it another way.

---

(PR also adds change to ignore avatars from non-primary world, and to broadcast keepObjectAlive messages for avatars on a more frequent interval, so the server can delete avatar ghosts more aggressively)