### PR TITLE
Somewhat hacky fix for live poses not keeping last active analytics' …

### DIFF
--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -19,6 +19,11 @@ import {AnalyticsMobile} from './AnalyticsMobile.js'
     const noneFrame = 'none';
     let activeFrame = '';
     let analyticsByFrame = {};
+    
+    function getDefaultAnalytics() {
+        return analyticsByFrame[noneFrame];
+    }
+    exports.getDefaultAnalytics = getDefaultAnalytics;
 
     /**
      * @return {Analytics}

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -516,6 +516,11 @@ export class HumanPoseAnalyzer {
 
         this.activeLensIndex = this.lenses.indexOf(lens);
         this.applyCurrentLensToHistory();
+        
+        const defaultHpa = realityEditor.analytics.getDefaultAnalytics().humanPoseAnalyzer
+        if (defaultHpa !== this) {
+            defaultHpa.setActiveLensByName(lens.name);
+        }
 
         // Swap hpri colors
         this.clones.all.forEach(clone => {


### PR DESCRIPTION
…lens mode when minimizing

This feels more intuitive for the user, who otherwise is wondering why live poses keep switching back to REBA mode as the analytics system starts sending live data to the `none` analytics session.