### PR TITLE
Analytics adjustments

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1855,7 +1855,7 @@ Logic Interface CSS
 
 #analytics-timeline-container {
     position: absolute;
-    bottom: calc(30px + 68px + 30px - 12px);
+    bottom: 48px;
     left: 50%;
     max-width: 1024px;
     width: 100%;

--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -358,7 +358,7 @@ realityEditor.device.onload = async function () {
         // show an error message rather than crash entirely; otherwise Vuforia Engine will never start
         console.error('error in initService functions, might lead to corrupted app state', initError);
         try {
-            realityEditor.gui.modal.showScreenTopNotification('Error initializing. Restart app or contact support.', 5000);
+            realityEditor.gui.modal.showScreenTopNotification('Error initializing. Restart app or contact support.', 30000);
         } catch (alertError) {
             alert(`Error initializing. Restart app or contact support. ${initError}, ${alertError}`);
         }


### PR DESCRIPTION
Makes the error that shows up due to uBlock developing a hatred for the phrase "analytics.js" last longer onscreen so that users (hopefully) notice it and come to us for education. Also moves the timeline down to make more space on short screens.