### PR TITLE
hide other tools and icons in the background when a full2d tool is open 

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -840,6 +840,11 @@ body {
     pointer-events: none;
 }
 
+.hiddenFrameContainerByFull2D {
+    display: none;
+    pointer-events: none;
+}
+
 .visibleFrame {
     visibility: visible;
     /*opacity: 1.0;*/

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -802,7 +802,7 @@ createNameSpace("realityEditor.envelopeManager");
         }
 
         // show all frames and icons that were hidden when the full2D frame opened
-        Array.from(document.querySelectorAll('.visibleFrameContainer')).forEach(frame => {
+        Array.from(document.querySelectorAll('.hiddenFrameContainerByFull2D')).forEach(frame => {
             frame.classList.remove('hiddenFrameContainerByFull2D');
         });
 

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -771,6 +771,14 @@ createNameSpace("realityEditor.envelopeManager");
             updateExitButton();
         }
 
+        // hide all other frames and icons while the full2D frame is open
+        let otherFrames = Array.from(document.querySelectorAll('.visibleFrameContainer')).filter(element => {
+            return !element.id.includes(focusedFrameId);
+        });
+        otherFrames.forEach(frame => {
+            frame.classList.add('hiddenFrameContainerByFull2D');
+        });
+
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
             frameId: focusedFrameId,
             isFull2D: true
@@ -792,6 +800,11 @@ createNameSpace("realityEditor.envelopeManager");
             knownEnvelopes[focusedFrameId].isFull2D = false;
             updateExitButton();
         }
+
+        // show all frames and icons that were hidden when the full2D frame opened
+        Array.from(document.querySelectorAll('.visibleFrameContainer')).forEach(frame => {
+            frame.classList.remove('hiddenFrameContainerByFull2D');
+        });
 
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
             frameId: focusedFrameId,


### PR DESCRIPTION
I think the UI looks cleaner if they are hidden while the background is blurred, since they don't blur and sometimes interfere with the focused tool's content.

Example before:
![Screenshot 2023-09-20 at 12 21 21 PM](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/3e97f567-c850-4fe6-aa45-60c39bda2474)

Example after:
![Screenshot 2023-09-20 at 12 20 33 PM](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/51294676-790b-4d35-976f-19bf26a6456b)

