### PR TITLE
default floor to bottom of mesh if no geometry directly below; slow down batched updates; safeguard cursor matrix

### DIFF
--- a/src/app/navmeshWorker.js
+++ b/src/app/navmeshWorker.js
@@ -268,7 +268,7 @@ const createNavmesh = (geometry, resolution) => { // resolution = number of pixe
     addTriangle(faceData, vertexVector1, vertexVector2, vertexVector3, weight, ignoreWeight);
   }
   
-  const floorOffset = floorOffsetDown < 0 ? floorOffsetDown : (floorOffsetUp > 0 ? floorOffsetUp : 0);
+  const floorOffset = floorOffsetDown < 0 ? floorOffsetDown : (floorOffsetUp > 0 ? floorOffsetUp : minY);
   
   // Calculate average weight of faces within pixels
   mapGrid(faceData, value => [value[1] === 0 ? 0 : value[0] / value[1], value[2], 0]);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -12,7 +12,7 @@ createNameSpace("realityEditor.avatar");
 
     let network, draw, utils; // shortcuts to access realityEditor.avatar._____
 
-    const KEEP_ALIVE_HEARTBEAT_INTERVAL = 1000; // once per 1 second
+    const KEEP_ALIVE_HEARTBEAT_INTERVAL = 3 * 1000; // once per 3 seconds
     const AVATAR_CREATION_TIMEOUT_LENGTH = 10 * 1000; // handle if avatar takes longer than 10 seconds to load
     const RAYCAST_AGAINST_GROUNDPLANE = false;
 

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -572,6 +572,18 @@ realityEditor.gui.ar.utilities.getAllVisibleFrames = function() {
     return visibleFrames;
 };
 
+realityEditor.gui.ar.utilities.isValidMatrix4x4 = function(mat) {
+    if (!mat) return false;
+    if (typeof mat !== 'object') return false;
+    if (typeof mat.length !== 'number') return false;
+    if (mat.length !== 16) return false;
+    for (let i = 0; i < 16; i++) {
+        if (typeof mat[i] !== 'number') return false;
+        if (isNaN(mat[i])) return false;
+    }
+    return true;
+}
+
 /**
  * Helper method for creating a new 4x4 identity matrix
  * @return {Array.<number>}

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -12,6 +12,8 @@ createNameSpace("realityEditor.network.realtime");
     const DEBUG = false;
     const PROXY = /(\w+\.)?toolboxedge.net/.test(window.location.host);
 
+    const BATCHED_UPDATE_FRAMERATE = 3;
+
     var desktopSocket;
     var sockets = {};
 
@@ -76,11 +78,11 @@ createNameSpace("realityEditor.network.realtime");
 
 
     function loop() {
-        if(typeof updateFramerate !== 'undefined') {
+        if (typeof BATCHED_UPDATE_FRAMERATE !== 'undefined') {
             setInterval(() => {
                 sendBatchedUpdates();
                 batchedUpdates = {};
-            }, 1000 / updateFramerate);
+            }, 1000 / BATCHED_UPDATE_FRAMERATE);
         } else {
             sendBatchedUpdates();
             batchedUpdates = {};

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -252,6 +252,11 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             }
         }
 
+        // verify that the matrix is valid, otherwise tool can init with NaN values
+        if (!realityEditor.gui.ar.utilities.isValidMatrix4x4(spatialCursorMatrix)) {
+            spatialCursorMatrix = null;
+        }
+
         let addedElement = realityEditor.gui.pocket.createFrame(toolName, {
             noUserInteraction: true,
             pageX: window.innerWidth / 2,


### PR DESCRIPTION
- floorOffset goes to geometry minY if no raycast result (if you didn't scan floor below initial position)
- batchedUpdates happen at only 3fps, to try to minimize network congestion from many avatars, worlds, etc
- avatar keepAlive heartbeat also occurs once per 3 seconds instead of once per 1 second, to reduce residual effects of processing tons of heartbeats. I increased their lifespan to 15 seconds on the server so this balances it here.
- I need to debug the spatial cursor further, but there's a case in which the three.js mesh's matrixWorld is not a properly formatted matrix (its scale values [0, 5, and 10th entry] are all zeros) so the resulting tool placement matrix has a bunch of NaNs in it. I added a safeguard for now to detect this and place the tool in front of the camera rather than being broken until refreshed. 