### PR TITLE
Disable limitScanRAM functionality

### DIFF
--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -23,7 +23,7 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
 
     let hasFirstSeenInstantWorld = false;
 
-    let limitScanRAM = false; // if true (toggled through menu), stop area target capture when device memory usage is high
+    const limitScanRAM = false; // if true, stop area target capture when device memory usage is high
     let maximumPercentRAM = 0.33; // the app will stop scanning when it reaches this threshold of total device memory
 
     let callbacks = {
@@ -115,18 +115,19 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
 
         realityEditor.app.onAreaTargetGenerateProgress('realityEditor.gui.ar.areaTargetScanner.onAreaTargetGenerateProgress');
 
-        realityEditor.app.subscribeToAppMemoryEvents('realityEditor.gui.ar.areaTargetScanner.onAppMemoryEvent');
+        // realityEditor.app.subscribeToAppMemoryEvents('realityEditor.gui.ar.areaTargetScanner.onAppMemoryEvent');
 
-        realityEditor.gui.settings.addToggleWithText('Limit Scan RAM', 'area target scan stops at threshold (e.g. 0.33)', 'maximumRAM', '../../../svg/powerSave.svg', false, '0.33',
-            function(newValue) {
-                console.log('limitScanRAM was set to ' + newValue);
-                limitScanRAM = newValue;
-            },
-            function(newValue) {
-                console.log('zone text was set to ' + newValue);
-                maximumPercentRAM = parseFloat(newValue) || 0.33;
-            }
-        ).moveToDevelopMenu();
+        // Disabled due to lack of access to develop menu in current UI
+        // realityEditor.gui.settings.addToggleWithText('Limit Scan RAM', 'area target scan stops at threshold (e.g. 0.33)', 'maximumRAM', '../../../svg/powerSave.svg', false, '0.33',
+        //     function(newValue) {
+        //         console.log('limitScanRAM was set to ' + newValue);
+        //         limitScanRAM = newValue;
+        //     },
+        //     function(newValue) {
+        //         console.log('zone text was set to ' + newValue);
+        //         maximumPercentRAM = parseFloat(newValue) || 0.33;
+        //     }
+        // ).moveToDevelopMenu();
     }
 
     function showNotificationIfNeeded() {

--- a/src/gui/ar/areaTargetScanner.js
+++ b/src/gui/ar/areaTargetScanner.js
@@ -114,20 +114,6 @@ createNameSpace("realityEditor.gui.ar.areaTargetScanner");
         });
 
         realityEditor.app.onAreaTargetGenerateProgress('realityEditor.gui.ar.areaTargetScanner.onAreaTargetGenerateProgress');
-
-        // realityEditor.app.subscribeToAppMemoryEvents('realityEditor.gui.ar.areaTargetScanner.onAppMemoryEvent');
-
-        // Disabled due to lack of access to develop menu in current UI
-        // realityEditor.gui.settings.addToggleWithText('Limit Scan RAM', 'area target scan stops at threshold (e.g. 0.33)', 'maximumRAM', '../../../svg/powerSave.svg', false, '0.33',
-        //     function(newValue) {
-        //         console.log('limitScanRAM was set to ' + newValue);
-        //         limitScanRAM = newValue;
-        //     },
-        //     function(newValue) {
-        //         console.log('zone text was set to ' + newValue);
-        //         maximumPercentRAM = parseFloat(newValue) || 0.33;
-        //     }
-        // ).moveToDevelopMenu();
     }
 
     function showNotificationIfNeeded() {


### PR DESCRIPTION
With improvements to Vuforia's AT scanning functionality, it is now very difficult for us to run out of RAM during the scanning process.  This removes the limitScanRAM function which, while disabled by default, could be previously toggled on on older devices.