### PR TITLE
Multi analytics spaghetti fix

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -63,7 +63,6 @@ export class Analytics {
         }
         if (this.humanPoseAnalyzer.settingsUi) {
             this.humanPoseAnalyzer.settingsUi.show();
-            this.humanPoseAnalyzer.setLiveHumanPosesVisible(true);
         }
     }
 
@@ -76,7 +75,6 @@ export class Analytics {
         }
         if (this.humanPoseAnalyzer.settingsUi) {
             this.humanPoseAnalyzer.settingsUi.hide();
-            this.humanPoseAnalyzer.setLiveHumanPosesVisible(false);
         }
     }
 

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -79,7 +79,7 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
 
         realityEditor.network.addPostMessageHandler('analyticsFocus', (msgData) => {
             if (!analyticsByFrame[msgData.frame]) {
-                return;
+                analyticsByFrame[msgData.frame] = makeAnalytics(msgData.frame);
             }
             if (activeFrame !== msgData.frame) {
                 getActiveAnalytics().blur();
@@ -92,7 +92,7 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
             if (!analyticsByFrame[msgData.frame]) {
                 return;
             }
-            analyticsByFrame[msgData.frame].blur(msgData.frame);
+            analyticsByFrame[msgData.frame].blur();
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetCursorTime', (msgData) => {
@@ -104,14 +104,17 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetDisplayRegion', (msgData) => {
-            if (!analyticsByFrame[msgData.frame] || activeFrame !== msgData.frame) {
+            if (!analyticsByFrame[msgData.frame]) {
                 return;
             }
-            getActiveAnalytics().setDisplayRegion(msgData.displayRegion);
+            analyticsByFrame[msgData.frame].setDisplayRegion(msgData.displayRegion);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsHydrateRegionCards', (msgData) => {
-            getActiveAnalytics().hydrateRegionCards(msgData.regionCards);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].hydrateRegionCards(msgData.regionCards);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetLens', (msgData) => {

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -146,7 +146,7 @@ const SpaghettiSelectionState = {
             spaghetti.getMeasurementLabel().requestVisible(false, spaghetti.pathId);
             
             if (activeSpaghettiByAnalyticsFrame[spaghetti.analytics.frame] === spaghetti) {
-                activeSpaghettiByAnalyticsFrame[spaghetti.analytics.frame] = spaghetti;
+                activeSpaghettiByAnalyticsFrame[spaghetti.analytics.frame] = null;
                 updateAllSpaghettiColorsByAnalytics(spaghetti.analytics);
             }
             
@@ -340,6 +340,9 @@ export class Spaghetti extends THREE.Group {
         this.setupPointerEvents();
         this.addPoints(points);
         
+        if (!spaghettiListsByAnalyticsFrame[this.analytics.frame]) {
+            spaghettiListsByAnalyticsFrame[this.analytics.frame] = [];
+        }
         spaghettiListsByAnalyticsFrame[this.analytics.frame].push(this);
     }
     
@@ -480,7 +483,8 @@ export class Spaghetti extends THREE.Group {
      * Returns false otherwise.
      */
     isActive() {
-        return activeSpaghettiByAnalyticsFrame[this.analytics.frame] === this || activeSpaghettiByAnalyticsFrame[this.analytics.frame] === null;
+        const activeSpaghetti = activeSpaghettiByAnalyticsFrame[this.analytics.frame];
+        return activeSpaghetti === this || activeSpaghetti === null || activeSpaghetti === undefined;
     }
 
     isVisible() {

--- a/src/humanPose/spaghetti.js
+++ b/src/humanPose/spaghetti.js
@@ -509,6 +509,9 @@ export class Spaghetti extends THREE.Group {
                 this.getMeasurementLabel().requestVisible(false, this.pathId);
                 return;
             }
+            if (this.analytics && realityEditor.analytics.getActiveAnalytics() !== this.analytics) {
+                return;
+            }
             if (!this.isVisible()) {
                 return;
             }
@@ -519,6 +522,9 @@ export class Spaghetti extends THREE.Group {
                 return;
             }
             if (realityEditor.device.isMouseEventCameraControl(e)) return;
+            if (this.analytics && realityEditor.analytics.getActiveAnalytics() !== this.analytics) {
+                return;
+            }
             if (!this.isVisible()) {
                 return;
             }


### PR DESCRIPTION
Spaghettis were previously having their active state modified by spaghettis in other analytics sessions. They were also messing with the timeline and receiving pointer events in those cases. This fixes those issues.