### PR TITLE
Mobile remote operator

### DIFF
--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -22,6 +22,20 @@ createNameSpace("realityEditor.device.environment");
         });
     };
 
+    // use this to distinguish between opening the remote operator in a mobile
+    // safari vs opening the userinterface in AR mode in the app
+    function isWithinToolboxApp() {
+        return typeof window.webkit !== 'undefined' &&
+            typeof window.webkit.messageHandlers !== 'undefined' &&
+            typeof window.webkitProxy === 'undefined';
+    }
+
+    // rather than checking for "isDesktop", this gives a more reliable way to
+    // determine whether to run the AR interface or the remote operator interface
+    function isARMode() {
+        return isWithinToolboxApp() && !isDesktop();
+    }
+
     function isDesktop() {
         const userAgent = window.navigator.userAgent;
         const isWebView = userAgent.includes('Mobile') && !userAgent.includes('Safari');
@@ -47,7 +61,7 @@ createNameSpace("realityEditor.device.environment");
         shouldDisplayLogicMenuModally: false,
         isSourceOfObjectPositions: true,
         isCameraOrientationFlipped: false,
-        waitForARTracking: !isDesktop(), // set to false on remote operator
+        waitForARTracking: !isDesktop() && isWithinToolboxApp(), // set to false on remote operator
         overrideMenusAndButtons: false,
         listenForDeviceOrientationChanges: true,
         enableViewFrustumCulling: true,
@@ -235,7 +249,9 @@ createNameSpace("realityEditor.device.environment");
     exports.getInitialPocketToolRotation = function() {
         return variables.initialPocketToolRotation;
     };
-    
+
     exports.isDesktop = isDesktop;
+    exports.isWithinToolboxApp = isWithinToolboxApp;
+    exports.isARMode = isARMode;
 
 }(realityEditor.device.environment));

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -27,7 +27,7 @@ createNameSpace("realityEditor.device.environment");
     function isWithinToolboxApp() {
         return typeof window.webkit !== 'undefined' &&
             typeof window.webkit.messageHandlers !== 'undefined' &&
-            typeof window.webkitProxy === 'undefined';
+            typeof window.webkitWasTamperedWith === 'undefined';
     }
 
     // rather than checking for "isDesktop", this gives a more reliable way to

--- a/src/device/environment.js
+++ b/src/device/environment.js
@@ -42,8 +42,11 @@ createNameSpace("realityEditor.device.environment");
         const isIpad = /Macintosh/i.test(navigator.userAgent) &&
             navigator.maxTouchPoints &&
             navigator.maxTouchPoints > 1;
+        const isIphone = /iPhone/i.test(navigator.userAgent) &&
+            navigator.maxTouchPoints &&
+            navigator.maxTouchPoints > 1;
 
-        return !isWebView && !isIpad;
+        return !isWebView && !isIpad && !isIphone;
     }
 
     // initialized with default variables for iPhone environment. add-ons can modify

--- a/src/gui/ar/areaCreator.js
+++ b/src/gui/ar/areaCreator.js
@@ -318,7 +318,13 @@ realityEditor.gui.ar.areaCreator.calculateGroundPlaneIntersection = function(eve
     }
 }
 
+realityEditor.gui.ar.areaCreator.cachedFloorOffset = null;
+
 realityEditor.gui.ar.areaCreator.calculateFloorOffset = function() {
+    if (realityEditor.gui.ar.areaCreator.cachedFloorOffset) {
+        return realityEditor.gui.ar.areaCreator.cachedFloorOffset;
+    }
+
     const worldObjectToolboxMatrix = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId()).worldMatrix;
     const worldObjectThreeMatrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
     realityEditor.gui.threejsScene.setMatrixFromArray(worldObjectThreeMatrix, worldObjectToolboxMatrix);

--- a/src/gui/ar/areaCreator.js
+++ b/src/gui/ar/areaCreator.js
@@ -321,8 +321,8 @@ realityEditor.gui.ar.areaCreator.calculateGroundPlaneIntersection = function(eve
 realityEditor.gui.ar.areaCreator.cachedFloorOffset = null;
 
 realityEditor.gui.ar.areaCreator.calculateFloorOffset = function() {
-    if (realityEditor.gui.ar.areaCreator.cachedFloorOffset) {
-        return realityEditor.gui.ar.areaCreator.cachedFloorOffset;
+    if (this.cachedFloorOffset) {
+        return this.cachedFloorOffset;
     }
 
     const worldObjectToolboxMatrix = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId()).worldMatrix;
@@ -334,6 +334,7 @@ realityEditor.gui.ar.areaCreator.calculateFloorOffset = function() {
     const groundToWorldMatrix = groundPlaneThreeMatrix.clone().invert().multiply(worldObjectThreeMatrix);
     const position = new realityEditor.gui.threejsScene.THREE.Vector3();
     position.setFromMatrixPosition(groundToWorldMatrix);
+    this.cachedFloorOffset = -position.y;
     return -position.y;
 }
 

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -667,6 +667,9 @@ realityEditor.gui.ar.positioning.moveFrameToCamera = function(objectKey, frameKe
  * @return {boolean}
  */
 realityEditor.gui.ar.positioning.canUnload = function(activeKey, finalMatrix, vehicleHalfWidth, vehicleHalfHeight, maxDistance) {
+    // don't bother unloading/reloading on desktop environments, as the camera moves around so quickly that this can cause more overhead than it saves
+    if (!realityEditor.device.environment.isARMode()) return false;
+
     // // if it's fully behind the viewport, it can be unloaded
     if (!realityEditor.sceneGraph.isInFrontOfCamera(activeKey)) {
         return true;

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -414,6 +414,10 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
                     if (!gltf.scene.material) {
                         console.warn('no material', gltf.scene);
                     } else {
+                        // cache the original gltf material on mobile browsers, to improve performance
+                        if (!realityEditor.device.environment.isDesktop() && !realityEditor.device.environment.isWithinToolboxApp()) {
+                            gltf.scene.originalMaterial = gltf.scene.material.clone();
+                        }
                         gltf.scene.material = customMaterials.areaTargetMaterialWithTextureAndHeight(gltf.scene.material, {
                             maxHeight: maxHeight,
                             center: center,
@@ -449,6 +453,10 @@ import { ViewFrustum, frustumVertexShader, frustumFragmentShader, MAX_VIEW_FRUST
 
                 allMeshes.forEach(child => {
                     if (typeof maxHeight !== 'undefined') {
+                        // cache the original gltf material on mobile browsers, to improve performance
+                        if (!realityEditor.device.environment.isDesktop() && !realityEditor.device.environment.isWithinToolboxApp()) {
+                            child.originalMaterial = child.material.clone();
+                        }
                         child.material = customMaterials.areaTargetMaterialWithTextureAndHeight(child.material, {
                             maxHeight: maxHeight,
                             center: center,


### PR DESCRIPTION
It seems about time to allow the remote operator to work on a phone or tablet web browser. Adds initial support to load the remote operator in an iPhone/iPad safari browser.
- uses `isARMode()` instead of `isDesktop()` to allow the remote-operator-addon to better determine whether to load remote operator features or AR features
- adds some performance improvements, mainly allowing the mobile browsers to use the default gltf material instead of the advanced material, because this improves the FPS from ~15 to 60 on my device and we aren't really using the frustum culling right now.

See also https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/pull/119 (adds multitouch controls for the camera) and https://github.com/ptcrealitylab/pop-up-onboarding-addon/pull/69