### PR TITLE
hide recently-used canvas on AR app, since it was causing weird blend mode bug

### DIFF
--- a/src/gui/recentlyUsedBar.js
+++ b/src/gui/recentlyUsedBar.js
@@ -362,8 +362,28 @@ class RecentlyUsedBar {
         }
     }
 
+    // we hide the ru-canvas in the AR app, to fix a very strange blend-mode bug noticed on iOS 17.4, iPhone 15 Pro Max
+    fixDeviceSpecificBlendModeBug() {
+        if (realityEditor.device.environment.isWithinToolboxApp()) {
+            if (!this.canvas.classList.contains('hidden')) {
+                this.canvas.classList.add('hidden');
+            }
+            return true;
+        }
+        if (this.canvas.classList.contains('hidden')) {
+            this.canvas.classList.remove('hidden');
+        }
+        return false;
+    }
+
     renderCanvas() {
         try {
+            if (this.fixDeviceSpecificBlendModeBug()) {
+                // don't render if the canvas is hidden - this will cancel the requestAnimationFrame loop
+                // once it's been detected once, which should be ok.
+                return;
+            }
+
             if (this.canvasHasContent) {
                 this.ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
             }


### PR DESCRIPTION
Addresses issue #645 by hiding the canvas that was causing the issues (since the canvas actually isn't really needed in the iOS app anyways, as it just renders the little white lines pointing to each app icon when you hover your mouse over the recently used tool icon bar).

I've tested that this fixes the issue, but I'm not quite satisfied with this solution since I don't understand why this canvas would be causing issues in the first place, as it doesn't have any blend mode applied to it as far as I can see.

Any ideas as to what the root cause might be? I can look into it further another day, but I'll open this thread for now.