### PR TITLE
revert to old billboarding on AR devices; use new method on desktop

### DIFF
--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -1179,16 +1179,21 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
                 let modelViewMatrix = [];
                 utilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
 
-                // the lookAt method isn't perfect – it has a singularity as you approach top or bottom
-                // so let's correct the scale and remove the rotation
-                let scale = realityEditor.sceneGraph.getSceneNodeById(activeKey).getVehicleScale();
-                let constructedModelViewMatrix = [
-                    scale, 0, 0, 0,
-                    0, -scale, 0, 0,
-                    0, 0, scale, 0,
-                    modelViewMatrix[12], modelViewMatrix[13], modelViewMatrix[14], 1
-                ];
-                utilities.multiplyMatrix(constructedModelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+                // In AR mode, we need to use this lookAt method, because camera up vec doesn't always match scene up vec
+                if (realityEditor.device.environment.isARMode()) {
+                    utilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+                } else {
+                    // the lookAt method isn't perfect – it has a singularity as you approach top or bottom
+                    // so let's correct the scale and remove the rotation – this works on desktop because camera up = scene up
+                    let scale = realityEditor.sceneGraph.getSceneNodeById(activeKey).getVehicleScale();
+                    let constructedModelViewMatrix = [
+                        scale, 0, 0, 0,
+                        0, -scale, 0, 0,
+                        0, 0, scale, 0,
+                        modelViewMatrix[12], modelViewMatrix[13], modelViewMatrix[14], 1
+                    ];
+                    utilities.multiplyMatrix(constructedModelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+                }
             }
 
             // TODO ben: sceneGraph probably gives better data for z-depth relative to camera

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -123,17 +123,21 @@ class EnvelopeIconRenderer {
         let modelViewMatrix = [];
         this.arUtilities.multiplyMatrix(modelMatrix, realityEditor.sceneGraph.getViewMatrix(), modelViewMatrix);
 
-        // the lookAt method isn't perfect – it has a singularity as you approach top or bottom
-        // so let's correct the scale and remove the rotation
-        let scale = realityEditor.sceneGraph.getSceneNodeById(frameId).getVehicleScale();
-        let constructedModelViewMatrix = [
-            scale, 0, 0, 0,
-            0, -scale, 0, 0,
-            0, 0, scale, 0,
-            modelViewMatrix[12], modelViewMatrix[13], modelViewMatrix[14], 1
-        ];
-
-        this.arUtilities.multiplyMatrix(constructedModelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+        // In AR mode, we need to use this lookAt method, because camera up vec doesn't always match scene up vec
+        if (realityEditor.device.environment.isARMode()) {
+            this.arUtilities.multiplyMatrix(modelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+        } else {
+            // the lookAt method isn't perfect – it has a singularity as you approach top or bottom
+            // so let's correct the scale and remove the rotation – this works on desktop because camera up = scene up
+            let scale = realityEditor.sceneGraph.getSceneNodeById(frameId).getVehicleScale();
+            let constructedModelViewMatrix = [
+                scale, 0, 0, 0,
+                0, -scale, 0, 0,
+                0, 0, scale, 0,
+                modelViewMatrix[12], modelViewMatrix[13], modelViewMatrix[14], 1
+            ];
+            this.arUtilities.multiplyMatrix(constructedModelViewMatrix, globalStates.projectionMatrix, finalMatrix);
+        }
 
         finalMatrix[14] = realityEditor.gui.ar.positioning.getFinalMatrixScreenZ(finalMatrix[14]);
 


### PR DESCRIPTION
In my enthusiasm to improve the billboarding for remote operators (https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/557) I forgot to test how it impacts rendering in AR, and now I've realized that the new method I used (basically just setting rotation to identity) doesn't work on AR because when you rotate the phone (like a steering wheel) the icons rotate with it. I've tried various maths for getting the perfect transform in AR but can't quite get it to avoid singularity behavior when you view from the top. Something something quaternions but I don't have the headspace for that right now.

This reverts to the old method on AR but keeps the new implementation for desktop.