### PR TITLE
normalize matrix3d transforms to fix chrome bug with dragover events on localhost

### DIFF
--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -762,8 +762,6 @@ createNameSpace("realityEditor.envelopeManager");
 
         if (globalDOMCache[focusedFrameId]) {
             globalDOMCache[focusedFrameId].classList.add('deactivatedIframeOverlay');
-            globalDOMCache['iframe' + focusedFrameId].classList.add('usePointerEvents');
-            globalDOMCache['iframe' + focusedFrameId].classList.remove('ignorePointerEvents');
         }
 
         if (knownEnvelopes[focusedFrameId]) {
@@ -786,8 +784,6 @@ createNameSpace("realityEditor.envelopeManager");
 
         if (globalDOMCache[focusedFrameId]) {
             globalDOMCache[focusedFrameId].classList.remove('deactivatedIframeOverlay');
-            globalDOMCache['iframe' + focusedFrameId].classList.remove('usePointerEvents');
-            globalDOMCache['iframe' + focusedFrameId].classList.add('ignorePointerEvents');
         }
 
         if (knownEnvelopes[focusedFrameId]) {

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -762,6 +762,8 @@ createNameSpace("realityEditor.envelopeManager");
 
         if (globalDOMCache[focusedFrameId]) {
             globalDOMCache[focusedFrameId].classList.add('deactivatedIframeOverlay');
+            globalDOMCache['iframe' + focusedFrameId].classList.add('usePointerEvents');
+            globalDOMCache['iframe' + focusedFrameId].classList.remove('ignorePointerEvents');
         }
 
         if (knownEnvelopes[focusedFrameId]) {
@@ -784,6 +786,8 @@ createNameSpace("realityEditor.envelopeManager");
 
         if (globalDOMCache[focusedFrameId]) {
             globalDOMCache[focusedFrameId].classList.remove('deactivatedIframeOverlay');
+            globalDOMCache['iframe' + focusedFrameId].classList.remove('usePointerEvents');
+            globalDOMCache['iframe' + focusedFrameId].classList.add('ignorePointerEvents');
         }
 
         if (knownEnvelopes[focusedFrameId]) {

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1208,7 +1208,12 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
 
                 let activeElt = globalDOMCache["object" + activeKey];
                 if (!activeVehicle.isOutsideViewport) {
-                    activeElt.style.transform = 'matrix3d(' + finalMatrix.toString() + ')';
+                    // normalize the matrix and clear the last column, to avoid some browser-specific bugs
+                    let normalizedMatrix = realityEditor.gui.ar.utilities.normalizeMatrix(finalMatrix);
+                    normalizedMatrix[3] = 0;
+                    normalizedMatrix[7] = 0;
+                    normalizedMatrix[11] = 0;
+                    activeElt.style.transform = 'matrix3d(' + normalizedMatrix.toString() + ')';
                 } else if (!activeElt.classList.contains('outsideOfViewport')) {
                     activeElt.classList.add('outsideOfViewport');
                 }
@@ -2007,8 +2012,7 @@ realityEditor.gui.ar.draw.createSubElements = function(iframeSrc, objectKey, fra
     // TODO: remove this 'sandbox' attribute if you try to embed iframes within the tool's iframe and you run into browser restrictions
     let allowPopups = realityEditor.device.environment.isWithinToolboxApp() ? '' : 'allow-popups';
     addIframe.setAttribute("sandbox", `allow-forms allow-pointer-lock allow-same-origin allow-scripts ${allowPopups}`);
-    // some file dragover events get blocked on localhost on Chrome unless child iframes have pointerevents-none
-    addIframe.classList.add('ignorePointerEvents');
+    addIframe.classList.add('usePointerEvents'); // override parent (addContainer) pointerEvents value
 
     // TODO: try to load elements with an XHR request so they don't block the rendering loop
 

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -2007,7 +2007,8 @@ realityEditor.gui.ar.draw.createSubElements = function(iframeSrc, objectKey, fra
     // TODO: remove this 'sandbox' attribute if you try to embed iframes within the tool's iframe and you run into browser restrictions
     let allowPopups = realityEditor.device.environment.isWithinToolboxApp() ? '' : 'allow-popups';
     addIframe.setAttribute("sandbox", `allow-forms allow-pointer-lock allow-same-origin allow-scripts ${allowPopups}`);
-    addIframe.classList.add('usePointerEvents'); // override parent (addContainer) pointerEvents value
+    // some file dragover events get blocked on localhost on Chrome unless child iframes have pointerevents-none
+    addIframe.classList.add('ignorePointerEvents');
 
     // TODO: try to load elements with an XHR request so they don't block the rendering loop
 
@@ -2377,7 +2378,7 @@ realityEditor.gui.ar.draw.deleteNode = function (objectId, frameId, nodeId) {
  */
 realityEditor.gui.ar.draw.deleteFrame = function (objectId, frameId) {
     
-    realityEditor.forEachNodeInFrame(objectId, frameId, realityEditor.gui.ar.draw.deleteNode);
+    realityEditor.forEachNodeInFrame(objectId, frameId, realityEditor.gui.ar.draw.deleteNode.bind(realityEditor.gui.ar.draw));
 
     delete objects[objectId].frames[frameId];
     if (this.globalDOMCache["object" + frameId]) {


### PR DESCRIPTION
Not worth merging ahead of the demo but this fixes my drag-and-drop errors.

Pointer events get re-enabled if the tool opens in fullscreenFull2D, as in that case the overlay div is removed and the iframe itself needs to receive pointer-events again.

(necessary on localhost. not necessary if you load remote operator by IP, for some unknown reason)

(the deleteNode.bind() is a separate error I noticed, unrelated to drag-and-drop)
