### PR TITLE
envelopes open in minimized state for others; ru-bar properly updates in response

### DIFF
--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -246,6 +246,8 @@ createNameSpace("realityEditor.envelopeManager");
      * @param {boolean} wasTriggeredByEnvelope
      */
     function focusEnvelope(frameId, wasTriggeredByEnvelope = false) {
+        if (knownEnvelopes[frameId].hasFocus) return;
+
         knownEnvelopes[frameId].hasFocus = true;
 
         // callbacks inside the envelope are auto-triggered if it opens itself, but need to be triggered if opened externally
@@ -263,7 +265,10 @@ createNameSpace("realityEditor.envelopeManager");
         // adjust exit/cancel/back buttons for # of open frames
         updateExitButton();
 
+        // hide the temporary icon
         realityEditor.gui.envelopeIconRenderer.onFocus(knownEnvelopes[frameId]);
+        // focusing an app also brings it to the front of the bar, same as opening it
+        realityEditor.gui.recentlyUsedBar.onOpen(knownEnvelopes[frameId]);
     }
 
     /**
@@ -272,6 +277,8 @@ createNameSpace("realityEditor.envelopeManager");
      * @param {boolean} wasTriggeredByEnvelope - can be triggered in multiple ways e.g. the minimize button or from within the envelope
      */
     function blurEnvelope(frameId, wasTriggeredByEnvelope = false) {
+        if (!knownEnvelopes[frameId].hasFocus) return;
+
         knownEnvelopes[frameId].hasFocus = false;
 
         // callbacks inside the envelope are auto-triggered if it opens itself, but need to be triggered if opened externally
@@ -749,5 +756,6 @@ createNameSpace("realityEditor.envelopeManager");
     exports.openEnvelope = openEnvelope;
     exports.closeEnvelope = closeEnvelope;
     exports.focusEnvelope = focusEnvelope;
+    exports.blurEnvelope = blurEnvelope;
 
 }(realityEditor.envelopeManager));

--- a/src/gui/recentlyUsedBar.js
+++ b/src/gui/recentlyUsedBar.js
@@ -60,7 +60,11 @@ class RecentlyUsedBar {
 
         realityEditor.envelopeManager.getOpenEnvelopes().forEach(function(envelope) {
             if (envelope.hasFocus) {
-                realityEditor.envelopeManager.closeEnvelope(envelope.frame);
+                if (envelope.isFull2D) {
+                    realityEditor.envelopeManager.closeEnvelope(envelope.frame);
+                } else {
+                    realityEditor.envelopeManager.blurEnvelope(envelope.frame);
+                }
             }
         });
         realityEditor.envelopeManager.openEnvelope(frameId, false);


### PR DESCRIPTION
Recently-used icons are ordered locally based on last (opened or focused) time. Won't necessarily be consistent across clients, as the focus state is personal to each client. But when you refresh the page it will be consistent with the server version.

Clicking on another recently-used icon will totally close the current envelope if it's a full2D envelope, or just blur the envelope if it has a 3D component.

Goes with: https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/773