### PR TITLE
better handle no UDP permissions; fix height of modal; increase area target scan time 

### DIFF
--- a/css/modal.css
+++ b/css/modal.css
@@ -347,6 +347,11 @@ a.modalLink:active { color: #757575; }
 }
 
 .loaderContainerPortrait {
+    height: max(36vh, 36vw) !important;
+    top: calc(50vh - max(36vh, 36vw)/2) !important;
+}
+
+.loaderContainerPortraitTall {
     height: max(50vh, 50vw) !important;
     top: calc(50vh - max(50vh, 50vw)/2) !important;
 }

--- a/css/modal.css
+++ b/css/modal.css
@@ -347,8 +347,8 @@ a.modalLink:active { color: #757575; }
 }
 
 .loaderContainerPortrait {
-    height: max(32vh, 32vw) !important;
-    top: calc(50vh - max(32vh, 32vw)/2) !important;
+    height: max(40vh, 40vw) !important;
+    top: calc(50vh - max(40vh, 40vw)/2) !important;
 }
 
 .loader {

--- a/css/modal.css
+++ b/css/modal.css
@@ -347,8 +347,8 @@ a.modalLink:active { color: #757575; }
 }
 
 .loaderContainerPortrait {
-    height: max(40vh, 40vw) !important;
-    top: calc(50vh - max(40vh, 40vw)/2) !important;
+    height: max(50vh, 50vw) !important;
+    top: calc(50vh - max(50vh, 50vw)/2) !important;
 }
 
 .loader {

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -80,8 +80,8 @@ createNameSpace('realityEditor.app.callbacks');
                 callback();
             }
             
-            let headerText = 'Needs camera access';
-            let descriptionText = 'Please enable camera access<br/>in your device\'s Settings app,<br/>and try again.';
+            let headerText = 'Needs camera and microphone access';
+            let descriptionText = `Please enable camera and microphone access in your device's Settings app, and try again.`;
 
             let notification = realityEditor.gui.modal.showSimpleNotification(
                 headerText, descriptionText, function () {

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -88,6 +88,7 @@ createNameSpace('realityEditor.app.callbacks');
                     console.log('closed...');
                 }, realityEditor.device.environment.variables.layoutUIForPortrait);
             notification.domElements.fade.style.backgroundColor = 'rgba(0,0,0,0.5)';
+            notification.domElements.container.classList.add('loaderContainerPortraitTall');
             return;
         }
         // projection matrix only needs to be retrieved once

--- a/src/app/callbacks.js
+++ b/src/app/callbacks.js
@@ -66,40 +66,6 @@ createNameSpace('realityEditor.app.callbacks');
         onPoseReceived: []
     }
 
-    function onOrientationSet() {
-        // if we don't have access to the Local Network, show a pop-up asking the user to turn it on.
-        realityEditor.app.didGrantNetworkPermissions('realityEditor.app.callbacks.receiveNetworkPermissions');
-    }
-
-    /**
-     * Requests Vuforia to start if Local Network access is provided, otherwise shows an error on screen
-     * @param {boolean} success
-     */
-    exports.receiveNetworkPermissions = function(success) {
-        if (typeof success !== 'undefined' && !success) {
-
-            while (listeners.onVuforiaInitFailure.length > 0) { // dismiss the intializing pop-up that was waiting
-                let callback = listeners.onVuforiaInitFailure.pop();
-                callback();
-            }
-
-            let headerText = 'Needs Local Network Access';
-            let descriptionText = 'Please enable "Local Network" access<br/>in your device\'s Settings app and try again.';
-
-            let notification = realityEditor.gui.modal.showSimpleNotification(
-                headerText, descriptionText, function () {
-                    console.log('closed...');
-                }, realityEditor.device.environment.variables.layoutUIForPortrait);
-            notification.domElements.fade.style.backgroundColor = 'rgba(0,0,0,0.5)';
-            return;
-        }
-
-        // start the AR framework in native iOS
-        realityEditor.app.promises.getVuforiaReady().then(success => {
-            vuforiaIsReady(success);
-        });
-    }
-
     /**
      * Callback for realityEditor.app.getVuforiaReady
      * Triggered when Vuforia Engine finishes initializing.
@@ -589,7 +555,6 @@ createNameSpace('realityEditor.app.callbacks');
     }
 
     // public methods (anything triggered by a native app callback needs to be public
-    exports.onOrientationSet = onOrientationSet;
     exports.vuforiaIsReady = vuforiaIsReady;
     exports.receivedProjectionMatrix = receivedProjectionMatrix;
     exports.receivedUDPMessage = receivedUDPMessage;

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -54,6 +54,7 @@ createNameSpace("realityEditor.device.environment");
         layoutUIForPortrait: false,
         defaultShowGroundPlane: false,
         supportsMemoryCreation: true,
+        hasLocalNetworkAccess: true, // set to false if iOS device permissions disabled
         // numbers
         lineWidthMultiplier: 1, // 5
         distanceScaleFactor: 1, // 10

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -453,7 +453,16 @@ realityEditor.device.onload = function () {
     
     if (realityEditor.device.initFunctions.length === 0) {
         realityEditor.app.promises.didGrantNetworkPermissions().then(success => {
-            realityEditor.app.callbacks.receiveNetworkPermissions(success);
+            // network permissions are no longer required for the app to function, but we can
+            // provide UI feedback if they try to use a feature (discovering unknown servers) that relies on this
+            if (typeof success === 'boolean') {
+                realityEditor.device.environment.variables.hasLocalNetworkAccess = success;
+            }
+
+            // start the AR framework in native iOS
+            realityEditor.app.promises.getVuforiaReady().then(success => {
+                realityEditor.app.callbacks.vuforiaIsReady(success);
+            });
         });
     } else {
         realityEditor.device.initFunctions.forEach(function(initFunction) {

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -341,7 +341,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
             div = document.createElement('div');
             div.id = 'scanGenerateProgressBarContainer';
             if (realityEditor.device.environment.variables.layoutUIForPortrait) {
-                div.style.top = 'calc(50vh + max(32vh, 32vw)/2 + 25px)';
+                div.style.top = 'calc(50vh + max(36vh, 36vw)/2 + 25px)';
             } else {
                 div.style.bottom = '30px';
             }

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -11,7 +11,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
     let feedbackInterval = null;
     let feedbackTick = 0;
 
-    const MAX_SCAN_TIME = 120;
+    const MAX_SCAN_TIME = 180;
     let timeLeftSeconds = MAX_SCAN_TIME;
 
     let loadingDialog = null;


### PR DESCRIPTION
Since we have websockets as a backup if no UDP, we no longer need to prevent you from using the app if you hit "No" for iOS Local Network permissions. Also, increases the modal height so that messages aren't cut off (for the remaining Camera and Microphone permissions modals)

![original](https://user-images.githubusercontent.com/32580292/228595837-ffd182fc-575f-4d1a-ac97-9da2fefa5bb0.jpg)
