### PR TITLE
temporarily disable spatial indicators

### DIFF
--- a/src/gui/spatialIndicator.js
+++ b/src/gui/spatialIndicator.js
@@ -4,6 +4,8 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import { mergeBufferGeometries } from '../../thirdPartyCode/three/BufferGeometryUtils.module.js';
 
 (function (exports) {
+
+    const DISABLE_SPATIAL_INDICATORS = true;
     
     const vertexShader = `
     varying vec2 vUv;
@@ -136,11 +138,13 @@ import { mergeBufferGeometries } from '../../thirdPartyCode/three/BufferGeometry
         return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
     }
 
-    window.addEventListener('pointerdown', (e) => {
-        if (realityEditor.device.isMouseEventCameraControl(e)) return;
-        if (!realityEditor.device.utilities.isEventHittingBackground(e)) return;
-        handleMouseClick(e);
-    });
+    if (!DISABLE_SPATIAL_INDICATORS) {
+        window.addEventListener('pointerdown', (e) => {
+            if (realityEditor.device.isMouseEventCameraControl(e)) return;
+            if (!realityEditor.device.utilities.isEventHittingBackground(e)) return;
+            handleMouseClick(e);
+        });
+    }
 
     let worldIntersectPoint = {};
     function getRaycastCoordinates(screenX, screenY) {


### PR DESCRIPTION
Since they don't sync across multiple clients yet, let's toggle them off for the upcoming demos until we reach a more final state.