### PR TITLE
updates receiveMatricesFromAR to be compatible with targetId tracking method

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -98,25 +98,25 @@ realityEditor.app.doesDeviceHaveDepthSensor = function(callBack) {
 };
 
 /**
- * Adds a new marker and fires a callback with error or success
- * and the markerName for reference
- * @param {string} markerName
+ * Adds a new target and fires a callback with error or success
+ * and the targetName for reference
+ * @param {string} targetName
  * @param {FunctionName} callBack
  */
-realityEditor.app.addNewMarker = function(markerName, callBack) {
-    this.appFunctionCall('addNewMarker', {markerName: markerName}, 'realityEditor.app.callBack('+callBack+', [__ARG1__, __ARG2__])');
+realityEditor.app.addNewTarget = function(targetName, callBack) {
+    this.appFunctionCall('addNewTarget', {targetName: targetName}, 'realityEditor.app.callBack('+callBack+', [__ARG1__, __ARG2__])');
 };
 
 /**
- * Adds a new marker using a JPG image and fires a callback with error or success
- * and the markerName for reference
- * @param {string} markerName
+ * Adds a new target using a JPG image and fires a callback with error or success
+ * and the targetName for reference
+ * @param {string} targetName
  * @param {string} objectID
  * @param {number} targetWidthMeters
  * @param {FunctionName} callBack
  */
-realityEditor.app.addNewMarkerJPG = function(markerName, objectID, targetWidthMeters, callBack) {
-    this.appFunctionCall('addNewMarkerJPG', {markerName: markerName, objectID: objectID, targetWidthMeters: targetWidthMeters}, 'realityEditor.app.callBack('+callBack+', [__ARG1__, __ARG2__])');
+realityEditor.app.addNewTargetJPG = function(targetName, objectID, targetWidthMeters, callBack) {
+    this.appFunctionCall('addNewTargetJPG', {targetName: targetName, objectID: objectID, targetWidthMeters: targetWidthMeters}, 'realityEditor.app.callBack('+callBack+', [__ARG1__, __ARG2__])');
 };
 
 /**
@@ -129,7 +129,7 @@ realityEditor.app.getProjectionMatrix = function(callBack) {
 };
 
 /**
- * Sets up a callback for the model matrices of all markers that are found, that will get called every frame.
+ * Sets up a callback for the model matrices of all targets that are found, that will get called every frame.
  * Callback will have a set of objectId mapped to matrix for each visibleObjects.
  * @param {FunctionName} callBack
  */

--- a/src/app/promises.js
+++ b/src/app/promises.js
@@ -5,7 +5,7 @@ createNameSpace("realityEditor.app.promises");
  * Provides a simpler interface to some APIs defined in app/index.js, by wrapping them in a Promise
  * APIs that return a single value vs those that return multiple values should be accessed like:
  * getDeviceReady().then(deviceName => {})
- * addNewMarker('target.xml').then(({success, fileName}) => {})
+ * addNewTarget('target.xml').then(({success, fileName}) => {})
  * APIs for subscriptions, such as the matrix stream, should still be accessed directly using app/index.js
  */
 (function(exports) {
@@ -22,10 +22,10 @@ createNameSpace("realityEditor.app.promises");
     //resolves to baseURL: string
     exports.getManagerBaseURL = makeAPI(app.getManagerBaseURL.bind(app));
 
-    // params: [markerName], resolves to: {success: boolean, fileName: string]}
-    exports.addNewMarker = makeAPI(app.addNewMarker.bind(app), ['success', 'fileName']);
-    // params: [markerName, objectID, targetWidthMeters], resolves to: {success: boolean, fileName: string]}
-    exports.addNewMarkerJPG = makeAPI(app.addNewMarkerJPG.bind(app), ['success', 'fileName']);
+    // params: [targetName], resolves to: {success: boolean, fileName: string]}
+    exports.addNewTarget = makeAPI(app.addNewTarget.bind(app), ['success', 'fileName']);
+    // params: [targetName, objectID, targetWidthMeters], resolves to: {success: boolean, fileName: string]}
+    exports.addNewTargetJPG = makeAPI(app.addNewTargetJPG.bind(app), ['success', 'fileName']);
 
     // resolves to providerId: string
     exports.getProviderId = makeAPI(app.getProviderId.bind(app));

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -20,8 +20,8 @@ createNameSpace("realityEditor.app.targetDownloader");
      */
 
     /**
-     * @type {Object.<string, {XML: DownloadState, DAT: DownloadState, JPG: DownloadState, MARKER_ADDED: DownloadState, FILENAME: String}>}
-     * Maps object names to the download states of their XML and DAT files, and whether the tracking engine has added the resulting marker
+     * @type {Object.<string, {XML: DownloadState, DAT: DownloadState, JPG: DownloadState, TARGET_ADDED: DownloadState, FILENAME: String}>}
+     * Maps object names to the download states of their XML and DAT files, and whether the tracking engine has added the resulting target
      */
     var targetDownloadStates = {};
 
@@ -78,7 +78,7 @@ createNameSpace("realityEditor.app.targetDownloader");
 
     let callbacks = {
         onCreateNavmesh: [],
-        onMarkerAdded: [],
+        onTargetAdded: [],
         onTargetState: []
     }
     
@@ -124,7 +124,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
 
     /**
-     * Downloads the JPG files, and adds the AR marker to the tracking engine, when a new UDP object heartbeat is detected
+     * Downloads the JPG files, and adds the AR target to the tracking engine, when a new UDP object heartbeat is detected
      * @param {{id: string, ip: string, vn: number, tcs: string, zone: string}} objectHeartbeat
      * id: the objectId
      * ip: the IP address of the server hosting this object
@@ -173,7 +173,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             DAT: DownloadState.NOT_STARTED,
             JPG: DownloadState.NOT_STARTED,
             GLB: DownloadState.NOT_STARTED,
-            MARKER_ADDED: DownloadState.NOT_STARTED
+            TARGET_ADDED: DownloadState.NOT_STARTED
         };
         var xmlAddress = realityEditor.network.getURL(objectHeartbeat.ip, realityEditor.network.getPort(objectHeartbeat), '/obj/' + objectName + '/target/target.xml');
 
@@ -213,7 +213,7 @@ createNameSpace("realityEditor.app.targetDownloader");
                 targetDownloadStates[objectID].DAT === DownloadState.STARTED ||
                 targetDownloadStates[objectID].JPG === DownloadState.STARTED ||
                 targetDownloadStates[objectID].GLB === DownloadState.STARTED ||
-                targetDownloadStates[objectID].MARKER_ADDED === DownloadState.STARTED) {
+                targetDownloadStates[objectID].TARGET_ADDED === DownloadState.STARTED) {
                 return false;
             }
         }
@@ -231,7 +231,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
 
     /**
-     * If successfully downloads target JPG, tries to add a new marker to Vuforia
+     * If successfully downloads target JPG, tries to add a new target to Vuforia
      * @param {boolean} success
      * @param {string} fileName
      */
@@ -269,7 +269,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
 
     /**
-     * If successfully downloads target JPG, tries to add a new marker to Vuforia
+     * If successfully downloads target JPG, tries to add a new target to Vuforia
      * @param {boolean} success
      * @param {string} fileName
      */
@@ -285,10 +285,10 @@ createNameSpace("realityEditor.app.targetDownloader");
             triggerDownloadStateCallbacks(objectID);
 
             var xmlFileName = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/obj/' + object.name + '/target/target.xml');
-            realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
-                onMarkerAdded(success, fileName);
+            realityEditor.app.promises.addNewTarget(xmlFileName).then(({success, fileName}) => {
+                onTargetAdded(success, fileName);
             });
-            targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+            targetDownloadStates[objectID].TARGET_ADDED = DownloadState.STARTED;
             targetDownloadStates[objectID].FILENAME = fileName;
             realityEditor.getObject(objectID).isJpgTarget = false;
 
@@ -369,7 +369,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     exports.onNavmeshCreated = onNavmeshCreated;
 
     /**
-     * If successfully downloads target JPG, tries to add a new marker to Vuforia
+     * If successfully downloads target JPG, tries to add a new target to Vuforia
      * @param {boolean} success
      * @param {string} fileName
      */
@@ -380,10 +380,10 @@ createNameSpace("realityEditor.app.targetDownloader");
         if (success) {
             targetDownloadStates[objectID].JPG = DownloadState.SUCCEEDED;
             let targetWidth = realityEditor.gui.utilities.getTargetSize(objectID).width;
-            realityEditor.app.promises.addNewMarkerJPG(fileName, objectID, targetWidth).then(({success, fileName}) => {
-                onMarkerAdded(success, fileName);
+            realityEditor.app.promises.addNewTargetJPG(fileName, objectID, targetWidth).then(({success, fileName}) => {
+                onTargetAdded(success, fileName);
             });
-            targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+            targetDownloadStates[objectID].TARGET_ADDED = DownloadState.STARTED;
             targetDownloadStates[objectID].FILENAME = fileName;
             realityEditor.getObject(objectID).isJpgTarget = true;
         } else {
@@ -396,27 +396,27 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
 
     /**
-     * Callback for realityEditor.app.addNewMarker
+     * Callback for realityEditor.app.addNewTarget
      * Updates the download state for that object to mark it as fully initialized in the AR engine
      * Marks the object as SUCCEEDED only if its target is added, so we can later provide visual feedback
      * @param {boolean} success
      * @param {string} fileName
      */
-    function onMarkerAdded(success, fileName) {
+    function onTargetAdded(success, fileName) {
         var objectID = getObjectIDFromFilename(fileName);
 
         if (success) {
-            targetDownloadStates[objectID].MARKER_ADDED = DownloadState.SUCCEEDED;
+            targetDownloadStates[objectID].TARGET_ADDED = DownloadState.SUCCEEDED;
             saveDownloadInfo(objectID); // only caches the target images after we confirm that they work
         } else {
-            console.error('failed to add marker: ' + fileName);
-            targetDownloadStates[objectID].MARKER_ADDED = DownloadState.FAILED;
+            console.error('failed to add target: ' + fileName);
+            targetDownloadStates[objectID].TARGET_ADDED = DownloadState.FAILED;
             onDownloadFailed(objectID);
         }
 
         triggerDownloadStateCallbacks(objectID);
 
-        callbacks.onMarkerAdded.forEach(listener => {
+        callbacks.onTargetAdded.forEach(listener => {
             if (listener.objectId === objectID) {
                 listener.callback(success, targetDownloadStates[objectID]);
             }
@@ -450,11 +450,11 @@ createNameSpace("realityEditor.app.targetDownloader");
      * @return {boolean}
      */
     function isObjectTargetInitialized(objectID) {
-        return targetDownloadStates[objectID] && targetDownloadStates[objectID].MARKER_ADDED === DownloadState.SUCCEEDED;
+        return targetDownloadStates[objectID] && targetDownloadStates[objectID].TARGET_ADDED === DownloadState.SUCCEEDED;
     }
 
     /**
-     * True if the marker failed to add given a successful download,
+     * True if the target failed to add given a successful download,
      * or the XML failed to download, or both the JPG and the DAT failed.
      * @param {string} objectID
      * @param {string} beatChecksum
@@ -467,15 +467,15 @@ createNameSpace("realityEditor.app.targetDownloader");
         let hasAttemptsLeft = retryMap[objectID].attemptsLeft > 0;
         let isNewChecksum = beatChecksum && beatChecksum !== retryMap[objectID].previousChecksum;
 
-        // if xml or marker adding failed, or (jpg AND dat) failed, don't rery download
-        let didMarkerAddFail = targetDownloadStates[objectID].MARKER_ADDED === DownloadState.FAILED;
+        // if xml or target adding failed, or (jpg AND dat) failed, don't rery download
+        let didTargetAddFail = targetDownloadStates[objectID].TARGET_ADDED === DownloadState.FAILED;
         let didXmlFail = targetDownloadStates[objectID].XML === DownloadState.FAILED;
         let didDatFail = targetDownloadStates[objectID].DAT === DownloadState.FAILED ||
                          targetDownloadStates[objectID].DAT === DownloadState.NOT_STARTED; // dat isn't guaranteed to start
         let didJpgFail = targetDownloadStates[objectID].JPG === DownloadState.FAILED ||
                          targetDownloadStates[objectID].JPG === DownloadState.NOT_STARTED; // jpg isn't guaranteed to start
 
-        return (hasAttemptsLeft || isNewChecksum) && (didMarkerAddFail || didXmlFail || (didDatFail && didJpgFail));
+        return (hasAttemptsLeft || isNewChecksum) && (didTargetAddFail || didXmlFail || (didDatFail && didJpgFail));
     }
 
     /**
@@ -563,7 +563,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     /**
      * @deprecated - use downloadAvailableTargetFiles instead, if the device can add objects based on DAT or JPG, not just DAT
      * @todo - evaluate if this is necessary at all or if it can be completely removed (github issue #14)
-     * Downloads the XML and DAT files, and adds the AR marker to the tracking engine, when a new UDP object heartbeat is detected
+     * Downloads the XML and DAT files, and adds the AR target to the tracking engine, when a new UDP object heartbeat is detected
      * @param {{id: string, ip: string, vn: number, tcs: string, zone: string}} objectHeartbeat
      * id: the objectId
      * ip: the IP address of the server hosting this object
@@ -599,7 +599,7 @@ createNameSpace("realityEditor.app.targetDownloader");
             targetDownloadStates[objectID] = {
                 XML: DownloadState.NOT_STARTED,
                 DAT: DownloadState.NOT_STARTED,
-                MARKER_ADDED: DownloadState.NOT_STARTED
+                TARGET_ADDED: DownloadState.NOT_STARTED
             };
         }
 
@@ -669,10 +669,10 @@ createNameSpace("realityEditor.app.targetDownloader");
                     return fileName.indexOf('xml') > -1;
                 })[0];
 
-                realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
-                    onMarkerAdded(success, fileName);
+                realityEditor.app.promises.addNewTarget(xmlFileName).then(({success, fileName}) => {
+                    onTargetAdded(success, fileName);
                 });
-                targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+                targetDownloadStates[objectID].TARGET_ADDED = DownloadState.STARTED;
                 targetDownloadStates[objectID].FILENAME = xmlFileName;
 
             } else {
@@ -733,7 +733,7 @@ createNameSpace("realityEditor.app.targetDownloader");
     /**
      * Callback for realityEditor.app.downloadFile for either target.xml or target.dat
      * Updates the corresponding object's targetDownloadState,
-     * and if both the XML and DAT are finished downloading, adds the resulting marker to the AR engine
+     * and if both the XML and DAT are finished downloading, adds the resulting target to the AR engine
      * @param {boolean} success
      * @param {string} fileName
      */
@@ -755,16 +755,16 @@ createNameSpace("realityEditor.app.targetDownloader");
 
         var hasXML = targetDownloadStates[objectID].XML === DownloadState.SUCCEEDED;
         var hasDAT = targetDownloadStates[objectID].DAT === DownloadState.SUCCEEDED;
-        var markerNotAdded = (targetDownloadStates[objectID].MARKER_ADDED === DownloadState.NOT_STARTED ||
-            targetDownloadStates[objectID].MARKER_ADDED === DownloadState.FAILED);
+        var targetNotAdded = (targetDownloadStates[objectID].TARGET_ADDED === DownloadState.NOT_STARTED ||
+            targetDownloadStates[objectID].TARGET_ADDED === DownloadState.FAILED);
 
-        // synchronizes the two async download calls to add the marker when both tasks have completed
+        // synchronizes the two async download calls to add the target when both tasks have completed
         var xmlFileName = isXML ? fileName : fileName.slice(0, -3) + 'xml';
-        if (hasXML && hasDAT && markerNotAdded) {
-            realityEditor.app.promises.addNewMarker(xmlFileName).then(({success, fileName}) => {
-                onMarkerAdded(success, fileName);
+        if (hasXML && hasDAT && targetNotAdded) {
+            realityEditor.app.promises.addNewTarget(xmlFileName).then(({success, fileName}) => {
+                onTargetAdded(success, fileName);
             });
-            targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+            targetDownloadStates[objectID].TARGET_ADDED = DownloadState.STARTED;
             targetDownloadStates[objectID].FILENAME = fileName;
 
             if (temporaryChecksumMap[objectID]) {
@@ -777,30 +777,30 @@ createNameSpace("realityEditor.app.targetDownloader");
     function reinstatePreviouslyAddedTargets() {
         Object.keys(targetDownloadStates).forEach(function(objectID) {
             let states = targetDownloadStates[objectID];
-            if (states && states.MARKER_ADDED === DownloadState.SUCCEEDED && targetDownloadStates[objectID].FILENAME) {
+            if (states && states.TARGET_ADDED === DownloadState.SUCCEEDED && targetDownloadStates[objectID].FILENAME) {
                 if (states.JPG === DownloadState.SUCCEEDED && states.DAT !== DownloadState.SUCCEEDED) {
                     let targetWidth = realityEditor.gui.utilities.getTargetSize(objectID).width;
-                    realityEditor.app.promises.addNewMarkerJPG(targetDownloadStates[objectID].FILENAME, objectID, targetWidth).then(({success, fileName}) => {
-                        onMarkerAdded(success, fileName);
+                    realityEditor.app.promises.addNewTargetJPG(targetDownloadStates[objectID].FILENAME, objectID, targetWidth).then(({success, fileName}) => {
+                        onTargetAdded(success, fileName);
                     });
-                    targetDownloadStates[objectID].MARKER_ADDED = DownloadState.STARTED;
+                    targetDownloadStates[objectID].TARGET_ADDED = DownloadState.STARTED;
                 } else if (states.DAT === DownloadState.SUCCEEDED) {
-                    realityEditor.app.promises.addNewMarker(targetDownloadStates[objectID].FILENAME).then(({success, fileName}) => {
-                        onMarkerAdded(success, fileName);
+                    realityEditor.app.promises.addNewTarget(targetDownloadStates[objectID].FILENAME).then(({success, fileName}) => {
+                        onTargetAdded(success, fileName);
                     });
                 }
             }
         });
     }
     
-    exports.addMarkerAddedCallback = function(objectId, callback) {
-        callbacks.onMarkerAdded.push({
+    exports.addTargetAddedCallback = function(objectId, callback) {
+        callbacks.onTargetAdded.push({
             objectId: objectId,
             callback: callback
         });
         
         if (typeof targetDownloadStates[objectId] !== 'undefined') {
-            if (targetDownloadStates[objectId].MARKER_ADDED === DownloadState.SUCCEEDED) {
+            if (targetDownloadStates[objectId].TARGET_ADDED === DownloadState.SUCCEEDED) {
                 // process any previously added targets in case we added the listener too late
                 callback(true, targetDownloadStates[objectId]);
             }

--- a/src/constructors.js
+++ b/src/constructors.js
@@ -70,6 +70,9 @@ function Objects() {
     this.objectId = null;
     // The name for the object used for interfaces.
     this.name = "";
+    // The UUID used internally by Vuforia for tracking
+    this.targetId = null;
+
     // The IP address for the object is relevant to point the Reality Editor to the right server.
     // It will be used for the UDP broadcasts.
     this.ip = "localhost";

--- a/src/constructors.js
+++ b/src/constructors.js
@@ -129,9 +129,9 @@ function Frame() {
     this.visualization = "ar";
     // position data for the ar visualization mode
     this.ar = {
-        // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Marker origin.
+        // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Target origin.
         x : 0,
-        // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Marker origin.
+        // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Target origin.
         y : 0,
         // Reality Editor: This is used to scale the UI element in 3D Space. Default scale is 1.
         scale : 0.5,
@@ -145,9 +145,9 @@ function Frame() {
     };
     // position data for the screen visualization mode
     this.screen = {
-        // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Marker origin.
+        // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Target origin.
         x : 0,
-        // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Marker origin.
+        // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Target origin.
         y : 0,
         // Reality Editor: This is used to scale the UI element in 3D Space. Default scale is 1.
         scale : 0.5
@@ -230,9 +230,9 @@ function Node() {
     this.frameId = null;
     // the actual data of the node
     this.data = new Data(); // todo maybe value
-    // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Marker origin.
+    // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Target origin.
     this.x = 0;
-    // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Marker origin.
+    // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Target origin.
     this.y = 0;
     // Reality Editor: This is used to scale the UI element in 3D Space. Default scale is 1.
     this.scale = 0.5;
@@ -268,9 +268,9 @@ function Logic() {
     this.name = "";
     // data for logic blocks. depending on the blockSize which one is used.
     this.data = new Data();
-    // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Marker origin.
+    // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Target origin.
     this.x = 0;
-    // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Marker origin.
+    // Reality Editor: This is used to position the UI element within its y axis in 3D Space. Relative to Target origin.
     this.y = 0;
     // Reality Editor: This is used to scale the UI element in 3D Space. Default scale is 1.
     this.scale = 0.5;

--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -195,7 +195,7 @@ realityEditor.gui.ar.draw.registerCallback = function(functionName, callback) {
 
 /**
  * The most recently received set of matrices for the currently visible objects.
- * A set of {objectId: matrix} pairs, one per recognized marker
+ * A set of {objectId: matrix} pairs, one per recognized target
  * @type {Object.<string, Array.<number>>}
  */
 realityEditor.gui.ar.draw.visibleObjectsCopy = {};
@@ -248,9 +248,9 @@ realityEditor.gui.ar.draw.frameNeedsToBeRendered = true;
 realityEditor.gui.ar.draw.prevSuppressedRendering = false;
 
 /**
- * Previously triggered directly by the native app when the AR engine updates with a new set of recognized markers,
+ * Previously triggered directly by the native app when the AR engine updates with a new set of recognized targets,
  * But now gets called 60FPS regardless of the AR engine, and just uses the most recent set of matrices.
- * @param {Object.<string, Array.<number>>} visibleObjects - set of {objectId: matrix} pairs, one per recognized marker
+ * @param {Object.<string, Array.<number>>} visibleObjects - set of {objectId: matrix} pairs, one per recognized target
  */
 realityEditor.gui.ar.draw.update = function (visibleObjects) {
     if (realityEditor.device.environment.isObjectRenderingSuppressed()) {
@@ -1108,7 +1108,7 @@ realityEditor.gui.ar.draw.drawTransformed = function (objectKey, activeKey, acti
             }
 
             // set initial position of frames and nodes placed in from pocket
-            // 1. drop directly onto marker plane if in freeze state (or quick-tapped the frame)
+            // 1. drop directly onto target plane if in freeze state (or quick-tapped the frame)
             // 2. otherwise float in unconstrained slightly in front of the editor camera
             // 3. animate so it looks like it is being pushed from pocket
             if (activePocketNodeWaiting && typeof activeVehicle.mostRecentFinalMatrix !== 'undefined') {
@@ -1511,9 +1511,9 @@ realityEditor.gui.ar.draw.debugDrawVehicle = function(activeVehicle, finalMatrix
 };
 
 /**
- * Temporarily disabled function that will snap the frame to the marker plane
+ * Temporarily disabled function that will snap the frame to the target plane
  * (by removing its rotation components) if the amount of rotation is very small
- * @todo: only do this if it is also close to the marker plane in the Z direction
+ * @todo: only do this if it is also close to the target plane in the Z direction
  * @param {Frame|Node} activeVehicle
  * @param {string} activeKey
  */

--- a/src/gui/ar/frameHistoryRenderer.js
+++ b/src/gui/ar/frameHistoryRenderer.js
@@ -453,10 +453,10 @@ createNameSpace("realityEditor.gui.ar.frameHistoryRenderer");
      * @param {string|null} nodeKey - if null, renders a frame ghost, otherwise renders the node ghost
      * @param {Frame} ghostFrame
      * @param {Node|null} ghostNode
-     * @param {Array.<number>} markerMatrix - the visibleObjects[objectKey] matrix
+     * @param {Array.<number>} targetMatrix - the visibleObjects[objectKey] matrix
      * @param {boolean} wasFrameDeleted
      */
-    function renderGhost(objectKey, frameKey, nodeKey, ghostFrame, ghostNode, markerMatrix, wasFrameDeleted) {
+    function renderGhost(objectKey, frameKey, nodeKey, ghostFrame, ghostNode, targetMatrix, wasFrameDeleted) {
         
         // some logic lets us customize the same function to render ghosts for frames and nodes
         var isNode = !!nodeKey;

--- a/src/gui/ar/moveabilityOverlay.js
+++ b/src/gui/ar/moveabilityOverlay.js
@@ -3,7 +3,7 @@ createNameSpace("realityEditor.gui.ar.moveabilityOverlay");
 /**
  * @fileOverview realityEditor.gui.ar.moveabilityOverlay
  * Draws the green SVG overlay that indicates when you can drag a frame or node.
- * Draws red lines over a given region when the frame moves behind the z=0 marker plane.
+ * Draws red lines over a given region when the frame moves behind the z=0 target plane.
  */
 
 realityEditor.gui.ar.moveabilityOverlay = {};

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -536,7 +536,7 @@ realityEditor.gui.ar.positioning.getScreenPosition = function(objectKey, frameKe
     var utils = realityEditor.gui.ar.utilities;
     var draw = realityEditor.gui.ar.draw;
     
-    // 1. recompute the ModelViewProjection matrix for the marker
+    // 1. recompute the ModelViewProjection matrix for the target
     var activeObjectMatrix = [];
     utils.multiplyMatrix(draw.visibleObjects[objectKey], globalStates.projectionMatrix, activeObjectMatrix);
     

--- a/src/gui/ar/utilities.js
+++ b/src/gui/ar/utilities.js
@@ -53,7 +53,7 @@ createNameSpace("realityEditor.gui.ar.utilities");
  * @fileOverview realityEditor.gui.ar.utilities.js
  * Various utility functions, mostly mathematical, for calculating AR geometry.
  * Includes simply utilities like multiplying and inverting a matrix,
- * as well as sophisticated algorithms for marker-plane intersections and raycasting points onto a plane.
+ * as well as sophisticated algorithms for target-plane intersections and raycasting points onto a plane.
  */
 
 /**
@@ -689,7 +689,7 @@ realityEditor.gui.ar.utilities.setAverageScale = function(object) {
  * @param {string} objectKey
  * @return {HTMLElement}
  */
-realityEditor.gui.ar.utilities.getDivWithMarkerTransformation = function(objectKey) {
+realityEditor.gui.ar.utilities.getDivWithTargetTransformation = function(objectKey) {
 
     let matrixComputationDiv = globalDOMCache['matrixComputationDivForObjects'];
     if (!matrixComputationDiv) {
@@ -728,7 +728,7 @@ realityEditor.gui.ar.utilities.getDivWithMarkerTransformation = function(objectK
 realityEditor.gui.ar.utilities.screenCoordinatesToTargetXY = function(objectKey, screenX, screenY) {
 
     // set dummy div transform to iframe without x,y,scale
-    let matrixComputationDiv = this.getDivWithMarkerTransformation(objectKey);
+    let matrixComputationDiv = this.getDivWithTargetTransformation(objectKey);
     let newPosition = webkitConvertPointFromPageToNode(matrixComputationDiv, new WebKitPoint(screenX, screenY));
 
     return {

--- a/src/gui/screenExtension.js
+++ b/src/gui/screenExtension.js
@@ -260,8 +260,8 @@ realityEditor.gui.screenExtension.onScreenTouchMove = function(eventObject) {
         
         // console.log('touched (x,y) = (' + visibleScreenObject.x + ', ' + visibleScreenObject.y + ')')
         
-        // var markerWidth = targetSize.width;
-        // var screenX = point.x + markerWidth/2;
+        // var targetWidth = targetSize.width;
+        // var screenX = point.x + targetWidth/2;
         //
         // console.log('x -> ' + screenX);
 
@@ -475,7 +475,7 @@ realityEditor.gui.screenExtension.sendScreenObject = function (){
 };
 
 /**
- * Map touchOffset x and y from marker units to 0-1 range representing the percent x and y within the touched frame
+ * Map touchOffset x and y from target units to 0-1 range representing the percent x and y within the touched frame
  * e.g. (0,0) means tapped upper left corner, (0.5, 0.5) is center, (1,1) is lower right corner
  * @param thisFrame
  * @return {{x: number, y: number}}
@@ -588,7 +588,7 @@ realityEditor.gui.screenExtension.updateArFrameVisibility = function (){
 
             // 1. move it so it is centered on the pointer, ignoring touchOffset
             var touchPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
-            // realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinateBasedOnMarker(thisFrame, touchPosition.x, touchPosition.y, false);
+            // realityEditor.gui.ar.positioning.moveVehicleToScreenCoordinateBasedOnTarget(thisFrame, touchPosition.x, touchPosition.y, false);
 
             let xPos = touchPosition.x - window.innerWidth/2; // (0, 0) is the middle of the screen
             let yPos = touchPosition.y - window.innerHeight/2;


### PR DESCRIPTION
New app version reports tracked targets using their targetId, rather than objectId. This method is still backwards compatible with old app versions or object versions which don't have a targetId.

Goes with https://github.com/ptcrealitylab/vuforia-spatial-toolbox-ios-swift/pull/555