### PR TITLE
Allow adding region cards during recording

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -196,7 +196,11 @@ export class Analytics {
         });
 
         for (let desc of regionCardDescriptions) {
-            let regionCard = new RegionCard(this.pinnedRegionCardsContainer, getPosesInTimeInterval(desc.startTime, desc.endTime));
+            const poses = getPosesInTimeInterval(desc.startTime, desc.endTime);
+            if (poses.length === 0) {
+                continue;
+            }
+            let regionCard = new RegionCard(this.pinnedRegionCardsContainer, poses);
             regionCard.state = RegionCardState.Pinned;
             if (desc.label) {
                 regionCard.setLabel(desc.label);

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -198,22 +198,33 @@ export class Analytics {
         for (let desc of regionCardDescriptions) {
             let regionCard = new RegionCard(this.pinnedRegionCardsContainer, getPosesInTimeInterval(desc.startTime, desc.endTime));
             regionCard.state = RegionCardState.Pinned;
-            regionCard.setLabel(desc.label || ('Step ' + this.nextStepNumber));
-            this.nextStepNumber += 1;
+            if (desc.label) {
+                regionCard.setLabel(desc.label);
+            }
             regionCard.removePinAnimation();
             this.addRegionCard(regionCard);
         }
     }
 
     addRegionCard(regionCard) {
+        // Allow for a small amount of inaccuracy in timestamps, e.g. when
+        // switching from live to historical clone source
+        const tolerance = 500;
         for (let pinnedRegionCard of this.pinnedRegionCards) {
-            if (pinnedRegionCard.startTime === regionCard.startTime &&
-                pinnedRegionCard.endTime === regionCard.endTime) {
+            if ((Math.abs(pinnedRegionCard.startTime - regionCard.startTime) < tolerance) &&
+               (Math.abs(pinnedRegionCard.endTime - regionCard.endTime) < tolerance)) {
                 // New region card already exists in the list
+                regionCard.remove();
                 return;
             }
         }
         this.pinnedRegionCards.push(regionCard);
+
+        if (regionCard.getLabel().length === 0) {
+            regionCard.setLabel('Step ' + this.nextStepNumber);
+        }
+
+        this.nextStepNumber += 1;
 
         this.updateCsvExportLink();
     }

--- a/src/analytics/regionCard.js
+++ b/src/analytics/regionCard.js
@@ -146,7 +146,6 @@ export class RegionCard {
     }
 
     unpin() {
-        console.log('unpin');
         this.remove();
         realityEditor.analytics.unpinRegionCard(this);
     }
@@ -197,7 +196,7 @@ export class RegionCard {
         this.labelElement = document.createElement('div');
         this.labelElement.classList.add('analytics-region-card-label');
         this.labelElement.setAttribute('contenteditable', true);
-        this.setLabel('Step');
+        this.setLabel('');
 
         let debouncedSave = null;
         this.labelElement.addEventListener('keydown', (event) => {

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -658,7 +658,7 @@ export class HumanPoseAnalyzer {
      * @return {Pose[]} - all poses in the time interval
      */
     getPosesInTimeInterval(firstTimestamp, secondTimestamp) {
-        let clonesList = this.clones.live;
+        let clonesList = this.clones.all;
         if (this.clones.historical.length >= this.clones.live.length) {
             clonesList = this.clones.historical;
         }

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -651,13 +651,21 @@ export class HumanPoseAnalyzer {
     }
 
     /**
-     * Sets all poses in the time interval
+     * Returns a list of poses in the time interval, preferring the historical
+     * data source where available
      * @param {number} firstTimestamp - start of time interval in ms
      * @param {number} secondTimestamp - end of time interval in ms
      * @return {Pose[]} - all poses in the time interval
      */
     getPosesInTimeInterval(firstTimestamp, secondTimestamp) {
-        const poses = this.clones.all.map(clone => clone.pose).filter(pose => pose.timestamp >= firstTimestamp && pose.timestamp <= secondTimestamp);
+        let clonesList = this.clones.all;
+        if (this.clones.historical.length >= this.clones.live.length) {
+            clonesList = this.clones.historical;
+        }
+        const poses = clonesList.map(clone => clone.pose).filter(pose => {
+            return pose.timestamp >= firstTimestamp &&
+                pose.timestamp <= secondTimestamp;
+        });
         poses.sort((a, b) => a.timestamp - b.timestamp);
         return poses;
     }

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -658,7 +658,7 @@ export class HumanPoseAnalyzer {
      * @return {Pose[]} - all poses in the time interval
      */
     getPosesInTimeInterval(firstTimestamp, secondTimestamp) {
-        let clonesList = this.clones.all;
+        let clonesList = this.clones.live;
         if (this.clones.historical.length >= this.clones.live.length) {
             clonesList = this.clones.historical;
         }

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -658,16 +658,21 @@ export class HumanPoseAnalyzer {
      * @return {Pose[]} - all poses in the time interval
      */
     getPosesInTimeInterval(firstTimestamp, secondTimestamp) {
-        let clonesList = this.clones.all;
-        if (this.clones.historical.length >= this.clones.live.length) {
-            clonesList = this.clones.historical;
+        function getPoses(clonesList) {
+            const poses = clonesList.map(clone => clone.pose).filter(pose => {
+                return pose.timestamp >= firstTimestamp &&
+                    pose.timestamp <= secondTimestamp;
+            });
+            poses.sort((a, b) => a.timestamp - b.timestamp);
+            return poses;
         }
-        const poses = clonesList.map(clone => clone.pose).filter(pose => {
-            return pose.timestamp >= firstTimestamp &&
-                pose.timestamp <= secondTimestamp;
-        });
-        poses.sort((a, b) => a.timestamp - b.timestamp);
-        return poses;
+
+        const live = getPoses(this.clones.live);
+        if (live.length > 0) {
+            return live;
+        }
+
+        return getPoses(this.clones.historical);
     }
 
     /**


### PR DESCRIPTION
Additionally modifies getPosesInTimeInterval to not return duplicate poses where possible. Previously, pulling from clones.all would result in duplicate poses with slightly different timestamps between clones.live and clones.historical.

This new functionality allows the Mark Step button in the spatialAnalytics envelope to function.