### PR TITLE
Click on icon to edit your username

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2232,3 +2232,92 @@ Logic Interface CSS
     color: yellow;
     font-size: 20px;
 }
+
+.inputModalCard {
+    position: absolute;
+    width: 84vw;
+    max-width: 460px;
+    /*height: 410px;*/
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+    background-color: rgb(242, 242, 242);
+    border-radius: 6px;
+    box-shadow: rgba(0,0,0,0.15) 0 4px 10px 6px;
+    box-sizing: border-box;
+    color: rgb(56, 56, 56);
+    display: block;
+    font-family: "Open Sans", "sans-serif";
+    font-size: 26px;
+    line-height: 45px;
+    pointer-events: auto;
+    padding: 30px 20px;
+    text-align: center;
+    vertical-align: middle;
+    z-index: 1100;
+}
+
+.inputModalCardText {
+    display: flex;
+    flex-direction: column;
+    margin: 10px 0 20px 0;
+}
+
+/* All child elements of popUpModalText that are h3 */
+.inputModalCardText h3 {
+    margin: 0 0 28px 0;
+    text-align: center;
+    font-weight: 600;
+    font-size: 1.4rem;
+    line-height: 1.5rem;
+    width: 100%;
+}
+
+/* All p elements that are siblings of h3 */
+.inputModalCardText p {
+    margin: 0 5px 10px 5px;
+    /*text-align: left;*/
+    font-size: 1rem;
+    line-height: 1.5rem;
+}
+
+.inputModalCardButton {
+    display: inline-block;
+    width: calc(100%);
+    height: 72px;
+    margin: 10px 0;
+    line-height: 72px;
+    text-align: center;
+    vertical-align: middle;
+    color: white;
+    font-size: 1.4rem;
+    font-weight: 600;
+    background-color: rgba(56, 56, 56);
+    border-radius: 12px;
+}
+
+.inputModalCardButton.buttonLight {
+    color: rgba(56, 56, 56);
+    background-color: rgba(217, 217, 217);
+}
+
+.inputModalCardInput {
+    font-size: 22px;
+    line-height: 32px;
+    width: 100%;
+    /*display: flex;*/
+    /*flex-direction: column;*/
+    margin: 10px 0 20px 0;
+}
+
+.inputModalCardButton:hover {
+    transform: scaleX(0.995) scaleY(0.975);
+    filter: brightness(0.9);
+    -webkit-filter: brightness(0.9);
+}
+
+.inputModalCardButton:active {
+    transform: scaleX(0.99) scaleY(0.95);
+    filter: brightness(0.8);
+    -webkit-filter: brightness(0.8);
+}

--- a/css/index.css
+++ b/css/index.css
@@ -2233,11 +2233,11 @@ Logic Interface CSS
     font-size: 20px;
 }
 
+/* Slight variation of popUpModal (and associated CSS classes), but available in userinterface rather than pop-up-addon */
 .inputModalCard {
     position: absolute;
     width: 84vw;
     max-width: 460px;
-    /*height: 410px;*/
     top: 50%;
     left: 50%;
     transform: translateY(-50%) translateX(-50%);
@@ -2263,7 +2263,6 @@ Logic Interface CSS
     margin: 10px 0 20px 0;
 }
 
-/* All child elements of popUpModalText that are h3 */
 .inputModalCardText h3 {
     margin: 0 0 28px 0;
     text-align: center;
@@ -2273,10 +2272,8 @@ Logic Interface CSS
     width: 100%;
 }
 
-/* All p elements that are siblings of h3 */
 .inputModalCardText p {
     margin: 0 5px 10px 5px;
-    /*text-align: left;*/
     font-size: 1rem;
     line-height: 1.5rem;
 }
@@ -2305,8 +2302,6 @@ Logic Interface CSS
     font-size: 22px;
     line-height: 32px;
     width: 100%;
-    /*display: flex;*/
-    /*flex-direction: column;*/
     margin: 10px 0 20px 0;
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -1803,6 +1803,10 @@ Logic Interface CSS
     height: 30px;
 }
 
+.avatarListIconMyAvatar {
+    cursor: pointer;
+}
+
 .avatarListIconImage {
     position: absolute;
     left: 0;

--- a/css/modal.css
+++ b/css/modal.css
@@ -46,6 +46,15 @@
     top: 26.5vh;
 }
 
+.classicModalTextInput {
+    position: absolute;
+    bottom: 200px;
+    left: 10%;
+    width: 80%;
+    line-height: 48px;
+    font-size: 1.2rem;
+}
+
 #modalCancel {
     left: 5vw;
     width: 15vw;
@@ -156,16 +165,29 @@
 
 /* Styles for 2D modal with grey background, header, description, and buttons */
 /* blurs the background behind the modal */
+/*#modalFadeClassic {*/
+/*    position: absolute;*/
+/*    top: 0;*/
+/*    left: 0;*/
+/*    width: 100vw;*/
+/*    height: 100vh;*/
+/*    background-color: rgba(0,0,0,0.2);*/
+/*    -webkit-backdrop-filter: blur(40px);*/
+/*    -webkit-transform: translateZ(8990px)*/
+/*}*/
+
 #modalFadeClassic {
     position: absolute;
     top: 0;
     left: 0;
     width: 100vw;
     height: 100vh;
-    background-color: rgba(0,0,0,0.2);
-    -webkit-backdrop-filter: blur(40px);
-    -webkit-transform: translateZ(8990px)
+    background-color: rgba(103, 103, 103, 0.4);
+    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
+    z-index: 100;
 }
+
 /* container for the modal */
 #modalContainerClassic {
     position: absolute;
@@ -191,6 +213,7 @@
     border-radius: 5px;
     background-color: rgba(255,255,255,0.7);
     -webkit-transform: translateZ(8995px);
+    z-index: 8995;
     color: black;
 }
 #modalHeaderClassic {

--- a/css/modal.css
+++ b/css/modal.css
@@ -165,17 +165,6 @@
 
 /* Styles for 2D modal with grey background, header, description, and buttons */
 /* blurs the background behind the modal */
-/*#modalFadeClassic {*/
-/*    position: absolute;*/
-/*    top: 0;*/
-/*    left: 0;*/
-/*    width: 100vw;*/
-/*    height: 100vh;*/
-/*    background-color: rgba(0,0,0,0.2);*/
-/*    -webkit-backdrop-filter: blur(40px);*/
-/*    -webkit-transform: translateZ(8990px)*/
-/*}*/
-
 #modalFadeClassic {
     position: absolute;
     top: 0;
@@ -213,7 +202,6 @@
     border-radius: 5px;
     background-color: rgba(255,255,255,0.7);
     -webkit-transform: translateZ(8995px);
-    z-index: 8995;
     color: black;
 }
 #modalHeaderClassic {

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -50,7 +50,7 @@ createNameSpace("realityEditor.avatar.draw");
 
             // it only makes sense to draw the laser beam on our own screen if at least one other user is connected
             let numConnectedAvatars = Object.keys(realityEditor.avatar.getConnectedAvatarList()).length;
-            if (numConnectedAvatars < 2) return;
+            if (numConnectedAvatars < 1) return;
 
             drawLaserBeam(myAvatarObject.objectId, null, realityEditor.avatar.utils.getColor(myAvatarObject), realityEditor.avatar.utils.getColorLighter(myAvatarObject), myAvatarTouchState.screenX, myAvatarTouchState.screenY);
         } catch (e) {
@@ -68,8 +68,8 @@ createNameSpace("realityEditor.avatar.draw");
             iconContainer.removeChild(iconContainer.lastChild);
         }
 
-        if (Object.keys(connectedAvatars).length < 2) {
-            return; // don't show my icon unless there is at least one other user connected
+        if (Object.keys(connectedAvatars).length < 1) {
+            return; // don't show unless there is at least one avatar
         }
 
         let sortedKeys = realityEditor.avatar.utils.sortAvatarList(connectedAvatars);
@@ -113,6 +113,34 @@ createNameSpace("realityEditor.avatar.draw");
             ['pointerout', 'pointercancel', 'pointerup'].forEach((eventName) => {
                 iconDiv.addEventListener(eventName, hideFullNameTooltip);
             });
+
+            if (isMyIcon) {
+                iconDiv.addEventListener('pointerup', (e) => {
+                    console.log('clicked on my icon - option to rename avatar?');
+                    // show a modal that lets you type in a name
+                    realityEditor.gui.modal.openInputModal({
+                        headerText: 'Edit Avatar Name',
+                        descriptionText: 'Specify the name that other users will see.',
+                        inputPlaceholderText: 'Your username here',
+                        // cancelButtonText: 'Cancel',
+                        // submitButtonText: 'Submit',
+                        onCancelCallback: (e) => {
+                            console.log('cancel edit name', e);
+                        },
+                        onSubmitCallback: (e, userName) => {
+                            console.log('submitted', userName);
+                            if (userName && typeof userName === 'string' && userName.length > 0) {
+                                console.log(`manually entered username myUserName ${userName}`);
+                                realityEditor.avatar.setMyUsername(userName);
+                                realityEditor.avatar.writeUsername(userName);
+                                // write to window.localStorage and use instead of anonymous in the future in this browser
+                                window.localStorage.setItem('manuallyEnteredUsername', userName);
+                            }
+                        },
+                        useSmallerVersion: true
+                    });
+                });
+            }
         });
 
         let iconsWidth = Math.min(MAX_ICONS, sortedKeys.length) * (ICON_WIDTH + ICON_GAP) - ICON_GAP;
@@ -140,6 +168,10 @@ createNameSpace("realityEditor.avatar.draw");
         let iconImg = document.createElement('img');
         iconImg.classList.add('avatarListIconImage');
         iconDiv.appendChild(iconImg);
+
+        if (isMyIcon) {
+            iconDiv.classList.add('avatarListIconMyAvatar');
+        }
 
         if (initials) {
             iconImg.src = 'svg/avatar-initials-background-dark.svg';
@@ -201,7 +233,7 @@ createNameSpace("realityEditor.avatar.draw");
         if (name) {
             nameDiv.innerText = isMyAvatar ? name + ' (you)' : name;
         } else {
-            nameDiv.innerText = isMyAvatar ? 'You (Anonymous)' : 'Anonymous';
+            nameDiv.innerText = isMyAvatar ? 'You (click to edit)' : 'Anonymous';
         }
         let width = Math.max(120, (nameDiv.innerText.length) * 12);
         nameDiv.style.width = width + 'px';

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -115,7 +115,7 @@ createNameSpace("realityEditor.avatar.draw");
             });
 
             if (isMyIcon) {
-                iconDiv.addEventListener('pointerup', (e) => {
+                iconDiv.addEventListener('pointerup', (_e) => {
                     console.log('clicked on my icon - option to rename avatar?');
                     // show a modal that lets you type in a name
                     realityEditor.gui.modal.openInputModal({
@@ -129,8 +129,7 @@ createNameSpace("realityEditor.avatar.draw");
                                 // write to window.localStorage and use instead of anonymous in the future in this browser
                                 window.localStorage.setItem('manuallyEnteredUsername', userName);
                             }
-                        },
-                        useSmallerVersion: true
+                        }
                     });
                 });
             }

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -122,15 +122,8 @@ createNameSpace("realityEditor.avatar.draw");
                         headerText: 'Edit Avatar Name',
                         descriptionText: 'Specify the name that other users will see.',
                         inputPlaceholderText: 'Your username here',
-                        // cancelButtonText: 'Cancel',
-                        // submitButtonText: 'Submit',
-                        onCancelCallback: (e) => {
-                            console.log('cancel edit name', e);
-                        },
                         onSubmitCallback: (e, userName) => {
-                            console.log('submitted', userName);
                             if (userName && typeof userName === 'string' && userName.length > 0) {
-                                console.log(`manually entered username myUserName ${userName}`);
                                 realityEditor.avatar.setMyUsername(userName);
                                 realityEditor.avatar.writeUsername(userName);
                                 // write to window.localStorage and use instead of anonymous in the future in this browser

--- a/src/avatar/draw.js
+++ b/src/avatar/draw.js
@@ -231,9 +231,9 @@ createNameSpace("realityEditor.avatar.draw");
         }
 
         if (name) {
-            nameDiv.innerText = isMyAvatar ? name + ' (you)' : name;
+            nameDiv.innerText = isMyAvatar ? name + ' (click to edit your name)' : name;
         } else {
-            nameDiv.innerText = isMyAvatar ? 'You (click to edit)' : 'Anonymous';
+            nameDiv.innerText = isMyAvatar ? 'You (click to edit your name)' : 'Anonymous';
         }
         let width = Math.max(120, (nameDiv.innerText.length) * 12);
         nameDiv.style.width = width + 'px';

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -39,7 +39,6 @@ createNameSpace("realityEditor.avatar");
     // if you set your name, and other clients will see your initials near the endpoint of your laser beam
     let isUsernameActive = false;
     let myUsername = window.localStorage.getItem('manuallyEnteredUsername') || null;
-    console.log(`myUsername = ${myUsername}`);
     let myProviderId = '';
 
     // these are used for raycasting against the environment when sending laser beams
@@ -75,13 +74,9 @@ createNameSpace("realityEditor.avatar");
         draw = realityEditor.avatar.draw;
         utils = realityEditor.avatar.utils;
 
-        console.log(`initService myUsername = ${myUsername}`);
-
         // begin creating our own avatar object when we localize within a world object
         realityEditor.worldObjects.onLocalizedWithinWorld(function(worldObjectKey) {
             if (worldObjectKey === realityEditor.worldObjects.getLocalWorldId()) { return; }
-
-            console.log(`initService myUsername = ${myUsername}`);
 
             // todo: for now, we don't create a new avatar object for each world we see, but in future we may want to
             //       migrate our existing avatar to the server hosting the current world object that we're looking at
@@ -512,14 +507,11 @@ createNameSpace("realityEditor.avatar");
     // you can set this even before the avatar has been created
     function setMyUsername(name) {
         myUsername = name;
-        console.log(`setMyUsername myUsername = ${name}`);
     }
 
     // name is one property within the avatar node's userProfile public data
     // avatar has to exist before calling this
     function writeUsername(name) {
-        console.log(`writeUsername myUsername = ${name}`);
-
         if (!myAvatarObject) { return; }
         connectedAvatarUserProfiles[myAvatarId].name = name;
         draw.updateAvatarName(myAvatarId, name);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -38,7 +38,8 @@ createNameSpace("realityEditor.avatar");
 
     // if you set your name, and other clients will see your initials near the endpoint of your laser beam
     let isUsernameActive = false;
-    let myUsername = null;
+    let myUsername = window.localStorage.getItem('manuallyEnteredUsername') || null;
+    console.log(`myUsername = ${myUsername}`);
     let myProviderId = '';
 
     // these are used for raycasting against the environment when sending laser beams
@@ -74,9 +75,13 @@ createNameSpace("realityEditor.avatar");
         draw = realityEditor.avatar.draw;
         utils = realityEditor.avatar.utils;
 
+        console.log(`initService myUsername = ${myUsername}`);
+
         // begin creating our own avatar object when we localize within a world object
         realityEditor.worldObjects.onLocalizedWithinWorld(function(worldObjectKey) {
             if (worldObjectKey === realityEditor.worldObjects.getLocalWorldId()) { return; }
+
+            console.log(`initService myUsername = ${myUsername}`);
 
             // todo: for now, we don't create a new avatar object for each world we see, but in future we may want to
             //       migrate our existing avatar to the server hosting the current world object that we're looking at
@@ -522,11 +527,14 @@ createNameSpace("realityEditor.avatar");
     // you can set this even before the avatar has been created
     function setMyUsername(name) {
         myUsername = name;
+        console.log(`setMyUsername myUsername = ${name}`);
     }
 
     // name is one property within the avatar node's userProfile public data
     // avatar has to exist before calling this
     function writeUsername(name) {
+        console.log(`writeUsername myUsername = ${name}`);
+
         if (!myAvatarObject) { return; }
         connectedAvatarUserProfiles[myAvatarId].name = name;
         draw.updateAvatarName(myAvatarId, name);
@@ -699,7 +707,8 @@ createNameSpace("realityEditor.avatar");
     exports.toggleDebugMode = toggleDebugMode;
     exports.getMyAvatarColor = getMyAvatarColor;
     exports.getAvatarColorFromProviderId = getAvatarColorFromProviderId;
-    exports.setMyUsername = setMyUsername;
+    exports.setMyUsername = setMyUsername; // this sets it preemptively if it doesn't exist yet
+    exports.writeUsername = writeUsername; // this propagates the data if it already exists
     exports.clearLinkCanvas = clearLinkCanvas;
     exports.getLinkCanvasInfo = getLinkCanvasInfo;
     exports.isDesktop = function() {return isDesktop};

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -37,7 +37,6 @@ createNameSpace("realityEditor.avatar");
     let lastBeamOnTimestamp = null;
 
     // if you set your name, and other clients will see your initials near the endpoint of your laser beam
-    let isUsernameActive = false;
     let myUsername = window.localStorage.getItem('manuallyEnteredUsername') || null;
     let myProviderId = '';
 

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -189,21 +189,6 @@ createNameSpace("realityEditor.avatar");
             network.processPendingAvatarInitializations(connectionStatus, cachedWorldObject, onOtherAvatarInitialized);
         });
 
-        const description = 'toggle on to show name to other users';
-        const propertyName = 'myUserName';
-        const iconSrc = '../../../svg/object.svg';
-        const defaultValue = false;
-        const placeholderText = '';
-        realityEditor.gui.settings.addToggleWithText('User Name', description, propertyName, iconSrc, defaultValue, placeholderText, (isToggled) => {
-            isUsernameActive = isToggled;
-            writeUsername(isToggled ? myUsername : null);
-        }, (text) => {
-            myUsername = text;
-            if (isUsernameActive) {
-                writeUsername(myUsername);
-            }
-        });
-
         setInterval(() => {
             if (myAvatarId && myAvatarObject) {
                 network.keepObjectAlive(myAvatarId);

--- a/src/gui/modal.js
+++ b/src/gui/modal.js
@@ -72,6 +72,7 @@ createNameSpace("realityEditor.gui.modal");
      * @param {string} submitButtonText
      * @param {function} onCancelCallback
      * @param {function} onSubmitCallback
+     * @param {boolean} useSmallerVersion
      */
     function openClassicModal(headerText, descriptionText, cancelButtonText, submitButtonText, onCancelCallback, onSubmitCallback, useSmallerVersion) {
         // create the instance of the modal
@@ -98,6 +99,50 @@ createNameSpace("realityEditor.gui.modal");
             event.stopPropagation();
         });
         
+        // present on the DOM
+        document.body.appendChild(domElements.fade);
+        document.body.appendChild(domElements.container);
+    }
+
+    function openInputModal({ headerText, descriptionText, inputPlaceholderText, cancelButtonText, submitButtonText, onCancelCallback, onSubmitCallback, useSmallerVersion }) {
+        // create the instance of the modal
+        // instantiate / modify the DOM elements
+        var domElements = createClassicModalDOM(useSmallerVersion);
+        domElements.header.innerHTML = headerText;
+        domElements.description.innerHTML = descriptionText;
+        domElements.cancelButton.innerHTML = cancelButtonText || 'Cancel';
+        domElements.submitButton.innerHTML = submitButtonText || 'Submit';
+        let inputField = document.createElement('input');
+        inputField.setAttribute('type', 'text');
+        if (inputPlaceholderText) {
+            inputField.setAttribute('placeholder', inputPlaceholderText);
+        }
+        inputField.classList.add('classicModalTextInput');
+        domElements.container.insertBefore(inputField, domElements.cancelButton);
+
+        realityEditor.device.keyboardEvents.openKeyboard(); // mark the keyboard as in-use until the modal disappears, so keyboard shortcuts are disabled
+        // realityEditor.device.environment.addSuppressedObjectRenderingFlag('inputModal'); // hide tools while modal is open
+
+        // attach callbacks to button pointer events + delete/hide when done
+        domElements.cancelButton.addEventListener('pointerup', function(event) {
+            realityEditor.device.keyboardEvents.closeKeyboard(); // release control of the keyboard
+            // realityEditor.device.environment.clearSuppressedObjectRenderingFlag('inputModal');
+            onCancelCallback(event);
+            hideModal(domElements);
+        });
+        domElements.submitButton.addEventListener('pointerup', function(event) {
+            realityEditor.device.keyboardEvents.closeKeyboard(); // release control of the keyboard
+            // realityEditor.device.environment.clearSuppressedObjectRenderingFlag('inputModal');
+            onSubmitCallback(event, inputField.value);
+            hideModal(domElements);
+        });
+
+        // disable touch actions elsewhere on the screen
+        // todo does this happen automatically from the fade element?
+        domElements.fade.addEventListener('pointerevent', function(event) {
+            event.stopPropagation();
+        });
+
         // present on the DOM
         document.body.appendChild(domElements.fade);
         document.body.appendChild(domElements.container);
@@ -136,7 +181,7 @@ createNameSpace("realityEditor.gui.modal");
 
     /**
      * Constructs the DOM and returns references to its elements
-     * @return {{fade: HTMLDivElement, container: HTMLDivElement, description: HTMLDivElement, cancelButton: HTMLDivElement, submitButton: HTMLDivElement}}
+     * @return {{fade: HTMLDivElement, container: HTMLDivElement, header: HTMLDivElement, description: HTMLDivElement, cancelButton: HTMLDivElement, submitButton: HTMLDivElement}}
      */
     function createClassicModalDOM(useSmallerCenteredVersion) {
         var fade = document.createElement('div'); // darkens/blurs the background
@@ -290,6 +335,7 @@ createNameSpace("realityEditor.gui.modal");
 
     exports.openClassicModal = openClassicModal;
     exports.openRealityModal = openRealityModal;
+    exports.openInputModal = openInputModal;
     exports.showSimpleNotification = showSimpleNotification;
     exports.showScreenTopNotification = showScreenTopNotification;
     

--- a/src/gui/modal.js
+++ b/src/gui/modal.js
@@ -104,7 +104,7 @@ createNameSpace("realityEditor.gui.modal");
         document.body.appendChild(domElements.container);
     }
 
-    function openInputModal({ headerText, descriptionText, inputPlaceholderText, cancelButtonText, submitButtonText, onCancelCallback, onSubmitCallback, useSmallerVersion }) {
+    function openInputModal({ headerText, descriptionText, inputPlaceholderText, cancelButtonText, submitButtonText, onCancelCallback, onSubmitCallback }) {
         // Add a blurry background that can be tapped on to cancel the modal
         let fade = document.createElement('div'); // darkens/blurs the background
         fade.id = 'modalFadeClassic';
@@ -116,28 +116,45 @@ createNameSpace("realityEditor.gui.modal");
         container.classList.add('inputModalCard');
         // container.classList.add('viewCard', 'center', 'popUpModal');
         let text = document.createElement('div');
+        let header = document.createElement('h3');
+        header.innerText = headerText;
+        text.appendChild(header);
+        let description = document.createElement('p');
+        description.innerText = descriptionText;
+        text.appendChild(description);
         text.classList.add('inputModalCardText');
-        text.innerHTML = `<h3>${headerText}</h3>
-        <p>${descriptionText}</p>`;
+
         let inputField = document.createElement('input');
         inputField.classList.add('inputModalCardInput');
         inputField.setAttribute('type', 'text');
         if (inputPlaceholderText) {
             inputField.setAttribute('placeholder', inputPlaceholderText);
         }
-        let submit = document.createElement('div');
-        submit.innerText = submitButtonText || 'Submit';
-        submit.classList.add('inputModalCardButton');
-        let cancel = document.createElement('div');
-        cancel.innerText = cancelButtonText || 'Cancel';
-        cancel.classList.add('inputModalCardButton', 'buttonLight');
-        cancel.style.marginBottom = '0';
+        inputField.addEventListener('keydown', (downEvent) => {
+            if (downEvent.key === 'Enter') {
+                hideModal();
+                if (onSubmitCallback) {
+                    onSubmitCallback(downEvent, inputField.value);
+                }
+            }
+        });
+
+        let submitButton = document.createElement('div');
+        submitButton.innerText = submitButtonText || 'Submit';
+        submitButton.classList.add('inputModalCardButton');
+        let cancelButton = document.createElement('div');
+        cancelButton.innerText = cancelButtonText || 'Cancel';
+        cancelButton.classList.add('inputModalCardButton', 'buttonLight');
+        cancelButton.style.marginBottom = '0';
+
         container.appendChild(text);
         container.appendChild(inputField);
-        container.appendChild(submit);
-        container.appendChild(cancel);
+        container.appendChild(submitButton);
+        container.appendChild(cancelButton);
         document.body.appendChild(container);
+
         realityEditor.device.keyboardEvents.openKeyboard(); // mark the keyboard as in-use until the modal disappears, so keyboard shortcuts are disabled
+        inputField.focus();
 
         const hideModal = () => {
             realityEditor.device.keyboardEvents.closeKeyboard(); // release control of the keyboard
@@ -146,7 +163,7 @@ createNameSpace("realityEditor.gui.modal");
         };
 
         // attach callbacks to button pointer events + delete/hide when done
-        [cancel, fade].forEach(elt => {
+        [cancelButton, fade].forEach(elt => {
             elt.addEventListener('pointerup', function(event) {
                 hideModal();
                 if (onCancelCallback) {
@@ -154,8 +171,8 @@ createNameSpace("realityEditor.gui.modal");
                 }
             });
         });
-        // tapping on the submit button sends the text input to the callback function
-        submit.addEventListener('pointerup', function(event) {
+        // tapping on the submitButton button sends the text input to the callback function
+        submitButton.addEventListener('pointerup', function(event) {
             hideModal();
             if (onSubmitCallback) {
                 onSubmitCallback(event, inputField.value);

--- a/src/gui/modal.js
+++ b/src/gui/modal.js
@@ -149,13 +149,17 @@ createNameSpace("realityEditor.gui.modal");
         [cancel, fade].forEach(elt => {
             elt.addEventListener('pointerup', function(event) {
                 hideModal();
-                onCancelCallback(event);
+                if (onCancelCallback) {
+                    onCancelCallback(event);
+                }
             });
         });
         // tapping on the submit button sends the text input to the callback function
         submit.addEventListener('pointerup', function(event) {
             hideModal();
-            onSubmitCallback(event, inputField.value);
+            if (onSubmitCallback) {
+                onSubmitCallback(event, inputField.value);
+            }
         });
     }
     


### PR DESCRIPTION
Brings up a modal to edit your username. Instantly propagates to other clients when you hit submit. Tested working on iOS app too. Saves name in browser localStorage and uses as default when you refresh the page if you're an anonymous user. Your signed-in username in the Manager overrides the saved value if you're signed in (the next time you refresh the page, but you can still edit for this session).

![Edit Username v1](https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/846da12c-785a-4fc1-a02e-a2676671ac05)

Fixes Issue #614 
