### PR TITLE
if a toolId is present in the URL, attempts to open the envelope when it loads

### DIFF
--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -89,6 +89,20 @@ createNameSpace("realityEditor.envelopeManager");
 
         realityEditor.gui.recentlyUsedBar.onEnvelopeRegistered(frame);
         realityEditor.gui.envelopeIconRenderer.onEnvelopeRegistered(knownEnvelopes[frameKey]);
+
+        // Parse the URL for a ?toolId, and open the envelope if possible
+        let searchParams = new URLSearchParams(window.location.search);
+        let toolboxActiveToolId = searchParams.get('toolId');
+        if (toolboxActiveToolId && frameKey === toolboxActiveToolId) {
+            setTimeout(() => {
+                // for now, open it after a slight delay so it doesn't get closed by another open envelope
+                // todo: don't rely on a timeout
+                openEnvelope(frameKey, false);
+                setTimeout(() => {
+                    focusEnvelope(frameKey, false);
+                }, 1000);
+            }, 1000);
+        }
     }
 
     /**

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -26,6 +26,8 @@ createNameSpace("realityEditor.envelopeManager");
      * @type {Object.<string, Envelope>}
      */
     var knownEnvelopes = {};
+
+    let alreadyProcessedUrlToolId = false;
     
     let callbacks = {
         onExitButtonShown: [],
@@ -90,10 +92,13 @@ createNameSpace("realityEditor.envelopeManager");
         realityEditor.gui.recentlyUsedBar.onEnvelopeRegistered(frame);
         realityEditor.gui.envelopeIconRenderer.onEnvelopeRegistered(knownEnvelopes[frameKey]);
 
+        if (alreadyProcessedUrlToolId) return;
+
         // Parse the URL for a ?toolId, and open the envelope if possible
         let searchParams = new URLSearchParams(window.location.search);
         let toolboxActiveToolId = searchParams.get('toolId');
         if (toolboxActiveToolId && frameKey === toolboxActiveToolId) {
+            alreadyProcessedUrlToolId = true; // prevent weird behavior if the tool reloads/re-registers
             setTimeout(() => {
                 // for now, open it after a slight delay so it doesn't get closed by another open envelope
                 // todo: don't rely on a timeout


### PR DESCRIPTION
There are some race conditions if you have multiple minimized envelopes and also pass a toolId into the URL. I ran out of brainpower to solve this without adding a timeout before opening, and another timeout before focusing. Probably not 100% robust if on a slow network, but works in the cases where I tried it. In the worst case, it will just open minimized, or close entirely after opening, if another envelope with an open=1 node loads too slowly.