### PR TITLE
force ignore potential cacheing of the reloadObject and reloadFrame responses

### DIFF
--- a/src/network/index.js
+++ b/src/network/index.js
@@ -953,7 +953,7 @@ realityEditor.network.onAction = function (action) {
 
                 _this.cout("got object");
 
-            });
+            }, { dontCache: true });
         }
     }
 
@@ -1215,7 +1215,7 @@ realityEditor.network.reloadFrame = function(objectKey, frameKey, fullActionMess
         }
 
         realityEditor.gui.ar.grouping.reconstructGroupStruct(frameKey, thisFrame);
-    });
+    }, { dontCache: true });
 }
 
 /**
@@ -2740,13 +2740,18 @@ realityEditor.network.updateNodeBlocksSettingsData = function(ip, objectKey, fra
  * @param {string|undefined} nodeKey
  * @param {string} url
  * @param {function<string, string, string, object>} callback
+ * @param {*} options
  */
-realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback) {
+realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback, options = {dontCache: false}) {
     if (!nodeKey) nodeKey = null;
     if (!frameKey) frameKey = null;
     var req = new XMLHttpRequest();
+    let urlSuffix = options.dontCache ? `?timestamp=${new Date().getTime()}` : '';
     try {
-        req.open('GET', url, true);
+        req.open('GET', url + urlSuffix, true);
+        if (options.dontCache) {
+            req.setRequestHeader('Cache-control', 'no-cache');
+        }
         // Just like regular ol' XHR
         req.onreadystatechange = function () {
             if (req.readyState === 4) {

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -953,7 +953,7 @@ realityEditor.network.onAction = function (action) {
 
                 _this.cout("got object");
 
-            }, { dontCache: true });
+            }, { bypassCache: true });
         }
     }
 
@@ -1215,7 +1215,7 @@ realityEditor.network.reloadFrame = function(objectKey, frameKey, fullActionMess
         }
 
         realityEditor.gui.ar.grouping.reconstructGroupStruct(frameKey, thisFrame);
-    }, { dontCache: true });
+    }, { bypassCache: true });
 }
 
 /**
@@ -2742,14 +2742,14 @@ realityEditor.network.updateNodeBlocksSettingsData = function(ip, objectKey, fra
  * @param {function<string, string, string, object>} callback
  * @param {*} options
  */
-realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback, options = {dontCache: false}) {
+realityEditor.network.getData = function (objectKey, frameKey, nodeKey, url, callback, options = {bypassCache: false}) {
     if (!nodeKey) nodeKey = null;
     if (!frameKey) frameKey = null;
     var req = new XMLHttpRequest();
-    let urlSuffix = options.dontCache ? `?timestamp=${new Date().getTime()}` : '';
+    let urlSuffix = options.bypassCache ? `?timestamp=${new Date().getTime()}` : '';
     try {
         req.open('GET', url + urlSuffix, true);
-        if (options.dontCache) {
+        if (options.bypassCache) {
             req.setRequestHeader('Cache-control', 'no-cache');
         }
         // Just like regular ol' XHR

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -12,7 +12,7 @@ createNameSpace("realityEditor.network.realtime");
     const DEBUG = false;
     const PROXY = /(\w+\.)?toolboxedge.net/.test(window.location.host);
 
-    const BATCHED_UPDATE_FRAMERATE = 3;
+    const BATCHED_UPDATE_FRAMERATE = updateFramerate;
 
     var desktopSocket;
     var sockets = {};


### PR DESCRIPTION
On toolboxedge.net, the responses had outdated values, causing frames not to appear. Question: should we default all getData requests to ignore caching, or only turn it on if the option is specified (which I did in only these two usages, to limit the impact of this change)

---
also reverts the batched update framerate back to 10, in case it would have messed up the poses