### PR TITLE
Improved transformation for billboarding the icons

### DIFF
--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1174,27 +1174,27 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
             finalMatrix = utilities.copyMatrix(realityEditor.sceneGraph.getCSSMatrix(activeKey));
 
             if (activeVehicle.alwaysFaceCamera === true) {
+                // this gives a pretty good billboard effect, as long as you aren't looking from top-down
                 let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(activeKey, 'CAMERA');
                 let modelViewMatrix = [];
                 utilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
-                utilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+
+                // the lookAt method isn't perfect – it has a singularity as you approach top or bottom
+                // so let's correct the scale and remove the rotation
+                let scale = realityEditor.sceneGraph.getSceneNodeById(activeKey).getVehicleScale();
+                let constructedModelViewMatrix = [
+                    scale, 0, 0, 0,
+                    0, -scale, 0, 0,
+                    0, 0, scale, 0,
+                    modelViewMatrix[12], modelViewMatrix[13], modelViewMatrix[14], 1
+                ];
+                utilities.multiplyMatrix(constructedModelViewMatrix, globalStates.projectionMatrix, finalMatrix);
             }
 
             // TODO ben: sceneGraph probably gives better data for z-depth relative to camera
             activeVehicle.screenZ = finalMatrix[14]; // but save pre-processed z position to use later to calculate screenLinearZ
 
-            var activeElementZIncrease = thisIsBeingEdited ? 100 : 0;
-            
-            finalMatrix[14] = 200 + activeElementZIncrease + 1000000 / Math.max(10, activeVehicle.screenZ);
-            // on devices that make elements visible from further away, make sure the z value increases proportionally so it is > 0
-            if (realityEditor.device.environment.variables.distanceScaleFactor > 1) {
-                finalMatrix[14] += realityEditor.device.environment.variables.distanceScaleFactor * 1000;
-            }
-            
-            // put frames all the way in the back if you are in node view
-            if (shouldRenderFramesInNodeView) {
-                finalMatrix[14] = 100;
-            }
+            finalMatrix[14] = realityEditor.gui.ar.positioning.getFinalMatrixScreenZ(finalMatrix[14], thisIsBeingEdited, shouldRenderFramesInNodeView);
             
             activeVehicle.mostRecentFinalMatrix = finalMatrix; // TODO ben: remove mostRecentFinalMatrix
             
@@ -1313,8 +1313,8 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                     if (activeVehicle.sendMatrix === true) {
                         // TODO ben: send translation iff not three.js fullscreen
                         if (activeVehicle.alwaysFaceCamera) {
-                            // thisMsg.modelViewMatrix = realityEditor.sceneGraph.getModelViewMatrixLookingAt(activeVehicle.uuid, 'CAMERA');
                             let modelMatrix = realityEditor.sceneGraph.getModelMatrixLookingAt(activeVehicle.uuid, 'CAMERA');
+                            // TODO: fixup the scale and rotation similar to the other alwaysFaceCamera conditional
                             let modelViewMatrix = [];
                             utilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
                             thisMsg.modelViewMatrix = modelViewMatrix;

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -759,3 +759,21 @@ realityEditor.gui.ar.positioning.getObjectPositionsOfTypes = function(objectType
     });
     return dataToSend;
 };
+
+// adjusts the screenZ to give values that correctly determine stacking order based on distance to screen
+realityEditor.gui.ar.positioning.getFinalMatrixScreenZ = function(originalScreenZ, thisIsBeingEdited = false, shouldRenderFramesInNodeView = false) {
+    // activeVehicle.screenZ = finalMatrix[14]; // but save pre-processed z position to use later to calculate screenLinearZ
+    let activeElementZIncrease = thisIsBeingEdited ? 100 : 0;
+    let newScreenZ = 200 + activeElementZIncrease + 1000000 / Math.max(10, originalScreenZ);
+    // on devices that make elements visible from further away, make sure the z value increases proportionally so it is > 0
+    if (realityEditor.device.environment.variables.distanceScaleFactor > 1) {
+        newScreenZ += realityEditor.device.environment.variables.distanceScaleFactor * 1000;
+    }
+
+    // put frames all the way in the back if you are in node view
+    if (shouldRenderFramesInNodeView) {
+        newScreenZ = 100;
+    }
+
+    return newScreenZ;
+};

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -760,16 +760,20 @@ realityEditor.gui.ar.positioning.getObjectPositionsOfTypes = function(objectType
     return dataToSend;
 };
 
-// adjusts the screenZ to give values that correctly determine stacking order based on distance to screen
+// adjusts the screenZ (modelViewProjection[14]) to give values that correctly determine stacking order based on distance
+// to screen. if you don't do this, CSS-3D tools/icons have opposite stacking order compared to how you might expect.
 realityEditor.gui.ar.positioning.getFinalMatrixScreenZ = function(originalScreenZ, thisIsBeingEdited = false, shouldRenderFramesInNodeView = false) {
-    // activeVehicle.screenZ = finalMatrix[14]; // but save pre-processed z position to use later to calculate screenLinearZ
     let activeElementZIncrease = thisIsBeingEdited ? 100 : 0;
+
+    // originalScreenZ is lower as it is closer to camera. We want newScreenZ to be higher when it approaches camera.
     let newScreenZ = 200 + activeElementZIncrease + 1000000 / Math.max(10, originalScreenZ);
+
+    // apply legacy adjustments to z order... these might be adjusted/removed in future...
+
     // on devices that make elements visible from further away, make sure the z value increases proportionally so it is > 0
     if (realityEditor.device.environment.variables.distanceScaleFactor > 1) {
         newScreenZ += realityEditor.device.environment.variables.distanceScaleFactor * 1000;
     }
-
     // put frames all the way in the back if you are in node view
     if (shouldRenderFramesInNodeView) {
         newScreenZ = 100;


### PR DESCRIPTION
Old icon billboarding looked like:
![old-billboarding-demo](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/2cc12c4b-72f8-4ab7-bd63-c756c95a6245)

New icon billboarding looks like:
![new-billboarding-demo](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/294e1889-84fb-494c-bca8-1bad183bfd4e)
