### PR TITLE
Hides non-fullscreen tools/icons when their MVP matrix has negative matrix[14]

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -885,6 +885,10 @@ body {
     opacity: 0.7;
 }
 
+.elementBehindCamera {
+    display: none;
+}
+
 .outsideOfViewport {
     display: none;
 }

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1209,6 +1209,15 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                     normalizedMatrix[7] = 0;
                     normalizedMatrix[11] = 0;
                     activeElt.style.transform = 'matrix3d(' + normalizedMatrix.toString() + ')';
+
+                    // if tool is rendering while it should be behind the camera, visually hide it (for now)
+                    if (normalizedMatrix[14] < 0 &&
+                        normalizedMatrix[14] !== globalStates.defaultFullscreenFrameZ &&
+                        normalizedMatrix[14] !== globalStates.defaultFullscreenFull2DFrameZ) {
+                        activeElt.classList.add('elementBehindCamera');
+                    } else {
+                        activeElt.classList.remove('elementBehindCamera');
+                    }
                 } else if (!activeElt.classList.contains('outsideOfViewport')) {
                     activeElt.classList.add('outsideOfViewport');
                 }

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1211,9 +1211,7 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                     activeElt.style.transform = 'matrix3d(' + normalizedMatrix.toString() + ')';
 
                     // if tool is rendering while it should be behind the camera, visually hide it (for now)
-                    if (normalizedMatrix[14] < 0 &&
-                        normalizedMatrix[14] !== globalStates.defaultFullscreenFrameZ &&
-                        normalizedMatrix[14] !== globalStates.defaultFullscreenFull2DFrameZ) {
+                    if (normalizedMatrix[14] < 0) {
                         activeElt.classList.add('elementBehindCamera');
                     } else {
                         activeElt.classList.remove('elementBehindCamera');

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -143,6 +143,13 @@ class EnvelopeIconRenderer {
         normalizedMatrix[7] = 0;
         normalizedMatrix[11] = 0;
 
+        // if tool is rendering while it should be behind the camera, visually hide it (for now)
+        if (normalizedMatrix[14] < 0) {
+            iconDiv.classList.add('elementBehindCamera');
+        } else {
+            iconDiv.classList.remove('elementBehindCamera');
+        }
+
         iconDiv.style.transform = 'matrix3d(' + normalizedMatrix.toString() + ')';
     }
 


### PR DESCRIPTION
This has nagged at me for awhile but I never tracked down what was causing it.

Prevents icons / CSS-3D transformed tools from rendering when you zoom past them – the way we manipulate the matrix in the render loop currently causes them to show up upside-down. Sets display:none when conditions are met. Only does this on non-fullscreen tools, which ensures that 3D content or an active envelope doesn't hide when you move the camera.

Note: I added a new CSS class `elementBehindCamera` to tag these with instead of re-using `outsideOfViewport` because outsideOfViewport has some complicated logic attached that involves reloading the iframe when it moves in and out (as calculated by `realityEditor.gui.ar.positioning.canUnload`) which is disabled on desktop, and I don't think we need to unload/reload icons each time you move the camera past them.

Old version:
![tools-rendering-upside-down](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/139120da-5af0-4be3-b27a-a04b80d95370)

New version:
![fixed-tools-rendering-upside-down](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/8a389789-108f-4df0-88ad-d59830c81418)
