### PR TITLE
Remove untextured "mesh_0" from gltf

### DIFF
--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -432,11 +432,20 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
                 wireMesh = new THREE.Mesh(gltf.scene.geometry, wireMaterial);
             } else {
                 let allMeshes = [];
+                let meshesToRemove = [];
                 gltf.scene.traverse(child => {
                     if (child.material && child.geometry) {
+                        if (child.name && child.name.toLocaleLowerCase() === 'mesh_0') {
+                            meshesToRemove.push(child);
+                            return;
+                        }
                         allMeshes.push(child);
                     }
                 });
+
+                for (let mesh of meshesToRemove) {
+                    mesh.removeFromParent();
+                }
 
                 allMeshes.forEach(child => {
                     if (typeof maxHeight !== 'undefined') {


### PR DESCRIPTION
Vuforia's authoring mesh includes an untextured mesh for places that it has only geometry data. Removes this untextured mesh from visuals and collision detection to make the mesh look better and keep collision detection accurate. This mesh could be added to the BVH to make it part of the collision detection while invisible but I didn't do that so it would be visually consistent.