### PR TITLE
Adds -webkit-user-drag:none to all elements; disables hover on mobile ru-icons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -61,6 +61,7 @@
     -webkit-transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
    -webkit-user-select: none;
     -webkit-touch-callout:none;
+    -webkit-user-drag: none;
 }
 
 #GUI {

--- a/src/gui/recentlyUsedBar.js
+++ b/src/gui/recentlyUsedBar.js
@@ -17,7 +17,7 @@ class RecentlyUsedBar {
         this.capacity = 3;
         this.hoveredFrameId = null;
         this.hoverAnimationPercent = 0;
-        this.hoverAnimationDurationMs = 60; // speed of the slowest part of the line
+        this.hoverAnimationDurationMs = 100; // speed of the slowest part of the line
         this.lastAnimationPositions = null;
         this.lastDraw = Date.now();
         this.canvasHasContent = false;

--- a/src/gui/recentlyUsedBar.js
+++ b/src/gui/recentlyUsedBar.js
@@ -169,8 +169,12 @@ class RecentlyUsedBar {
             icon.src = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/frames/' + name + '/icon.gif');
 
             icon.addEventListener('pointerdown', this.onIconPointerDown);
-            icon.addEventListener('pointerover', this.onIconPointerOver);
-            icon.addEventListener('pointerout', this.onIconPointerOut);
+            // hovering over the button only makes sense on a desktop environment – touchscreens don't have hover
+            if (realityEditor.device.environment.requiresMouseEvents()) {
+                icon.addEventListener('pointerover', this.onIconPointerOver);
+                icon.addEventListener('pointerout', this.onIconPointerOut);
+                icon.addEventListener('pointercancel', this.onIconPointerOut);
+            }
 
             this.iconElts.push(icon);
 


### PR DESCRIPTION
It seems that setting user-select:none affects selecting the text on elements, touch-action:none affects scrolling and zooming, and pointer-events:none makes the elements completely ignore touches. None of these is what I need to disable long-pressing on certain images triggering iOS's built-in drag-and-drop feature.

Adding `-webkit-user-drag:none` does the trick, though! Originally I was just going to apply it on the minimized tool icons, but instead I'm applying it everywhere, as I saw that there are all sorts of buttons that have a weird "drag" behavior if it isn't added more globally.

I also disabled the lines that appear when you hover over a recently used tool icon, on mobile, since "hover" only makes sense if you have a mouse, not a touchscreen.

Lastly, I slightly increased the animation time of the lines that go from the recently used tool icons, because before it was essentially imperceptible. It's still very subtle but Valentin wants it to stay subtle.