### PR TITLE
Miscellaneous Analytics Fixes

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -229,6 +229,8 @@ export class Analytics {
         }
         this.livePlayback = livePlayback;
         this.loadingHistory = true;
+        this.humanPoseAnalyzer.resetLiveHistoryClones();
+        this.humanPoseAnalyzer.resetLiveHistoryLines();
         await realityEditor.humanPose.loadHistory(region);
         this.loadingHistory = false;
         if (region && !fromSpaghetti) {

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -103,6 +103,9 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetDisplayRegion', (msgData) => {
+            if (activeFrame === 'none') {
+                return;
+            }
             getActiveAnalytics().setDisplayRegion(msgData.displayRegion);
         });
 

--- a/src/analytics/timeline.js
+++ b/src/analytics/timeline.js
@@ -659,7 +659,6 @@ export class Timeline {
      */
     setDisplayRegion(displayRegion) {
         this.displayRegion = displayRegion;
-        this.poses = [];
         if (!this.displayRegion) {
             this.resetBounds();
             return;
@@ -685,7 +684,7 @@ export class Timeline {
         // Snap zoom to equal entire displayRegion
         let newWidthMs = endTime - startTime;
         this.timeMin = startTime;
-        this.widthMs = newWidthMs;
+        this.widthMs = Math.max(newWidthMs, MIN_WIDTH_MS);
         this.minTimeMin = this.timeMin;
         if (this.width > 0) {
             this.pixelsPerMs = this.width / this.widthMs;

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -1076,7 +1076,7 @@ export class HumanPoseAnalyzer {
             return [];
         }
 
-        const maxDeltaT = 100; // ms, don't show clones that are more than some time interval away from the current time
+        const maxDeltaT = 200; // ms, don't show clones that are more than some time interval away from the current time
         let bestData = [];
 
         // Dan: This used to be more optimized, but required a sorted array of clones, which we don't have when mixing historical and live data (could be added though)

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -1082,22 +1082,19 @@ export class HumanPoseAnalyzer {
         // Dan: This used to be more optimized, but required a sorted array of clones, which we don't have when mixing historical and live data (could be added though)
         for (let i = 0; i < this.clones.all.length; i++) {
             const clone = this.clones.all[i];
+            const distance = Math.abs(clone.pose.timestamp - timestamp);
+            if (distance > maxDeltaT) {
+                continue;
+            }
             const objectId = clone.pose.metadata.poseObjectId;
             const bestDatum = bestData.find(data => data.objectId === objectId);
             if (!bestDatum) {
-                if (Math.abs(clone.pose.timestamp - timestamp) > maxDeltaT) {
-                    continue;
-                }
                 bestData.push({
                     clone,
-                    distance: Math.abs(clone.pose.timestamp - timestamp),
+                    distance,
                     objectId
                 });
             } else {
-                if (Math.abs(clone.pose.timestamp - timestamp) > maxDeltaT) {
-                    continue;
-                }
-                const distance = Math.abs(clone.pose.timestamp - timestamp);
                 if (distance < bestDatum.distance) {
                     bestDatum.clone = clone;
                     bestDatum.distance = distance;


### PR DESCRIPTION
Most notably prevents race condition where a frame opening automatically while minimized would send a setDisplayRegion to the fallback 'none' analytics, causing the loading of history to happen two times in parallel. Additionally fixes the initial display of data after a recording finishes and cleans up conditions where the timeline would be too narrow due to very short recordings.