### PR TITLE
Fixes issues with tool opening focusing and blurring on reload, fixes…

### DIFF
--- a/src/analytics/analytics.js
+++ b/src/analytics/analytics.js
@@ -233,7 +233,7 @@ export class Analytics {
         this.humanPoseAnalyzer.resetLiveHistoryLines();
         if (region.startTime >= 0 && region.endTime >= 0) {
             // Only load history if display region is unbounded, new tools set displayRegion to (Date.now(), -1)
-            await realityEditor.humanPose.loadHistory(region);
+            await realityEditor.humanPose.loadHistory(region, this);
         }
         this.loadingHistory = false;
         if (region && !fromSpaghetti) {

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -27,6 +27,11 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
         return analyticsByFrame[activeFrame];
     }
     exports.getActiveAnalytics = getActiveAnalytics;
+    
+    function getAnalyticsByFrame(frame) {
+        return analyticsByFrame[frame];
+    }
+    exports.getAnalyticsByFrame = getAnalyticsByFrame;
 
     /**
      * @return {HumanPoseAnalyzer}
@@ -89,18 +94,24 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
             if (!analyticsByFrame[msgData.frame]) {
                 return;
             }
-            // if (activeFrame === msgData.frame) {
-            //     activeFrame = noneFrame;
-            // }
+            if (activeFrame === msgData.frame) {
+                activeFrame = noneFrame;
+            }
             analyticsByFrame[msgData.frame].blur();
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetCursorTime', (msgData) => {
-            getActiveAnalytics().setCursorTime(msgData.time);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setCursorTime(msgData.time);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetHighlightRegion', (msgData) => {
-            getActiveAnalytics().setHighlightRegion(msgData.highlightRegion);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setHighlightRegion(msgData.highlightRegion);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetDisplayRegion', (msgData) => {
@@ -118,23 +129,38 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetLens', (msgData) => {
-            getActiveAnalytics().setLens(msgData.lens);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setLens(msgData.lens);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetLensDetail', (msgData) => {
-            getActiveAnalytics().setLensDetail(msgData.lensDetail);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setLensDetail(msgData.lensDetail);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetSpaghettiAttachPoint', (msgData) => {
-            getActiveAnalytics().setSpaghettiAttachPoint(msgData.spaghettiAttachPoint);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setSpaghettiAttachPoint(msgData.spaghettiAttachPoint);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetSpaghettiVisible', (msgData) => {
-            getActiveAnalytics().setSpaghettiVisible(msgData.spaghettiVisible);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setSpaghettiVisible(msgData.spaghettiVisible);
         });
 
         realityEditor.network.addPostMessageHandler('analyticsSetAllClonesVisible', (msgData) => {
-            getActiveAnalytics().setSpaghettiVisible(msgData.allClonesVisible);
+            if (!analyticsByFrame[msgData.frame]) {
+                return;
+            }
+            analyticsByFrame[msgData.frame].setSpaghettiVisible(msgData.allClonesVisible);
         });
     }
     exports.initService = initService;

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -31,15 +31,6 @@ export const AnimationMode = {
 };
 
 /**
- * Processes the given historical poses and renders them efficiently
- * @param {Pose[]}  poses - the poses to render
- */
-function bulkRenderHistoricalPoses(poses) {
-    let analytics = realityEditor.analytics.getActiveAnalytics();
-    analytics.bulkRenderHistoricalPoses(poses);
-}
-
-/**
  * Processes the poseObject given and renders them into the corresponding poseRenderInstances
  * @param {HumanPoseObject[]} poseObjects - the poseObjects to render
  * @param {number} timestamp - the timestamp of the poseObjects
@@ -320,19 +311,6 @@ function setCursorTime(time, fromSpaghetti) {
 }
 
 /**
- * Finalize historical renderer matrices after loading them from
- * history logs
- */
-function finishHistoryPlayback() {
-    let activeHumanPoseAnalyzer = realityEditor.analytics.getActiveHumanPoseAnalyzer();
-    if (!activeHumanPoseAnalyzer) {
-        console.warn('No active HPA');
-        return;
-    }
-    activeHumanPoseAnalyzer.markHistoricalColorNeedsUpdate();
-}
-
-/**
  * Shows the HumanPoseAnalyzer's settings UI
  */
 function showAnalyzerSettingsUI() {
@@ -404,7 +382,6 @@ function setChildHumanPosesVisible(visible) {
 
 // TODO: Remove deprecated API use
 export {
-    bulkRenderHistoricalPoses,
     renderLiveHumanPoseObjects,
     resetLiveHistoryLines,
     resetHistoryLines,
@@ -418,7 +395,6 @@ export {
     advanceLens,
     advanceCloneMaterial,
     getPosesInTimeInterval,
-    finishHistoryPlayback,
     showAnalyzerSettingsUI,
     hideAnalyzerSettingsUI,
     toggleAnalyzerSettingsUI,

--- a/src/humanPose/index.js
+++ b/src/humanPose/index.js
@@ -125,11 +125,12 @@ import {JOINT_TO_INDEX} from './constants.js';
 
     /**
      * @param {TimeRegion} historyRegion
+     * @param {Analytics} analytics
      */
-    async function loadHistory(historyRegion) {
+    async function loadHistory(historyRegion, analytics) {
         if (!realityEditor.sceneGraph || !realityEditor.sceneGraph.getWorldId() || !realityEditor.device || !realityEditor.device.environment) {
             setTimeout(() => {
-                loadHistory(historyRegion);
+                loadHistory(historyRegion, analytics);
             }, 500);
             return;
         }
@@ -179,16 +180,16 @@ import {JOINT_TO_INDEX} from './constants.js';
                 }
             }
             if (log) {
-                await replayHistory(log);
+                await replayHistory(log, analytics);
             } else {
                 console.error('Unable to load history log after retries', `${historyLogsUrl}/${logName}`);
             }
         }
 
-        draw.finishHistoryPlayback();
+        analytics.humanPoseAnalyzer.markHistoricalColorNeedsUpdate();
     }
 
-    async function replayHistory(history) {
+    async function replayHistory(history, analytics) {
         inHistoryPlayback = true;
         const timeObjects = {};
         const timestampStrings = Object.keys(history);
@@ -249,7 +250,7 @@ import {JOINT_TO_INDEX} from './constants.js';
                 poses.push(pose);
             }
         });
-        draw.bulkRenderHistoricalPoses(poses);
+        analytics.bulkRenderHistoricalPoses(poses);
         inHistoryPlayback = false;
     }
 


### PR DESCRIPTION
… history loading into none Analytics session

This was specifically an issue caused by my last pull request setting the activeFrame to 'none' on blur. In this case, refreshing the page would launch an Analytics session and immediately make it inactive (as intended), but `loadHistory` would always use the active analytics, causing the history to load into the 'none' analytics session and not be closeable/on the timeline.