### PR TITLE
Added mitigation measure for occasional miss of delete on server

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -396,6 +396,7 @@ realityEditor.app.enableHumanTracking = function () {
  */
 realityEditor.app.disableHumanTracking = function () {
     this.appFunctionCall('disableHumanTracking', null, null);
+    realityEditor.humanPose.deleteLocalHumanObjects();
 };
 
 /**

--- a/src/humanPose/index.js
+++ b/src/humanPose/index.js
@@ -483,8 +483,20 @@ import {JOINT_TO_INDEX} from './constants.js';
         }
     }
 
+    function deleteLocalHumanObjects() {
+        myHumanPoseId = null;
+    
+        for (let objectId of Object.values(nameIdMap)) {
+            delete humanPoseObjects[objectId];
+            delete realityEditor.objects[objectId];
+        }
+        nameIdMap = {}
+    }
+
     exports.initService = initService;
     exports.loadHistory = loadHistory;
+    exports.deleteLocalHumanObjects = deleteLocalHumanObjects;
+
 }(realityEditor.humanPose));
 
 export const initService = realityEditor.humanPose.initService;


### PR DESCRIPTION
Added mitigation measure for occasional miss of UDP action message about deletion of human object on server. One can use a toggle to switch off human tracking and now also wipe out local human object hanging on device.

It has one minor issue in the case when human tracking is quickly disabled and enabled. In that case, there are two human objects from the same device on server (eg. _HUMAN_deviceGA42d823_pose1__G4ckapkg4ly, _HUMAN_deviceGA42d823_pose1__pg9h11b77sw). However, once the stale object cleaner removes the older one which is already wiped out on the device, this causes deletion of both and new human object is created quickly. This is due to the behaviour of deleteObject(objectKey) on server which deletes the desired object but also calls utilities.deleteObject(). This uses a name  '_HUMAN_deviceGA42d823_pose1' to find the objectId and it resolves to the other object. 