### PR TITLE
app.setPause and app.setResume can take a completionHandler callback

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -210,16 +210,26 @@ realityEditor.app.get3dSnapshot = function(callBack) {
 
 /**
  * Pauses the tracker (freezes the background)
+ * @param {FunctionName|null} callBack - optional, returns success when done pausing
  */
-realityEditor.app.setPause = function() {
-    this.appFunctionCall('setPause', null, null);
+realityEditor.app.setPause = function(callBack = null) {
+    if (callBack) {
+        this.appFunctionCall('setPause', null, 'realityEditor.app.callBack('+callBack+', [__ARG1__])');
+    } else {
+        this.appFunctionCall('setPause', null, null);
+    }
 };
 
 /**
  * Resumes the tracker (unfreezes the background)
+ * @param {FunctionName|null} callBack - optional, returns success when done resuming
  */
-realityEditor.app.setResume = function() {
-    this.appFunctionCall('setResume', null, null);
+realityEditor.app.setResume = function(callBack = null) {
+    if (callBack) {
+        this.appFunctionCall('setResume', null, 'realityEditor.app.callBack('+callBack+', [__ARG1__])');
+    } else {
+        this.appFunctionCall('setResume', null, null);
+    }
 };
 
 /**

--- a/src/app/promises.js
+++ b/src/app/promises.js
@@ -27,6 +27,11 @@ createNameSpace("realityEditor.app.promises");
     // params: [targetName, objectID, targetWidthMeters], resolves to: {success: boolean, fileName: string]}
     exports.addNewTargetJPG = makeAPI(app.addNewTargetJPG.bind(app), ['success', 'fileName']);
 
+    // resolves to success: boolean
+    exports.setPause = makeAPI(app.setPause.bind(app));
+    // resolves to success: boolean
+    exports.setResume = makeAPI(app.setResume.bind(app));
+
     // resolves to providerId: string
     exports.getProviderId = makeAPI(app.getProviderId.bind(app));
     


### PR DESCRIPTION
New promise versions of setPause and setResume that resolve when pause/resume is complete, with success status.

These can be used to ensure that the app has finished pausing/resuming AR before continuing, since the regular app function calls aren't guaranteed to be synchronous.