### PR TITLE
dont download all icon.gif files if UI is overridden (e.g. with pop-up-addon)

### DIFF
--- a/src/network/availableFrames.js
+++ b/src/network/availableFrames.js
@@ -48,10 +48,14 @@ createNameSpace("realityEditor.network.availableFrames");
         var urlEndpoint = realityEditor.network.getURL(serverIP, realityEditor.network.getPortByIp(serverIP), '/availableFrames/');
         realityEditor.network.getData(null, null, null, urlEndpoint, function (_nullObj, _nullFrame, _nullNode, response) {
             framesPerServer[serverIP] = response;
-            setTimeout(() => {
-              downloadFramePocketAssets(serverIP); // preload the icons
-            }, 5000);
-            triggerServerFramesInfoUpdatedCallbacks(); // this can be detected to update the pocket if it is already open
+            if (!realityEditor.device.environment.variables.overrideMenusAndButtons) {
+                setTimeout(() => {
+                    downloadFramePocketAssets(serverIP); // preload the icons
+                }, 5000);
+                triggerServerFramesInfoUpdatedCallbacks(); // this can be detected to update the pocket if it is already open
+            } else {
+                console.log('skipping downloading the icon.gif files for each tool, as the pocket UI is overridden');
+            }
         });
     }
 


### PR DESCRIPTION
Decreases the number of network requests the system makes when it starts up – since we don't show the old pocket anymore, we probably don't need to download all of the icon.gif files for the tools we never see. As a side effect, eliminates some error messages from the console that always show up on launch (depending on which addons/tools you have)

<img width="1022" alt="Screenshot 2023-09-14 at 10 08 49 AM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/1e6f968a-397f-43a0-bb8c-e76ae609a774">
