### PR TITLE
Remove ACES filmic tone mapping

### DIFF
--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -54,8 +54,6 @@ import { MapShaderSettingsUI } from "../measure/mapShaderSettingsUI.js";
         renderer = new THREE.WebGLRenderer({canvas: domElement, alpha: true, antialias: false});
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.setSize(rendererWidth, rendererHeight);
-        renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        renderer.toneMappingExposure = 1.0;
         renderer.outputEncoding = THREE.sRGBEncoding;
         renderer.autoClear = false;
 


### PR DESCRIPTION
It brings a bit of drama to the scan lighting but we're not in the business of drama