### PR TITLE
Laser pointer off screen arrow fix

### DIFF
--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -207,6 +207,7 @@ createNameSpace("realityEditor.avatar.draw");
                 avatarMeshes[objectKey].pointer.visible = false;
                 avatarMeshes[objectKey].beam.visible = false;
                 avatarMeshes[objectKey].textLabel.style.display = 'none';
+                realityEditor.gui.spatialArrow.deleteLaserBeamIndicator(objectKey);
             }
             return;
         }
@@ -356,7 +357,8 @@ createNameSpace("realityEditor.avatar.draw");
             endWorldPositionArray = realityEditor.sceneGraph.convertToNewCoordSystem(endWorldPositionArray, groundPlaneSceneNode, worldSceneNode);
             endWorldPosition.set(endWorldPositionArray[0], endWorldPositionArray[1], endWorldPositionArray[2]);
         }
-        realityEditor.gui.spatialArrow.drawArrowBasedOnWorldPosition(endWorldPosition, color, lightColor);
+        // realityEditor.gui.spatialArrow.drawArrowBasedOnWorldPosition(endWorldPosition, color, lightColor);
+        realityEditor.gui.spatialArrow.addLaserBeamIndicator(objectKey, endWorldPosition, color, lightColor);
     }
 
     // helper to create a box mesh

--- a/src/gui/spatialArrow.js
+++ b/src/gui/spatialArrow.js
@@ -210,6 +210,25 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             
             drawArrowBasedOnWorldPosition(worldPos, indicator.avatarColor, indicator.avatarColorLighter);
         })
+        
+        // displaying off screen arrows for laser beams
+        for (let idx in laserBeamIndicators) {
+            let laserBeam = laserBeamIndicators[idx];
+            drawArrowBasedOnWorldPosition(laserBeam.worldPos, laserBeam.color, laserBeam.colorLighter);
+        }
+    }
+    
+    let laserBeamIndicators = {};
+    function addLaserBeamIndicator(id, worldPos, color, colorLighter) {
+        laserBeamIndicators[id] = {
+            worldPos,
+            color,
+            colorLighter
+        };
+    }
+    
+    function deleteLaserBeamIndicator(id) {
+        delete laserBeamIndicators[id];
     }
     
     function drawIndicatorArrows() {
@@ -225,5 +244,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
 
     exports.initService = initService;
     exports.drawArrowBasedOnWorldPosition = drawArrowBasedOnWorldPosition;
+    exports.addLaserBeamIndicator = addLaserBeamIndicator;
+    exports.deleteLaserBeamIndicator = deleteLaserBeamIndicator;
 
 })(realityEditor.gui.spatialArrow);


### PR DESCRIPTION
Before, the laser pointer arrows were drawn asynchronously in spatialArrow.js, sometimes got cleared unintentionally. This push fixed the issue. Now the arrows for off screen laser pointer should be drawn to the screen no matter what.