### PR TITLE
Make minimized icons green; load svgs instead of gifs

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2019,3 +2019,12 @@ Logic Interface CSS
 .iframeOverlayWithoutFocus {
     pointer-events: none; /* deactivates the tool's touchPropagation cover when an envelope loses focus */
 }
+
+.minimizedEnvelopeIcon {
+    position: absolute;
+    border-radius: 96px;
+    /* this is a trick to turn a black image with white borders into a colored image with black borders */
+    filter: invert(1) brightness(90%) saturate(200%) blur(1px); /* assumes it's a black semi-transparent icon */
+    -webkit-filter: invert(1) brightness(90%) saturate(200%) blur(1px); /* blur smooths out jagged pixel edges */
+    background-color: #BF55E2; /* inverse of PTC-green */
+}

--- a/css/index.css
+++ b/css/index.css
@@ -2023,5 +2023,18 @@ Logic Interface CSS
 .minimizedEnvelopeIcon {
     position: absolute;
     border-radius: 96px;
-    background-color: #40AA1D; /* PTC-green */
+}
+
+.tool-color-gradient {
+    /*animation: tool-color-gradient-anim 0.3s infinite alternate;*/
+    background: linear-gradient(90deg, #000000,#000000, #00ffff, #ee7752, #e73c7e, #23a6d5, #23d5ab,#000000, #000000);
+    background-size: 2000% 200%;
+    animation: gradient 10s infinite;
+    border-radius: 50px;
+}
+
+@keyframes gradient {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
 }

--- a/css/index.css
+++ b/css/index.css
@@ -2023,8 +2023,5 @@ Logic Interface CSS
 .minimizedEnvelopeIcon {
     position: absolute;
     border-radius: 96px;
-    /* this is a trick to turn a black image with white borders into a colored image with black borders */
-    filter: invert(1) brightness(90%) saturate(200%) blur(1px); /* assumes it's a black semi-transparent icon */
-    -webkit-filter: invert(1) brightness(90%) saturate(200%) blur(1px); /* blur smooths out jagged pixel edges */
-    background-color: #BF55E2; /* inverse of PTC-green */
+    background-color: #40AA1D; /* PTC-green */
 }

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -91,16 +91,12 @@ class EnvelopeIconRenderer {
         let icon = document.createElement('img');
         icon.src = src;
         let iconWidth = 440, borderWidth = 16;
-        icon.style.position = 'absolute';
+        icon.classList.add('minimizedEnvelopeIcon');
         icon.style.width = `${iconWidth}px`;
         icon.style.height = `${iconWidth}px`;
         icon.style.left = `calc(100vw/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
         icon.style.top = `calc(100vh/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
         icon.style.border = `${borderWidth}px solid white`;
-        icon.style.borderRadius = '96px';
-        icon.style.backgroundColor = '#BF55E2'; // inverse of PTC-green
-        icon.style.filter = 'invert(1)';
-        icon.style.webkitFilter = 'invert(1)';
         container.appendChild(icon);
 
         icon.addEventListener('pointerup', () => {

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -64,7 +64,7 @@ class EnvelopeIconRenderer {
             let object = realityEditor.getObject(objectId);
             let name = frame.src;
             let port = realityEditor.network.getPort(object);
-            let path = '/frames/' + name + '/icon.gif';
+            let path = '/frames/' + name + '/icon-foreground.svg';
             let src = realityEditor.network.getURL(object.ip, port, path);
             iconDiv = this.createIconDiv(frameId, src);
         }

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -98,6 +98,9 @@ class EnvelopeIconRenderer {
         icon.style.top = `calc(100vh/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
         icon.style.border = `${borderWidth}px solid white`;
         icon.style.borderRadius = '96px';
+        icon.style.backgroundColor = '#BF55E2'; // inverse of PTC-green
+        icon.style.filter = 'invert(1)';
+        icon.style.webkitFilter = 'invert(1)';
         container.appendChild(icon);
 
         icon.addEventListener('pointerup', () => {

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -91,7 +91,7 @@ class EnvelopeIconRenderer {
         let icon = document.createElement('img');
         icon.src = src;
         let iconWidth = 440, borderWidth = 16;
-        icon.classList.add('minimizedEnvelopeIcon');
+        icon.classList.add('minimizedEnvelopeIcon', 'tool-color-gradient');
         icon.style.width = `${iconWidth}px`;
         icon.style.height = `${iconWidth}px`;
         icon.style.left = `calc(100vw/2 - ${iconWidth}px/2 - ${borderWidth}px)`;


### PR DESCRIPTION
After adding https://github.com/ptcrealitylab/pop-up-onboarding-addon/pull/43 and https://github.com/ptcrealitylab/vuforia-spatial-core-addon/pull/241, loads the white-line-only icon-foreground.svg files instead of the black-background icon.gifs, and adds a green background with CSS, to make the minimized icons stand out more against the background 