### PR TITLE
Fix bug in previous implementation of "hidden by blurred background"

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -840,11 +840,6 @@ body {
     pointer-events: none;
 }
 
-.hiddenFrameContainerByFull2D {
-    display: none;
-    pointer-events: none;
-}
-
 .visibleFrame {
     visibility: visible;
     /*opacity: 1.0;*/
@@ -854,6 +849,12 @@ body {
     visibility: visible;
     opacity: 0.4;
     pointer-events: none;
+}
+
+.hiddenFrameContainerByFull2D {
+    /*display: none;*/
+    pointer-events: none;
+    visibility: hidden;
 }
 
 .webGlFrame {

--- a/css/index.css
+++ b/css/index.css
@@ -851,7 +851,7 @@ body {
     pointer-events: none;
 }
 
-.hiddenFrameContainerByFull2D {
+.hiddenByFull2DBlurredBackground {
     /* use visibility instead of display:none to prevent iframe from stopping its computations */
     pointer-events: none;
     visibility: hidden;

--- a/css/index.css
+++ b/css/index.css
@@ -852,7 +852,7 @@ body {
 }
 
 .hiddenFrameContainerByFull2D {
-    /*display: none;*/
+    /* use visibility instead of display:none to prevent iframe from stopping its computations */
     pointer-events: none;
     visibility: hidden;
 }

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -779,6 +779,8 @@ createNameSpace("realityEditor.envelopeManager");
             frame.classList.add('hiddenFrameContainerByFull2D');
         });
         
+        // just hiding the iframes still leaves their proxied gl content on the screen. hide the canvas.
+        // this should be safe to do because the focused full2D tool is 2D by nature and shouldn't be using the 3D canvas
         let webGlCanvas = document.getElementById('glcanvas');
         if (webGlCanvas) {
             webGlCanvas.style.visibility = 'hidden';

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -808,7 +808,7 @@ createNameSpace("realityEditor.envelopeManager");
             updateExitButton();
         }
 
-        // show all frames and icons that were hidden when the full2D frame opened, and the 
+        // show all frames and icons that were hidden when the full2D frame opened, and the webgl canvas
         Array.from(document.querySelectorAll('.hiddenByFull2DBlurredBackground')).forEach(element => {
             element.classList.remove('hiddenByFull2DBlurredBackground');
         });

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -776,14 +776,14 @@ createNameSpace("realityEditor.envelopeManager");
             return !element.id.includes(focusedFrameId);
         });
         otherFrames.forEach(frame => {
-            frame.classList.add('hiddenFrameContainerByFull2D');
+            frame.classList.add('hiddenByFull2DBlurredBackground');
         });
-        
+
         // just hiding the iframes still leaves their proxied gl content on the screen. hide the canvas.
         // this should be safe to do because the focused full2D tool is 2D by nature and shouldn't be using the 3D canvas
         let webGlCanvas = document.getElementById('glcanvas');
         if (webGlCanvas) {
-            webGlCanvas.style.visibility = 'hidden';
+            webGlCanvas.classList.add('hiddenByFull2DBlurredBackground');
         }
 
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
@@ -808,15 +808,10 @@ createNameSpace("realityEditor.envelopeManager");
             updateExitButton();
         }
 
-        // show all frames and icons that were hidden when the full2D frame opened
-        Array.from(document.querySelectorAll('.hiddenFrameContainerByFull2D')).forEach(frame => {
-            frame.classList.remove('hiddenFrameContainerByFull2D');
+        // show all frames and icons that were hidden when the full2D frame opened, and the 
+        Array.from(document.querySelectorAll('.hiddenByFull2DBlurredBackground')).forEach(element => {
+            element.classList.remove('hiddenByFull2DBlurredBackground');
         });
-
-        let webGlCanvas = document.getElementById('glcanvas');
-        if (webGlCanvas) {
-            webGlCanvas.style.visibility = '';
-        }
 
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
             frameId: focusedFrameId,

--- a/src/envelopeManager.js
+++ b/src/envelopeManager.js
@@ -772,12 +772,17 @@ createNameSpace("realityEditor.envelopeManager");
         }
 
         // hide all other frames and icons while the full2D frame is open
-        let otherFrames = Array.from(document.querySelectorAll('.visibleFrameContainer')).filter(element => {
+        let otherFrames = Array.from(document.querySelectorAll('.visibleFrameContainer, .visibleFrame')).filter(element => {
             return !element.id.includes(focusedFrameId);
         });
         otherFrames.forEach(frame => {
             frame.classList.add('hiddenFrameContainerByFull2D');
         });
+        
+        let webGlCanvas = document.getElementById('glcanvas');
+        if (webGlCanvas) {
+            webGlCanvas.style.visibility = 'hidden';
+        }
 
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
             frameId: focusedFrameId,
@@ -805,6 +810,11 @@ createNameSpace("realityEditor.envelopeManager");
         Array.from(document.querySelectorAll('.hiddenFrameContainerByFull2D')).forEach(frame => {
             frame.classList.remove('hiddenFrameContainerByFull2D');
         });
+
+        let webGlCanvas = document.getElementById('glcanvas');
+        if (webGlCanvas) {
+            webGlCanvas.style.visibility = '';
+        }
 
         callbacks.onFullscreenFull2DToggled.forEach(cb => cb({
             frameId: focusedFrameId,


### PR DESCRIPTION
Improvement based on @ptc-mklaudiny's observation that the time-series graph stops ticking forward while the blurred background is hiding it in the previous implementation (https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/525).

A similar side effect seems to be that a proxied gl context doesn't render while display:none is applied to the corresponding iframe, so I didn't need to specifically hide the glcanvas in the previous implementation.

This solution uses visibility:hidden on the iframes, but as a result also needs to apply visibility:hidden to the glcanvas.