### PR TITLE
Analytics: Patches support

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -171,7 +171,8 @@ export class Analytics {
         const patches = Object.values(desktopRenderer.getCameraVisPatches() || {});
 
         for (const patch of patches) {
-            patch.visible = true;
+            patch.show();
+            patch.resetShaderMode();
         }
     }
 
@@ -356,17 +357,17 @@ export class Analytics {
             return;
         }
 
-        const patches = desktopRenderer.cloneCameraVisPatches();
+        const patches = desktopRenderer.cloneCameraVisPatches('HIDDEN');
         if (!patches) {
             return;
         }
 
         // Hide cloned patches after brief delay to not clutter the space
-        setTimeout(() => {
-            for (const patch of Object.values(patches)) {
-                patch.visible = false;
-            }
-        }, patchTolerance);
+        // setTimeout(() => {
+        //     for (const patch of Object.values(patches)) {
+        //         patch.visible = false;
+        //     }
+        // }, patchTolerance);
     }
 
     writeDehydratedRegionCards() {

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -333,7 +333,11 @@ export class Analytics {
         });
 
         for (let desc of regionCardDescriptions) {
-            const poses = this.humanPoseAnalyzer.getPosesInTimeInterval(desc.startTime, desc.endTime);
+            let poses = this.humanPoseAnalyzer.getPosesInTimeInterval(desc.startTime, desc.endTime);
+            if (poses.length === 0) {
+                let defaultAnalytics = realityEditor.analytics.getDefaultAnalytics();
+                poses = defaultAnalytics.humanPoseAnalyzer.getPosesInTimeInterval(desc.startTime, desc.endTime);
+            }
             let regionCard = new RegionCard(this, this.pinnedRegionCardsContainer, poses, desc);
             regionCard.state = RegionCardState.Pinned;
             if (desc.label) {

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -325,6 +325,16 @@ export class Analytics {
         this.nextStepNumber += 1;
 
         this.updateCsvExportLink();
+
+        // wider tolerance for associating local cameravis patches with
+        // potentially remote region cards
+        const patchTolerance = 3000;
+        if (Math.abs(regionCard.endTime - Date.now()) < patchTolerance) {
+            const desktopRenderer = realityEditor.gui.ar.desktopRenderer;
+            if (desktopRenderer) {
+                desktopRenderer.cloneCameraVisPatches();
+            }
+        }
     }
 
     writeDehydratedRegionCards() {

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -347,12 +347,26 @@ export class Analytics {
         // wider tolerance for associating local cameravis patches with
         // potentially remote region cards
         const patchTolerance = 3000;
-        if (Math.abs(regionCard.endTime - Date.now()) < patchTolerance) {
-            const desktopRenderer = realityEditor.gui.ar.desktopRenderer;
-            if (desktopRenderer) {
-                desktopRenderer.cloneCameraVisPatches();
-            }
+        if (Math.abs(regionCard.endTime - Date.now()) > patchTolerance) {
+            return;
         }
+
+        const desktopRenderer = realityEditor.gui.ar.desktopRenderer;
+        if (!desktopRenderer) {
+            return;
+        }
+
+        const patches = desktopRenderer.cloneCameraVisPatches();
+        if (!patches) {
+            return;
+        }
+
+        // Hide cloned patches after brief delay to not clutter the space
+        setTimeout(() => {
+            for (const patch of Object.values(patches)) {
+                patch.visible = false;
+            }
+        }, patchTolerance);
     }
 
     writeDehydratedRegionCards() {

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -24,6 +24,8 @@ export class Analytics {
         this.timelineContainer = document.createElement('div');
         this.timelineContainer.id = 'analytics-timeline-container';
 
+        this.patchFilter = this.patchFilter.bind(this);
+
         this.container.appendChild(this.timelineContainer);
         this.timeline = new Timeline(this, this.timelineContainer);
 
@@ -76,7 +78,6 @@ export class Analytics {
         if (this.humanPoseAnalyzer.settingsUi) {
             this.humanPoseAnalyzer.settingsUi.hide();
         }
-        this.resetPatchVisibility();
     }
 
     /**
@@ -95,6 +96,7 @@ export class Analytics {
         if (this.threejsContainer.parent) {
             realityEditor.gui.threejsScene.removeFromScene(this.threejsContainer);
         }
+        this.resetPatchVisibility();
     }
 
     /**
@@ -159,6 +161,28 @@ export class Analytics {
     }
 
     /**
+     * @param {CameraVisPatch} patch
+     * @return {boolean}
+     */
+    patchFilter(patch) {
+        if (!this.lastDisplayRegion) {
+            return true;
+        }
+
+        if (this.lastDisplayRegion.startTime > 0 &&
+            patch.creationTime < this.lastDisplayRegion.startTime) {
+            return false;
+        }
+
+        if (this.lastDisplayRegion.endTime > 0 &&
+            patch.creationTime > this.lastDisplayRegion.endTime) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * We take control over CameraVis patch visibility for
      * animation reasons so this restores them all
      */
@@ -168,7 +192,7 @@ export class Analytics {
             return;
         }
 
-        const patches = Object.values(desktopRenderer.getCameraVisPatches() || {});
+        const patches = Object.values(desktopRenderer.getCameraVisPatches() || {}).filter(this.patchFilter);
 
         for (const patch of patches) {
             patch.show();

--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -76,6 +76,7 @@ export class Analytics {
         if (this.humanPoseAnalyzer.settingsUi) {
             this.humanPoseAnalyzer.settingsUi.hide();
         }
+        this.resetPatchVisibility();
     }
 
     /**
@@ -155,6 +156,23 @@ export class Analytics {
             this.timeline.draw();
         }
         requestAnimationFrame(this.draw);
+    }
+
+    /**
+     * We take control over CameraVis patch visibility for
+     * animation reasons so this restores them all
+     */
+    resetPatchVisibility() {
+        const desktopRenderer = realityEditor.gui.ar.desktopRenderer;
+        if (!desktopRenderer) {
+            return;
+        }
+
+        const patches = Object.values(desktopRenderer.getCameraVisPatches() || {});
+
+        for (const patch of patches) {
+            patch.visible = true;
+        }
     }
 
     /**

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -112,20 +112,6 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
             analyticsByFrame[msgData.frame].blur();
         });
 
-        realityEditor.network.addPostMessageHandler('analyticsSetCursorTime', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setCursorTime(msgData.time);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetHighlightRegion', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setHighlightRegion(msgData.highlightRegion);
-        });
-
         realityEditor.network.addPostMessageHandler('analyticsSetDisplayRegion', (msgData) => {
             if (!analyticsByFrame[msgData.frame]) {
                 return;
@@ -138,41 +124,6 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
                 return;
             }
             analyticsByFrame[msgData.frame].hydrateRegionCards(msgData.regionCards);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetLens', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setLens(msgData.lens);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetLensDetail', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setLensDetail(msgData.lensDetail);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetSpaghettiAttachPoint', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setSpaghettiAttachPoint(msgData.spaghettiAttachPoint);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetSpaghettiVisible', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setSpaghettiVisible(msgData.spaghettiVisible);
-        });
-
-        realityEditor.network.addPostMessageHandler('analyticsSetAllClonesVisible', (msgData) => {
-            if (!analyticsByFrame[msgData.frame]) {
-                return;
-            }
-            analyticsByFrame[msgData.frame].setSpaghettiVisible(msgData.allClonesVisible);
         });
     }
     exports.initService = initService;

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -62,6 +62,20 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
     }
     exports.getActiveTimeline = getActiveTimeline;
 
+    function onVehicleDeleted(event) {
+        if (!event.objectKey || !event.frameKey || event.nodeKey) {
+            return;
+        }
+        if (!analyticsByFrame[event.frameKey]) {
+            return;
+        }
+        analyticsByFrame[event.frameKey].close();
+        delete analyticsByFrame[event.frameKey];
+        if (activeFrame === event.frameKey) {
+            activeFrame = noneFrame;
+        }
+    }
+
     function initService() {
         activeFrame = noneFrame;
         analyticsByFrame[noneFrame] = makeAnalytics(noneFrame);
@@ -125,6 +139,9 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
             }
             analyticsByFrame[msgData.frame].hydrateRegionCards(msgData.regionCards);
         });
+
+        realityEditor.device.registerCallback('vehicleDeleted', onVehicleDeleted); // deleted using userinterface
+        realityEditor.network.registerCallback('vehicleDeleted', onVehicleDeleted); // deleted using server
     }
     exports.initService = initService;
 }(realityEditor.analytics));

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -95,11 +95,13 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
         });
 
         realityEditor.network.addPostMessageHandler('analyticsClose', (msgData) => {
-            if (!analyticsByFrame[msgData.frame] || activeFrame !== msgData.frame) {
+            if (!analyticsByFrame[msgData.frame]) {
                 return;
             }
-            activeFrame = noneFrame;
             analyticsByFrame[msgData.frame].close();
+            if (activeFrame === msgData.frame) {
+                activeFrame = noneFrame;
+            }
         });
 
         realityEditor.network.addPostMessageHandler('analyticsFocus', (msgData) => {
@@ -120,10 +122,10 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
             if (!analyticsByFrame[msgData.frame]) {
                 return;
             }
+            analyticsByFrame[msgData.frame].blur();
             if (activeFrame === msgData.frame) {
                 activeFrame = noneFrame;
             }
-            analyticsByFrame[msgData.frame].blur();
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetDisplayRegion', (msgData) => {

--- a/src/analytics/timeline.js
+++ b/src/analytics/timeline.js
@@ -521,15 +521,16 @@ export class Timeline {
         this.gfx.fillStyle = 'rgb(200, 200, 200)';
 
         for (const patch of patches) {
-            let timeStart = patch.__creationTime - 1000;
-            let timeEnd = patch.__creationTime + 2000;
+            let timeStart = patch.creationTime;
+            let timeEnd = patch.creationTime + 1000;
 
             let patchVisible = this.cursorTime > timeStart && this.cursorTime < timeEnd;
-            if (this.cursorTime < this.timeMin || this.cursorTime > timeMax) {
-                patchVisible = true;
-            }
 
-            patch.visible = patchVisible;
+            if (patchVisible) {
+                patch.show();
+            } else {
+                patch.hide();
+            }
 
             if (timeEnd < this.timeMin || timeStart > timeMax) {
                 continue;

--- a/src/analytics/timeline.js
+++ b/src/analytics/timeline.js
@@ -509,7 +509,9 @@ export class Timeline {
             return;
         }
 
-        let patches = Object.values(desktopRenderer.getCameraVisPatches() || {});
+        let patches = Object.values(desktopRenderer.getCameraVisPatches() || {})
+            .filter(this.analytics.patchFilter);
+
         if (patches.length === 0) {
             return;
         }

--- a/src/analytics/timeline.js
+++ b/src/analytics/timeline.js
@@ -195,6 +195,7 @@ export class Timeline {
         this.calculateAndDrawTicks();
         this.drawPoses();
         this.drawPinnedRegionCards();
+        this.drawPatches();
 
         this.drawHighlightRegion();
 
@@ -500,7 +501,53 @@ export class Timeline {
                 this.gfx.setLineDash([]);
             }
         }
+    }
 
+    drawPatches() {
+        const desktopRenderer = realityEditor.gui.ar.desktopRenderer;
+        if (!desktopRenderer) {
+            return;
+        }
+
+        let patches = Object.values(desktopRenderer.getCameraVisPatches() || {});
+        if (patches.length === 0) {
+            return;
+        }
+
+        const timeMax = this.timeMin + this.widthMs;
+
+        const rowY = boardStart + rowPad + (rowHeight + rowPad) * 2;
+
+        this.gfx.fillStyle = 'rgb(200, 200, 200)';
+
+        for (const patch of patches) {
+            let timeStart = patch.__creationTime - 1000;
+            let timeEnd = patch.__creationTime + 2000;
+
+            let patchVisible = this.cursorTime > timeStart && this.cursorTime < timeEnd;
+            if (this.cursorTime < this.timeMin || this.cursorTime > timeMax) {
+                patchVisible = true;
+            }
+
+            patch.visible = patchVisible;
+
+            if (timeEnd < this.timeMin || timeStart > timeMax) {
+                continue;
+            }
+
+            // Limit to timeline bounds
+            timeStart = Math.max(timeStart, this.timeMin);
+            timeEnd = Math.min(timeEnd, timeMax);
+
+            const startX = this.timeToX(timeStart);
+            const endX = this.timeToX(timeEnd);
+            this.gfx.fillRect(
+                startX,
+                rowY,
+                endX - startX,
+                rowHeight
+            );
+        }
     }
 
     calculateAndDrawTicks() {


### PR DESCRIPTION
This enables creating and viewing patches as a part of the Analytics workflow. During recording, "Mark Step" saves a patch at that moment in time to provide spatial context. Playback on the timeline then displays this patch when the cursor time overlaps with its approximate creation time.