### PR TITLE
Allow clicking on icons while drawing is open

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2020,9 +2020,19 @@ Logic Interface CSS
     pointer-events: none; /* deactivates the tool's touchPropagation cover when an envelope loses focus */
 }
 
+.minimizedEnvelopeContainer {
+    width: 100vw;
+    height: 100vh;
+}
+
 .minimizedEnvelopeIcon {
     position: absolute;
     border-radius: 96px;
+    border: 16px solid white;
+    width: 440px;
+    height: 440px;
+    left: calc(100vw/2 - 440px/2 - 16px);
+    top: calc(100vh/2 - 440px/2 - 16px);
 }
 
 .tool-color-gradient {
@@ -2037,4 +2047,11 @@ Logic Interface CSS
     0% { background-position: 0% 50%; }
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
+}
+
+.minimizedEnvelopeIcon:hover {
+    border: 24px solid white;
+    left: calc(100vw/2 - 440px/2 - 24px);
+    top: calc(100vh/2 - 440px/2 - 24px);
+    background: black;
 }

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -158,17 +158,6 @@ createNameSpace("realityEditor.envelopeManager");
         const envelope = knownEnvelopes[frameId];
         if (envelope.isOpen) return;
 
-        // first, blur or close the current envelope if there is one focused
-        getOpenEnvelopes().forEach(openEnvelope => {
-            if (openEnvelope.hasFocus) {
-                if (openEnvelope.isFull2D) {
-                    realityEditor.envelopeManager.closeEnvelope(openEnvelope.frame);
-                } else {
-                    realityEditor.envelopeManager.blurEnvelope(openEnvelope.frame);
-                }
-            }
-        });
-
         envelope.isOpen = true;
         envelope.hasFocus = true;
 

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -158,6 +158,17 @@ createNameSpace("realityEditor.envelopeManager");
         const envelope = knownEnvelopes[frameId];
         if (envelope.isOpen) return;
 
+        // first, blur or close the current envelope if there is one focused
+        getOpenEnvelopes().forEach(openEnvelope => {
+            if (openEnvelope.hasFocus) {
+                if (openEnvelope.isFull2D) {
+                    realityEditor.envelopeManager.closeEnvelope(openEnvelope.frame);
+                } else {
+                    realityEditor.envelopeManager.blurEnvelope(openEnvelope.frame);
+                }
+            }
+        });
+
         envelope.isOpen = true;
         envelope.hasFocus = true;
 
@@ -247,6 +258,17 @@ createNameSpace("realityEditor.envelopeManager");
      */
     function focusEnvelope(frameId, wasTriggeredByEnvelope = false) {
         if (knownEnvelopes[frameId].hasFocus) return;
+
+        // first, blur or close the current envelope if there is one focused
+        getOpenEnvelopes().forEach(openEnvelope => {
+            if (openEnvelope.hasFocus) {
+                if (openEnvelope.isFull2D) {
+                    realityEditor.envelopeManager.closeEnvelope(openEnvelope.frame);
+                } else {
+                    realityEditor.envelopeManager.blurEnvelope(openEnvelope.frame);
+                }
+            }
+        });
 
         knownEnvelopes[frameId].hasFocus = true;
 

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -83,20 +83,12 @@ class EnvelopeIconRenderer {
     createIconDiv(frameId, src) {
         let container = document.createElement('div');
         container.id = 'envelopeIcon_' + frameId;
-        container.classList.add('main', 'visibleFrameContainer');
-        container.style.width = '100vw';
-        container.style.height = '100vh';
+        container.classList.add('main', 'visibleFrameContainer', 'minimizedEnvelopeContainer');
         this.gui.appendChild(container);
 
         let icon = document.createElement('img');
         icon.src = src;
-        let iconWidth = 440, borderWidth = 16;
         icon.classList.add('minimizedEnvelopeIcon', 'tool-color-gradient');
-        icon.style.width = `${iconWidth}px`;
-        icon.style.height = `${iconWidth}px`;
-        icon.style.left = `calc(100vw/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
-        icon.style.top = `calc(100vh/2 - ${iconWidth}px/2 - ${borderWidth}px)`;
-        icon.style.border = `${borderWidth}px solid white`;
         container.appendChild(icon);
 
         icon.addEventListener('pointerup', () => {

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -1660,7 +1660,9 @@ realityEditor.network.onInternalPostMessage = function (e) {
                 tempThisObject.fullscreenZPosition = msgContent.fullscreenZPosition;
             }
 
-            let zIndex = tempThisObject.fullscreenZPosition || globalStates.defaultFullscreenFrameZ; // defaults to background
+            // z-index can be specified. if not, goes to background if not full2D, foreground if full2D
+            let zIndex = tempThisObject.fullscreenZPosition ||
+                msgContent.fullScreenFull2D ? globalStates.defaultFullscreenFull2DFrameZ : globalStates.defaultFullscreenFrameZ;
 
             if (typeof msgContent.fullScreenAnimated !== 'undefined') {
 

--- a/src/states.js
+++ b/src/states.js
@@ -176,7 +176,7 @@ var globalStates = {
     interface: "gui",
 
     useGroundPlane: false,
-    defaultFullscreenFrameZ: 100
+    defaultFullscreenFrameZ: 1
 };
 
 var globalCanvas = {};

--- a/src/states.js
+++ b/src/states.js
@@ -176,7 +176,8 @@ var globalStates = {
     interface: "gui",
 
     useGroundPlane: false,
-    defaultFullscreenFrameZ: 1
+    defaultFullscreenFrameZ: -10,
+    defaultFullscreenFull2DFrameZ: 100
 };
 
 var globalCanvas = {};


### PR DESCRIPTION
Moves fullscreen tools to background (z = -10) so we can click on tool icons. If fullscreen tool is full2D (chat and search), moves to foreground (z = 100) so the icons don't render on top of the 2D content.

Since new envelopes can be added/opened while one is focused now, added some code to the focus handlers to close/blur the active envelope when a new envelope enters the foreground.

Also adds a hover visual feedback to minimized icons, so you can tell when you will click on them vs the background.