### PR TITLE
Alter three's updateMatrixWorld to not touch hidden objects

### DIFF
--- a/thirdPartyCode/three/three.module.js
+++ b/thirdPartyCode/three/three.module.js
@@ -8105,6 +8105,9 @@ class Object3D extends EventDispatcher {
 	}
 
 	updateMatrixWorld( force ) {
+		if (!this.visible) {
+			return;
+		}
 
 		if ( this.matrixAutoUpdate ) this.updateMatrix();
 


### PR DESCRIPTION
Significantly improves the performance of updateMatrixWorld, previously a large contributor to frame time.