### PR TITLE
Spaghetti now fades out if it is not the one the user is interacting …

### DIFF
--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -569,6 +569,11 @@ export class HumanPoseAnalyzer {
     setHighlightRegion(highlightRegion, fromSpaghetti) {
         if (!highlightRegion) {
             this.setAnimationMode(AnimationMode.cursor);
+            if (!fromSpaghetti) {
+                for (let mesh of Object.values(this.historyLines[this.activeLens.name].all)) {
+                    mesh.setHighlightRegion(null);
+                }
+            }
             // Clear prevAnimationState because we're no longer in a
             // highlighting state
             this.prevAnimationState = null;

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -509,6 +509,8 @@ export class HumanPoseAnalyzer {
      * @param {AnalyticsLens} lens - the lens to set as active
      */
     setActiveLens(lens) {
+        const previousLens = this.activeLens;
+
         this.activeLensIndex = this.lenses.indexOf(lens);
         this.applyCurrentLensToHistory();
 
@@ -519,12 +521,17 @@ export class HumanPoseAnalyzer {
         });
 
         // Swap history lines
-        this.lenses.forEach(l => {
-            this.historyLineContainers.historical[l.name].visible = false;
-            this.historyLineContainers.live[l.name].visible = false;
-        });
+        this.historyLineContainers.historical[previousLens.name].visible = false;
+        this.historyLineContainers.live[previousLens.name].visible = false;
         this.historyLineContainers.historical[lens.name].visible = true;
         this.historyLineContainers.live[lens.name].visible = true;
+
+        // Update corresponding spaghettis to match previous selection state
+        Object.keys(this.historyLines[previousLens.name].all).forEach(key => {
+            const previousSpaghetti = this.historyLines[previousLens.name].all[key];
+            const nextSpaghetti = this.historyLines[lens.name].all[key];
+            previousSpaghetti.transferStateTo(nextSpaghetti);
+        });
 
         // Update UI
         if (this.settingsUi) {

--- a/src/humanPose/HumanPoseAnalyzerSettingsUi.js
+++ b/src/humanPose/HumanPoseAnalyzerSettingsUi.js
@@ -112,6 +112,16 @@ export class HumanPoseAnalyzerSettingsUi {
     }
     
     setUpEventListeners() {
+        this.root.addEventListener('pointerdown', (event) => {
+            event.stopPropagation();
+        });
+        this.root.addEventListener('pointermove', (event) => {
+            event.stopPropagation();
+        });
+        this.root.addEventListener('pointerup', (event) => {
+            event.stopPropagation();
+        });
+        
         // Toggle menu minimization when clicking on the header, but only if not dragging
         this.root.querySelector('.hpa-settings-header').addEventListener('mousedown', event => {
             let mouseDownX = event.clientX;

--- a/src/humanPose/HumanPoseAnalyzerSettingsUi.js
+++ b/src/humanPose/HumanPoseAnalyzerSettingsUi.js
@@ -112,16 +112,6 @@ export class HumanPoseAnalyzerSettingsUi {
     }
     
     setUpEventListeners() {
-        this.root.addEventListener('pointerdown', (event) => {
-            event.stopPropagation();
-        });
-        this.root.addEventListener('pointermove', (event) => {
-            event.stopPropagation();
-        });
-        this.root.addEventListener('pointerup', (event) => {
-            event.stopPropagation();
-        });
-        
         // Toggle menu minimization when clicking on the header, but only if not dragging
         this.root.querySelector('.hpa-settings-header').addEventListener('mousedown', event => {
             let mouseDownX = event.clientX;

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -85,7 +85,6 @@ const SpaghettiSelectionState = {
         onPointerDown: (spaghetti, e) => {
             const intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.pageX, e.pageY, spaghetti.meshPaths);
             const index = spaghetti.getPointFromIntersects(intersects);
-            console.log(activeSpaghetti, spaghetti.isActive(), index);
             if (index === -1) {
                 return;
             }

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -150,7 +150,10 @@ const SpaghettiSelectionState = {
                 updateAllSpaghettiColors();
             }
             
-            // Cannot set animation mode here, other spaghetti may be selected, HPA update function resolves this
+            if (spaghetti.analytics) {
+                spaghetti.analytics.setHighlightRegion(null, true);
+                spaghetti.analytics.setCursorTime(-1, true);
+            }
         }
     },
     SINGLE: {
@@ -515,6 +518,10 @@ export class Spaghetti extends THREE.Group {
      * @param {{startTime: number, endTime: number}} highlightRegion
      */
     setHighlightRegion(highlightRegion) {
+        if (!highlightRegion) {
+            SpaghettiSelectionState.NONE.transition(this);
+            return;
+        }
         const firstTimestamp = highlightRegion.startTime;
         const secondTimestamp = highlightRegion.endTime;
 

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -86,6 +86,12 @@ const SpaghettiSelectionState = {
             const intersects = realityEditor.gui.threejsScene.getRaycastIntersects(e.pageX, e.pageY, spaghetti.meshPaths);
             const index = spaghetti.getPointFromIntersects(intersects);
             if (index === -1) {
+                spaghetti.highlightRegion = {
+                    startIndex: -1,
+                    endIndex: -1,
+                    regionExists: false
+                }
+                spaghetti.updateColors();
                 return;
             }
             SpaghettiSelectionState.SINGLE.transition(spaghetti, index);
@@ -147,7 +153,6 @@ const SpaghettiSelectionState = {
             const index = spaghetti.getPointFromIntersects(intersects);
             if (index === -1) {
                 SpaghettiSelectionState.NONE.transition(spaghetti);
-                e.stopImmediatePropagation();
                 return;
             }
             const initialSelectionIndex = spaghetti.highlightRegion.startIndex;
@@ -234,7 +239,6 @@ const SpaghettiSelectionState = {
             const index = spaghetti.getPointFromIntersects(intersects);
             if (index === -1) {
                 SpaghettiSelectionState.NONE.transition(spaghetti);
-                e.stopImmediatePropagation();
                 return;
             }
 

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -435,6 +435,28 @@ export class Spaghetti extends THREE.Group {
         this.reset();
         this.addPoints(points);
     }
+    
+    transferStateTo(otherSpaghetti) {
+        if (activeSpaghetti === this) {
+            activeSpaghetti = otherSpaghetti;
+        }
+        otherSpaghetti.selectionState = this.selectionState;
+        otherSpaghetti.highlightRegion = {
+            startIndex: this.highlightRegion.startIndex,
+            endIndex: this.highlightRegion.endIndex,
+            regionExists: this.highlightRegion.regionExists
+        }
+        otherSpaghetti.cursorIndex = this.cursorIndex;
+        otherSpaghetti.updateColors();
+        this.selectionState = SpaghettiSelectionState.NONE;
+        this.highlightRegion = {
+            startIndex: -1,
+            endIndex: -1,
+            regionExists: false
+        }
+        this.cursorIndex = -1;
+        this.updateColors();
+    }
 
     /**
      * Deallocates all mesh paths and points, and removes them from the scene

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -498,6 +498,9 @@ export class Spaghetti extends THREE.Group {
 
     setupPointerEvents() {
         document.addEventListener('pointerdown', (e) => {
+            if (!e.target.classList.contains('mainProgram')) {
+                return;
+            }
             if (realityEditor.device.isMouseEventCameraControl(e)) {
                 this.getMeasurementLabel().requestVisible(false, this.pathId);
                 return;
@@ -508,6 +511,9 @@ export class Spaghetti extends THREE.Group {
             this.onPointerDown(e);
         });
         document.addEventListener('pointermove', (e) => {
+            if (!e.target.classList.contains('mainProgram')) {
+                return;
+            }
             if (realityEditor.device.isMouseEventCameraControl(e)) return;
             if (!this.isVisible()) {
                 return;


### PR DESCRIPTION
…with

This change makes it so that in cases where multiple people were tracked (ex: the Mercedes demo), clicking on one person's spaghetti hides the other people's spaghettis, making it clearer what can be interacted with (It doesn't make sense to select points across spaghettis and is currently not supported, but leads to confusing behavior if attempted). Unselecting the spaghetti makes all other spaghettis visible again.