### PR TITLE
fix issue with onLocalized UI getting stuck localizing forever

### DIFF
--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -25,6 +25,7 @@ createNameSpace("realityEditor.worldObjects");
      * @type {Object.<string, Array.<number>>}
      */
     var worldCorrections = {};
+    let worldUsedForCorrection = null;
 
     // a string that all world object's uuids are built from
     const worldObjectId = '_WORLD_';
@@ -382,6 +383,7 @@ createNameSpace("realityEditor.worldObjects");
                 localizedWithinWorldCallbacks.forEach(function(callback) {
                     callback(objectKey);
                 });
+                worldUsedForCorrection = objectKey;
                 realityEditor.app.tap();
                 setTimeout(function() {
                     realityEditor.app.tap();
@@ -403,6 +405,8 @@ createNameSpace("realityEditor.worldObjects");
         let bestWorld = getBestWorldObject();
         if (bestWorld && bestWorld.objectId !== getLocalWorldId()) {
             callback(bestWorld.objectId); // trigger immediately if we're already localized
+        } else if (worldUsedForCorrection) {
+            callback(worldUsedForCorrection); // works even when suppressedObjectRendering is on
         }
     }
 


### PR DESCRIPTION
The previous fix that I was using to get `onLocalizedWithinWorld` to trigger wasn't always working; it seems to be because if you're still on the Setup Metaverse screen when it localizes, the toolbox has a `suppressObjectRendering` flag toggled on, causing `getBestWorldObject` used internally in onLocalizedWithinWorld  to return the _WORLD_local.

This new method has a backup, where it returns the world ID directly used by the `setOrigin` function.