### PR TITLE
Creating a scan works on cellular; listens for beats and action messages with web sockets

### DIFF
--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -193,7 +193,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
             createPendingWorldObject(serverIp);
         } else {
             let detectedServers = realityEditor.network.discovery.getDetectedServerIPs({limitToWorldService: true});
-            let randomServerIP = Object.keys(detectedServers)[0];
+            let randomServerIP = Object.keys(detectedServers)[0] || '127.0.0.1';
             //.filter(detectedServer => {
             //    return detectedServer !== '127.0.0.1';
             //})[0];

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -68,6 +68,7 @@ createNameSpace("realityEditor.network.discovery");
     function processNewObjectDiscovery(ip, port, id) {
         let url = realityEditor.network.getURL(ip, port, '/object/' + id);
         realityEditor.network.getData(id,  null, null, url, function (objectKey, frameKey, nodeKey, msg) {
+            if (!msg) return;
             if (typeof discoveryMap[ip][id] !== 'undefined') {
                 discoveryMap[ip][id].metadata = {
                     name: msg.name,

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -68,7 +68,6 @@ createNameSpace("realityEditor.network.discovery");
     function processNewObjectDiscovery(ip, port, id) {
         let url = realityEditor.network.getURL(ip, port, '/object/' + id);
         realityEditor.network.getData(id,  null, null, url, function (objectKey, frameKey, nodeKey, msg) {
-            if (!msg) return;
             if (typeof discoveryMap[ip][id] !== 'undefined') {
                 discoveryMap[ip][id].metadata = {
                     name: msg.name,
@@ -135,50 +134,11 @@ createNameSpace("realityEditor.network.discovery");
         }
     }
 
-    // /**
-    //  * This lets the remote operator or the phone app discover the primary world + all other objects on the primary world server,
-    //  * in the cases where UDP messages aren't working -> the primary world cannot be loaded by typical means
-    //  */
-    // function discoverPrimaryWorldIfNeeded() {
-    //     if (typeof objects[primaryWorld.id] !== 'undefined') return;
-    //
-    //     console.log('TRY TO LOAD OBJECTS DIRECTLY');
-    //
-    //     let netState = realityEditor.network.state;
-    //
-    //     console.log('netState = ', netState);
-    //
-    //     if (!netState) return;
-    //
-    //     let url;
-    //     if (netState.proxyUrl) {
-    //         let ip = netState.proxyUrl; // actually doesn't matter what we pass in, getURL assembles the right URL regardless
-    //         let port = 'direct'; // the value doesn't matter in this implementation, as long as it's not a number
-    //         url = realityEditor.network.getURL(ip, port, '/allObjects/');
-    //     } else {
-    //         let primaryWorldIP = primaryWorld.ip || window.location.hostname || '127.0.0.1';
-    //         url = realityEditor.network.getURL(primaryWorldIP, realityEditor.network.getPortByIp(primaryWorldIP), '/allObjects/');
-    //     }
-    //
-    //     console.log('url = ', url);
-    //
-    //     realityEditor.network.getData(null, null, null, url, function(_nullObj, _nullFrame, _nullNode, msg) {
-    //         console.log('discoverObjectsFromServer got all objects', msg);
-    //
-    //         msg.forEach(function(heartbeat) {
-    //             console.log('addHeartbeatObject from /allObjects/', heartbeat);
-    //             realityEditor.network.addHeartbeatObject(heartbeat);
-    //         });
-    //     });
-    // }
-
     exports.setPrimaryWorld = (ip, id) => {
         primaryWorld = {
             ip: ip,
             id: id
         };
-
-        // setTimeout(discoverPrimaryWorldIfNeeded, 5000);
     }
 
     exports.getPrimaryWorldInfo = () => {

--- a/src/network/discovery.js
+++ b/src/network/discovery.js
@@ -68,6 +68,7 @@ createNameSpace("realityEditor.network.discovery");
     function processNewObjectDiscovery(ip, port, id) {
         let url = realityEditor.network.getURL(ip, port, '/object/' + id);
         realityEditor.network.getData(id,  null, null, url, function (objectKey, frameKey, nodeKey, msg) {
+            if (!msg) return;
             if (typeof discoveryMap[ip][id] !== 'undefined') {
                 discoveryMap[ip][id].metadata = {
                     name: msg.name,
@@ -134,11 +135,50 @@ createNameSpace("realityEditor.network.discovery");
         }
     }
 
+    // /**
+    //  * This lets the remote operator or the phone app discover the primary world + all other objects on the primary world server,
+    //  * in the cases where UDP messages aren't working -> the primary world cannot be loaded by typical means
+    //  */
+    // function discoverPrimaryWorldIfNeeded() {
+    //     if (typeof objects[primaryWorld.id] !== 'undefined') return;
+    //
+    //     console.log('TRY TO LOAD OBJECTS DIRECTLY');
+    //
+    //     let netState = realityEditor.network.state;
+    //
+    //     console.log('netState = ', netState);
+    //
+    //     if (!netState) return;
+    //
+    //     let url;
+    //     if (netState.proxyUrl) {
+    //         let ip = netState.proxyUrl; // actually doesn't matter what we pass in, getURL assembles the right URL regardless
+    //         let port = 'direct'; // the value doesn't matter in this implementation, as long as it's not a number
+    //         url = realityEditor.network.getURL(ip, port, '/allObjects/');
+    //     } else {
+    //         let primaryWorldIP = primaryWorld.ip || window.location.hostname || '127.0.0.1';
+    //         url = realityEditor.network.getURL(primaryWorldIP, realityEditor.network.getPortByIp(primaryWorldIP), '/allObjects/');
+    //     }
+    //
+    //     console.log('url = ', url);
+    //
+    //     realityEditor.network.getData(null, null, null, url, function(_nullObj, _nullFrame, _nullNode, msg) {
+    //         console.log('discoverObjectsFromServer got all objects', msg);
+    //
+    //         msg.forEach(function(heartbeat) {
+    //             console.log('addHeartbeatObject from /allObjects/', heartbeat);
+    //             realityEditor.network.addHeartbeatObject(heartbeat);
+    //         });
+    //     });
+    // }
+
     exports.setPrimaryWorld = (ip, id) => {
         primaryWorld = {
             ip: ip,
             id: id
         };
+
+        // setTimeout(discoverPrimaryWorldIfNeeded, 5000);
     }
 
     exports.getPrimaryWorldInfo = () => {

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -111,7 +111,7 @@ createNameSpace("realityEditor.network.realtime");
             // if we haven't already created a socket connection to that IP, create a new one,
             //   and register update listeners, and emit a /subscribe message so it can connect back to us
             realityEditor.network.realtime.createSocketInSet('realityServers', serverAddress, function(_socket) {
-                if (object.ip === '127.0.0.1') { return; } // ignore localhost, no need for realtime because only one client
+                // if (object.ip === '127.0.0.1') { return; } // ignore localhost, no need for realtime because only one client
                 sockets['realityServers'][serverAddress].emit(realityEditor.network.getIoTitle(object.port, '/subscribe/realityEditorUpdates'), JSON.stringify({editorId: globalStates.tempUuid}));
                 addServerUpdateListener(serverAddress);
             });
@@ -242,6 +242,23 @@ createNameSpace("realityEditor.network.realtime");
      * @param {string} serverAddress
      */
     function addServerUpdateListener(serverAddress) {
+
+        let hasCloudProxySocket = realityEditor.cloud.socket;
+
+        if (!hasCloudProxySocket) {
+            console.log('No cloud socket – add /udp/beat and /udp/action listeners to existing realtime socket');
+            // this allows the app to receive heartbeats when not on a Wi-Fi network that supports UDP
+            addServerSocketMessageListener(serverAddress, '/udp/beat', (msg) => {
+                // console.log('realtime socket got beat', msg);
+                realityEditor.app.callbacks.receivedUDPMessage(msg);
+            });
+
+            // this allows the app to receive action messages when not on a Wi-Fi network that supports UDP
+            addServerSocketMessageListener(serverAddress, '/udp/action', (msg) => {
+                // console.log('realtime socket got action', msg);
+                realityEditor.app.callbacks.receivedUDPMessage(msg);
+            });
+        }
 
         addServerSocketMessageListener(serverAddress, '/batchedUpdate', function(msg) {
             var msgContent = typeof msg === 'string' ? JSON.parse(msg) : msg;

--- a/src/network/realtime.js
+++ b/src/network/realtime.js
@@ -111,7 +111,6 @@ createNameSpace("realityEditor.network.realtime");
             // if we haven't already created a socket connection to that IP, create a new one,
             //   and register update listeners, and emit a /subscribe message so it can connect back to us
             realityEditor.network.realtime.createSocketInSet('realityServers', serverAddress, function(_socket) {
-                // if (object.ip === '127.0.0.1') { return; } // ignore localhost, no need for realtime because only one client
                 sockets['realityServers'][serverAddress].emit(realityEditor.network.getIoTitle(object.port, '/subscribe/realityEditorUpdates'), JSON.stringify({editorId: globalStates.tempUuid}));
                 addServerUpdateListener(serverAddress);
             });

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -131,6 +131,9 @@ createNameSpace("realityEditor.worldObjects");
         };
         console.log('try loading local world object...', worldObjectBeat);
 
+        // process the heartbeat automatically, in case UDP isn't allowed on this network (e.g. cellular)
+        realityEditor.network.discovery.processHeartbeat(worldObjectBeat);
+
         if (!realityEditor.network.state.isCloudInterface) {
             realityEditor.network.addHeartbeatObject(worldObjectBeat);
         }


### PR DESCRIPTION
Backup method to enable full system capabilities while on a network that doesn't allow UDP messages (e.g. cellular data plan). Remote operator connected to the cloud proxy already uses a web socket interface to listen for beats and action messages; this extends the same logic to all clients (e.g. the phone that made the scan). Also manually adds 127.0.0.1 to the possible servers that this scan can go to, so that it doesn't break while trying to generate a new world object while scanning.