### PR TITLE
implements the getUserDetails tool API by setting avatar user name

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -200,11 +200,20 @@ createNameSpace("realityEditor.avatar");
             }
         }, KEEP_ALIVE_HEARTBEAT_INTERVAL);
 
-
         realityEditor.app.promises.getProviderId().then(providerId => {
             myProviderId = providerId;
             // write user name will also persist providerId
             writeUsername(myUsername);
+        });
+
+        realityEditor.network.addPostMessageHandler('getUserDetails', (_, fullMessageData) => {
+            realityEditor.network.postMessageIntoFrame(fullMessageData.frame, {
+                userDetails: {
+                    name: myUsername,
+                    providerId: myProviderId,
+                    sessionId: globalStates.tempUuid
+                }
+            });
         });
     }
     
@@ -504,7 +513,13 @@ createNameSpace("realityEditor.avatar");
         });
     }
 
-    // name is one property within the avatar node's userProfile public data 
+    // you can set this even before the avatar has been created
+    function setMyUsername(name) {
+        myUsername = name;
+    }
+
+    // name is one property within the avatar node's userProfile public data
+    // avatar has to exist before calling this
     function writeUsername(name) {
         if (!myAvatarObject) { return; }
         connectedAvatarUserProfiles[myAvatarId].name = name;
@@ -672,6 +687,7 @@ createNameSpace("realityEditor.avatar");
     exports.toggleDebugMode = toggleDebugMode;
     exports.getMyAvatarColor = getMyAvatarColor;
     exports.getAvatarColorFromProviderId = getAvatarColorFromProviderId;
+    exports.setMyUsername = setMyUsername;
     exports.clearLinkCanvas = clearLinkCanvas;
     exports.getLinkCanvasInfo = getLinkCanvasInfo;
     exports.isDesktop = function() {return isDesktop};


### PR DESCRIPTION
Goes with https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/805

Includes name, sessionId, and providerId, in case any of these are useful for the tool.

Requires an update to the pop-up-onboarding-addon to fetch the user name from the metaverse manager...
