### PR TITLE
"Minimize" button removes focus from a tool; renders temporary icon in place

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1972,7 +1972,7 @@ Logic Interface CSS
 .ru-container {
     position: absolute;
     top: 60px;
-    left: calc(30px + 54px + 30px);
+    left: 150px;
     transform: translateZ(1100px);
     z-index: 1100;
 }
@@ -1980,9 +1980,9 @@ Logic Interface CSS
 .ru-icon {
     width: 54px;
     height: 54px;
-    margin: 0 12px;
+    margin: 0 6px;
     border: 2px solid rgba(0, 0, 0, 0);
-    border-radius: 8px;
+    border-radius: 12.8px;
 }
 
 .ru-icon.ru-icon-active {

--- a/css/index.css
+++ b/css/index.css
@@ -1968,3 +1968,7 @@ Logic Interface CSS
 .deactivatedIframeOverlay {
     pointer-events: none; /* deactivates the tool's touchPropagation cover, so the iframe is directly interactable */
 }
+
+.iframeOverlayWithoutFocus {
+    pointer-events: none; /* deactivates the tool's touchPropagation cover when an envelope loses focus */
+}

--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
     <script src="src/gui/moveabilityCorners.js"></script>
 
     <script src="src/gui/recentlyUsedBar.js"></script>
+    <script src="src/gui/envelopeIcons.js"></script>
 
     <script src="src/spatialCursor/index.js" type="module"></script>
     <script src="src/spatialCursor/shader/normalCursorFragmentShader.js" type="module"></script>

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -377,6 +377,7 @@ realityEditor.device.onload = function () {
     realityEditor.gui.spatialIndicator.initService();
     realityEditor.gui.spatialArrow.initService();
     realityEditor.gui.recentlyUsedBar.initService();
+    realityEditor.gui.envelopeIconRenderer.initService();
 
     realityEditor.app.promises.getDeviceReady().then(deviceName => {
         globalStates.device = deviceName;

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -1,0 +1,115 @@
+class EnvelopeIconRenderer {
+    constructor() {
+        this.knownEnvelopes = {};
+        this.arUtilities = realityEditor.gui.ar.utilities;
+    }
+
+    onEnvelopeRegistered(envelope) {
+        this.knownEnvelopes[envelope.frame] = envelope;
+    }
+
+    onOpen(envelope) {
+        this.knownEnvelopes[envelope.frame].isOpen = true;
+        this.knownEnvelopes[envelope.frame].hasFocus = true;
+    }
+
+    onClose(envelope) {
+        this.knownEnvelopes[envelope.frame].isOpen = false;
+        this.knownEnvelopes[envelope.frame].hasFocus = false;
+    }
+
+    onFocus(envelope) {
+        this.knownEnvelopes[envelope.frame].hasFocus = true;
+    }
+
+    onBlur(envelope) {
+        this.knownEnvelopes[envelope.frame].hasFocus = false;
+    }
+
+    initService() {
+        this.gui = document.getElementById('GUI');
+
+        realityEditor.gui.ar.draw.addUpdateListener(() => {
+            Object.values(this.knownEnvelopes).forEach(envelope => {
+                this.updateEnvelope(envelope);
+            });
+        });
+    }
+
+    updateEnvelope(envelope) {
+        if (envelope.isOpen && !envelope.hasFocus) {
+            this.renderEnvelopeIcon(envelope.object, envelope.frame);
+        } else {
+            this.removeEnvelopeIcon(envelope.frame);
+        }
+    }
+
+    removeEnvelopeIcon(frameId) {
+        if (!globalDOMCache['envelopeIcon_' + frameId]) return;
+        this.gui.removeChild(globalDOMCache['envelopeIcon_' + frameId]);
+        globalDOMCache['envelopeIcon_' + frameId] = null;
+    }
+
+    renderEnvelopeIcon(objectId, frameId) {
+        // lazily instantiate the envelope icon if it doesn't already exist
+        let iconDiv = this.getIconDiv(frameId);
+        let frame = realityEditor.getFrame(objectId, frameId);
+        if (!iconDiv) {
+            let object = realityEditor.getObject(objectId);
+            let name =  frame.src;
+            let src = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/frames/' + name + '/icon.gif');
+            iconDiv = this.createIconDiv(frameId, src);
+        }
+
+        // let finalMatrix = this.arUtilities.copyMatrix(realityEditor.sceneGraph.getCSSMatrix(frameId));
+
+        // We ALWAYS want the icon to face the camera, so don't need to check if frame.alwaysFaceCamera is true
+        // if (frame.alwaysFaceCamera === true) {
+        let finalMatrix = [];
+        let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(frameId, 'CAMERA');
+        let modelViewMatrix = [];
+        this.arUtilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
+        this.arUtilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+        // }
+
+        iconDiv.style.transform = 'matrix3d(' + finalMatrix.toString() + ')';
+    }
+
+    getIconDiv(frameId) {
+        return globalDOMCache['envelopeIcon_' + frameId];
+    }
+
+    createIconDiv(frameId, src) {
+        let container = document.createElement('div');
+        container.id = 'envelopeIcon_' + frameId;
+        container.classList.add('main', 'visibleFrameContainer');
+        container.style.width = '100vw';
+        container.style.height = '100vh';
+
+        let icon = document.createElement('img');
+        icon.src = src;
+
+        let iconWidth = 440;
+        let borderWidth = 16;
+        icon.style.position = 'absolute';
+        icon.style.width = `${iconWidth}px`;
+        icon.style.height = `${iconWidth}px`;
+        icon.style.left = `calc(100vw/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
+        icon.style.top = `calc(100vh/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
+
+        icon.style.border = `${borderWidth}px solid white`;
+        icon.style.borderRadius = '96px';
+
+        container.appendChild(icon);
+
+        icon.addEventListener('pointerup', () => {
+            realityEditor.envelopeManager.focusEnvelope(frameId);
+        });
+
+        this.gui.appendChild(container);
+        globalDOMCache['envelopeIcon_' + frameId] = container;
+        return container;
+    }
+}
+
+realityEditor.gui.envelopeIconRenderer = new EnvelopeIconRenderer();

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -1,7 +1,23 @@
+/**
+ * This is used to render temporarily icons for envelopes that have received a
+ * "blur" event to remove their 2D UI layer but keep their 3D fullscreen content
+ * on the screen; we add simple image divs floating at the envelope origin so
+ * that clicking on them can restore "focus" to that envelope.
+ */
 class EnvelopeIconRenderer {
     constructor() {
         this.knownEnvelopes = {};
         this.arUtilities = realityEditor.gui.ar.utilities;
+    }
+
+    initService() {
+        this.gui = document.getElementById('GUI');
+
+        realityEditor.gui.ar.draw.addUpdateListener(() => {
+            Object.values(this.knownEnvelopes).forEach(envelope => {
+                this.updateEnvelope(envelope);
+            });
+        });
     }
 
     onEnvelopeRegistered(envelope) {
@@ -26,16 +42,6 @@ class EnvelopeIconRenderer {
         this.knownEnvelopes[envelope.frame].hasFocus = false;
     }
 
-    initService() {
-        this.gui = document.getElementById('GUI');
-
-        realityEditor.gui.ar.draw.addUpdateListener(() => {
-            Object.values(this.knownEnvelopes).forEach(envelope => {
-                this.updateEnvelope(envelope);
-            });
-        });
-    }
-
     updateEnvelope(envelope) {
         if (envelope.isOpen && !envelope.hasFocus) {
             this.renderEnvelopeIcon(envelope.object, envelope.frame);
@@ -52,31 +58,26 @@ class EnvelopeIconRenderer {
 
     renderEnvelopeIcon(objectId, frameId) {
         // lazily instantiate the envelope icon if it doesn't already exist
-        let iconDiv = this.getIconDiv(frameId);
+        let iconDiv = globalDOMCache['envelopeIcon_' + frameId];
         let frame = realityEditor.getFrame(objectId, frameId);
         if (!iconDiv) {
             let object = realityEditor.getObject(objectId);
-            let name =  frame.src;
-            let src = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/frames/' + name + '/icon.gif');
+            let name = frame.src;
+            let port = realityEditor.network.getPort(object);
+            let path = '/frames/' + name + '/icon.gif';
+            let src = realityEditor.network.getURL(object.ip, port, path);
             iconDiv = this.createIconDiv(frameId, src);
         }
 
-        // let finalMatrix = this.arUtilities.copyMatrix(realityEditor.sceneGraph.getCSSMatrix(frameId));
-
         // We ALWAYS want the icon to face the camera, so don't need to check if frame.alwaysFaceCamera is true
-        // if (frame.alwaysFaceCamera === true) {
+        // let finalMatrix = this.arUtilities.copyMatrix(realityEditor.sceneGraph.getCSSMatrix(frameId));
         let finalMatrix = [];
         let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(frameId, 'CAMERA');
         let modelViewMatrix = [];
         this.arUtilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
         this.arUtilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
-        // }
 
         iconDiv.style.transform = 'matrix3d(' + finalMatrix.toString() + ')';
-    }
-
-    getIconDiv(frameId) {
-        return globalDOMCache['envelopeIcon_' + frameId];
     }
 
     createIconDiv(frameId, src) {
@@ -85,28 +86,24 @@ class EnvelopeIconRenderer {
         container.classList.add('main', 'visibleFrameContainer');
         container.style.width = '100vw';
         container.style.height = '100vh';
+        this.gui.appendChild(container);
 
         let icon = document.createElement('img');
         icon.src = src;
-
-        let iconWidth = 440;
-        let borderWidth = 16;
+        let iconWidth = 440, borderWidth = 16;
         icon.style.position = 'absolute';
         icon.style.width = `${iconWidth}px`;
         icon.style.height = `${iconWidth}px`;
         icon.style.left = `calc(100vw/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
         icon.style.top = `calc(100vh/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
-
         icon.style.border = `${borderWidth}px solid white`;
         icon.style.borderRadius = '96px';
-
         container.appendChild(icon);
 
         icon.addEventListener('pointerup', () => {
             realityEditor.envelopeManager.focusEnvelope(frameId);
         });
 
-        this.gui.appendChild(container);
         globalDOMCache['envelopeIcon_' + frameId] = container;
         return container;
     }


### PR DESCRIPTION
- Opening an envelope will grant it focus
- Minimize button appears if there is a tool that has focus
- Pressing the minimize button removes focus, sending a "blur" event into the tool (to tell it to hide its 2D layer) and setting `pointer-events: none` on the fullscreen iframe
- When blurred, the envelopeIconRenderer renders a placeholder icon at the tool position, using the icon.gif from the tool
- Clicking on the placeholder icon will restore focus to the envelope, sending a "focus" event into the tool (to tell it to show its 2D layer)
- If you've blurred some envelopes, pressing the "close" button will close all envelopes whose contents are visible

Requires https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/761, can test with https://github.com/ptcrealitylab/vuforia-spatial-core-addon/pull/234