### PR TITLE
Human tracking filtering low confidence joints

### DIFF
--- a/src/humanPose/AccelerationLens.js
+++ b/src/humanPose/AccelerationLens.js
@@ -3,8 +3,11 @@ import {MotionStudyLens} from "./MotionStudyLens.js";
 import {MotionStudyColors} from "./MotionStudyColors.js";
 import {JOINTS} from "./constants.js";
 
-const HIGH_CUTOFF = 35 // In m/s^2
-const MED_CUTOFF = 15 // In m/s^2
+const HIGH_CUTOFF = 35; // in m/s^2
+const MED_CUTOFF = 15; // in m/s^2
+
+export const MIN_ACCELERATION = 0; // in m/s^2
+export const MAX_ACCELERATION = 40; // in m/s^2
 
 /**
  * AccelerationLens is a lens that calculates the acceleration of each joint in the pose history.

--- a/src/humanPose/AccelerationLens.js
+++ b/src/humanPose/AccelerationLens.js
@@ -35,7 +35,7 @@ export class AccelerationLens extends MotionStudyLens {
      * @return {boolean} True if the joint has had its acceleration calculated, false otherwise.
      */
     accelerationAppliedToJoint(joint) {
-        return joint.acceleration && joint.accelerationMagnitude && joint.accelerationMagnitude !== -1
+        return joint.acceleration && joint.accelerationMagnitude && joint.accelerationMagnitude !== -1;
     }
     
     applyLensToPose(pose) {

--- a/src/humanPose/AccelerationLens.js
+++ b/src/humanPose/AccelerationLens.js
@@ -141,6 +141,7 @@ export class AccelerationLens extends MotionStudyLens {
     }
     
     getColorForPose(pose) {
+        // 'head' joint is always valid when body is tracked. Thus, acceleration is calculated under normal circumstances.
         if (!this.accelerationAppliedToJoint(pose.getJoint(JOINTS.HEAD))) {
             return MotionStudyColors.undefined;
         }

--- a/src/humanPose/AccelerationLens.js
+++ b/src/humanPose/AccelerationLens.js
@@ -26,7 +26,7 @@ export class AccelerationLens extends MotionStudyLens {
      * @return {boolean} True if the joint has had its velocity calculated, false otherwise.
      */
     velocityAppliedToJoint(joint) {
-        return joint.velocity && joint.speed > 0.000001;
+        return joint.velocity && joint.speed && joint.speed !== -1;
     }
 
     /**
@@ -35,7 +35,7 @@ export class AccelerationLens extends MotionStudyLens {
      * @return {boolean} True if the joint has had its acceleration calculated, false otherwise.
      */
     accelerationAppliedToJoint(joint) {
-        return joint.acceleration && joint.accelerationMagnitude > 0.000001
+        return joint.acceleration && joint.accelerationMagnitude && joint.accelerationMagnitude !== -1
     }
     
     applyLensToPose(pose) {
@@ -45,9 +45,9 @@ export class AccelerationLens extends MotionStudyLens {
             pose.forEachJoint(joint => {
                 // Velocity and acceleration are zero for the first pose
                 joint.velocity = new THREE.Vector3(); 
-                joint.speed = 0;
+                joint.speed = -1; // -1 means that the metric cannot calculated based on data
                 joint.acceleration = new THREE.Vector3();
-                joint.accelerationMagnitude = 0;
+                joint.accelerationMagnitude = -1; // -1 means that the metric cannot calculated based on data
             });
         } else if (!previousPreviousPose) {
             pose.forEachJoint(joint => {
@@ -55,15 +55,15 @@ export class AccelerationLens extends MotionStudyLens {
                 if (!joint.valid || !previousJoint.valid) {
                     // Velocity and acceleration are zero if a joint is invalid in current or previous pose
                     joint.velocity = new THREE.Vector3();
-                    joint.speed = 0;
+                    joint.speed = -1;
                     joint.acceleration = new THREE.Vector3();
-                    joint.accelerationMagnitude = 0;
+                    joint.accelerationMagnitude = -1;
                 } else {  // joint.valid == true && previousJoint.valid == true 
                     joint.velocity = joint.position.clone().sub(previousJoint.position).divideScalar(pose.timestamp - previousPose.timestamp); // mm/ms = m/s
                     joint.speed = joint.velocity.length();
                     // Acceleration is zero for the second pose
                     joint.acceleration = new THREE.Vector3(); 
-                    joint.accelerationMagnitude = 0;
+                    joint.accelerationMagnitude = -1;
                 }
             });
         } else {
@@ -73,15 +73,15 @@ export class AccelerationLens extends MotionStudyLens {
                 if (!joint.valid || !previousJoint.valid) {
                     // Velocity and acceleration are zero if a joint is invalid in current or previous pose
                     joint.velocity = new THREE.Vector3();
-                    joint.speed = 0;
+                    joint.speed = -1;
                     joint.acceleration = new THREE.Vector3();
-                    joint.accelerationMagnitude = 0;
+                    joint.accelerationMagnitude = -1;
                 } else if (!previousPreviousJoint.valid) {   // joint.valid == true && previousJoint.valid == true
                     joint.velocity = joint.position.clone().sub(previousJoint.position).divideScalar(pose.timestamp - previousPose.timestamp); // mm/ms = m/s
                     joint.speed = joint.velocity.length();
                     // Acceleration is zero if a joint is invalid in previous previous pose
                     joint.acceleration = new THREE.Vector3();
-                    joint.accelerationMagnitude = 0;
+                    joint.accelerationMagnitude = -1;
                 } else {  // joint.valid == true && previousJoint.valid == true && previousPreviousJoint.valid == true
                     joint.velocity = joint.position.clone().sub(previousJoint.position).divideScalar(pose.timestamp - previousPose.timestamp); // mm/ms = m/s
                     joint.speed = joint.velocity.length();
@@ -125,7 +125,7 @@ export class AccelerationLens extends MotionStudyLens {
     }
 
     getColorForJoint(joint) {
-        if (typeof joint.accelerationMagnitude !== "number") {
+        if (!this.accelerationAppliedToJoint(joint)) {
             return MotionStudyColors.undefined;
         }
         const acceleration = joint.accelerationMagnitude;
@@ -133,7 +133,7 @@ export class AccelerationLens extends MotionStudyLens {
     }
 
     getColorForBone(bone) {
-        if (typeof bone.joint0.accelerationMagnitude !== "number" || typeof bone.joint1.accelerationMagnitude !== "number") {
+        if (!this.accelerationAppliedToJoint(bone.joint0) || !this.accelerationAppliedToJoint(bone.joint1)) {
             return MotionStudyColors.undefined;
         }
         const maxAcceleration = Math.max(bone.joint0.accelerationMagnitude, bone.joint1.accelerationMagnitude);
@@ -141,7 +141,7 @@ export class AccelerationLens extends MotionStudyLens {
     }
     
     getColorForPose(pose) {
-        if (typeof pose.getJoint(JOINTS.HEAD).accelerationMagnitude !== "number") {
+        if (!this.accelerationAppliedToJoint(pose.getJoint(JOINTS.HEAD))) {
             return MotionStudyColors.undefined;
         }
         let maxAcceleration = 0;

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -398,7 +398,7 @@ export class HumanPoseAnalyzer {
             const timestamp = pose.timestamp;
             const id = pose.metadata.poseObjectId;
             let currentPoint = pose.getJoint(JOINTS.HEAD).position.clone();
-            currentPoint.y += 400;
+            currentPoint.y += 400; // mm
             if (!this.historyLines[lens.name].all.hasOwnProperty(id)) {
                 this.createSpaghetti(lens, id, historical);
             }
@@ -565,6 +565,7 @@ export class HumanPoseAnalyzer {
         this.jointConfidenceThreshold = confidence;
         console.info('jointConfidenceThreshold=', confidence);
 
+        // update all poses and derived clones for visualisation
         [this.clones.live, this.clones.historical].forEach(relevantClones => {
             relevantClones.forEach(clone => clone.pose.setBodyPartValidity(this.jointConfidenceThreshold));
             // lens calculations need to be updated based on changed valid attribute of joints
@@ -583,7 +584,13 @@ export class HumanPoseAnalyzer {
                 clone.renderer.markColorNeedsUpdate();
             });
             
-        });        
+        }); 
+        
+        // update all spaghetti lines
+        this.lenses.forEach(lens => {
+           this.reprocessSpaghettiForLens(lens);
+        });
+
     }
 
     getJointConfidenceThreshold() {

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -565,11 +565,10 @@ export class HumanPoseAnalyzer {
         this.jointConfidenceThreshold = confidence;
         console.info('jointConfidenceThreshold=', confidence);
 
-        // TODO: what about other lenses?
         [this.clones.live, this.clones.historical].forEach(relevantClones => {
             relevantClones.forEach(clone => clone.pose.setBodyPartValidity(this.jointConfidenceThreshold));
-            // TODO: enable when lens also use valid attribute
-            // const posesChanged = this.activeLens.applyLensToHistory(relevantClones.map(clone => clone.pose));
+            // results from current lens need to be updated based on changed valid attribute of joints
+            this.activeLens.applyLensToHistory(relevantClones.map(clone => clone.pose));
             relevantClones.forEach(clone => {
                 if (clone.visible) {
                     clone.updateJointPositions();

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -567,8 +567,12 @@ export class HumanPoseAnalyzer {
 
         [this.clones.live, this.clones.historical].forEach(relevantClones => {
             relevantClones.forEach(clone => clone.pose.setBodyPartValidity(this.jointConfidenceThreshold));
-            // results from current lens need to be updated based on changed valid attribute of joints
-            this.activeLens.applyLensToHistory(relevantClones.map(clone => clone.pose));
+            // lens calculations need to be updated based on changed valid attribute of joints
+            let poses = relevantClones.map(clone => clone.pose);
+            this.lenses.forEach(lens => {
+                // need to upate whole history, although it takes a bit of time
+                lens.applyLensToHistory(poses, true /* force */); 
+            });
             relevantClones.forEach(clone => {
                 if (clone.visible) {
                     clone.updateJointPositions();

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -65,7 +65,7 @@ export class HumanPoseAnalyzer {
         // auxiliary human objects supporting fused human objects
         this.childHumanObjectsVisible = false;
 
-        this.jointConfidenceThreshold = 0.2;
+        this.jointConfidenceThreshold = 0.25;
 
         this.historyLines = {}; // Dictionary of {lensName: {(all | historical | live): Spaghetti}}, separated by historical and live
         this.historyLineContainers = {
@@ -591,6 +591,7 @@ export class HumanPoseAnalyzer {
            this.reprocessSpaghettiForLens(lens);
         });
 
+        this.motionStudy.updateRegionCards();
     }
 
     getJointConfidenceThreshold() {

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -1,5 +1,5 @@
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
-import {DISPLAY_INVALID_ELEMENTS, JOINTS} from './constants.js';
+import {JOINTS, JOINT_CONFIDENCE_THRESHOLD} from './constants.js';
 import {Spaghetti} from './spaghetti.js';
 import {RebaLens} from "./RebaLens.js";
 import {OverallRebaLens} from "./OverallRebaLens.js";
@@ -65,7 +65,7 @@ export class HumanPoseAnalyzer {
         // auxiliary human objects supporting fused human objects
         this.childHumanObjectsVisible = false;
 
-        this.jointConfidenceThreshold = 0.25;
+        this.jointConfidenceThreshold = JOINT_CONFIDENCE_THRESHOLD;
 
         this.historyLines = {}; // Dictionary of {lensName: {(all | historical | live): Spaghetti}}, separated by historical and live
         this.historyLineContainers = {
@@ -194,7 +194,8 @@ export class HumanPoseAnalyzer {
         this.settingsUi.setHistoricalHistoryLinesVisible(this.historicalHistoryLineContainer.visible);
         this.settingsUi.setActiveJointByName(this.activeJointName);
         this.settingsUi.setChildHumanPosesVisible(this.childHumanObjectsVisible);
-        this.settingsUi.setJointConfidenceThreshold(this.jointConfidenceThreshold);
+        this.settingsUi.setJointConfidenceFilter(true);
+        //this.settingsUi.setJointConfidenceThreshold(this.jointConfidenceThreshold);
     }
 
     /**
@@ -563,7 +564,7 @@ export class HumanPoseAnalyzer {
 
     setJointConfidenceThreshold(confidence) {
         this.jointConfidenceThreshold = confidence;
-        console.info('jointConfidenceThreshold=', confidence);
+        //console.info('jointConfidenceThreshold=', confidence);
 
         // update all poses and derived clones for visualisation
         [this.clones.live, this.clones.historical].forEach(relevantClones => {

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -583,6 +583,10 @@ export class HumanPoseAnalyzer {
         });        
     }
 
+    getJointConfidenceThreshold() {
+        return this.jointConfidenceThreshold;
+    }
+
     /**
      * Sets the active lens
      * @param {MotionStudyLens} lens - the lens to set as active

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -330,7 +330,9 @@ export class HumanPoseAnalyzer {
         } else {
             this.clones.live.push(poseRenderInstance);
         }
-        poseRenderInstance.setPose(pose, this.jointConfidenceThreshold); // Needs to be set before visible is set, setting a pose always makes visible at the moment
+        
+        pose.setBodyPartValidity(this.jointConfidenceThreshold); // Needs to be called before setPose(), because it sets internal attributes needed by setPose() 
+        poseRenderInstance.setPose(pose); // Needs to be set before visible is set, setting a pose always makes visible at the moment
         const canBeVisible = this.childHumanObjectsVisible || !pose.metadata.poseHasParent;
         if (this.animationMode === AnimationMode.all) {
             poseRenderInstance.setVisible(canBeVisible);
@@ -562,12 +564,10 @@ export class HumanPoseAnalyzer {
     setJointConfidenceThreshold(confidence) {
         this.jointConfidenceThreshold = confidence;
         console.info('jointConfidenceThreshold=', confidence);
-        //this.reprocessLens(this.activeLens, true);
-        //this.applyCurrentLensToHistory(true); 
 
         // TODO: what about other lenses?
         [this.clones.live, this.clones.historical].forEach(relevantClones => {
-            relevantClones.forEach(clone => clone.updateBodyPartValidity(this.jointConfidenceThreshold));
+            relevantClones.forEach(clone => clone.pose.setBodyPartValidity(this.jointConfidenceThreshold));
             // TODO: enable when lens also use valid attribute
             // const posesChanged = this.activeLens.applyLensToHistory(relevantClones.map(clone => clone.pose));
             relevantClones.forEach(clone => {

--- a/src/humanPose/HumanPoseAnalyzer.js
+++ b/src/humanPose/HumanPoseAnalyzer.js
@@ -65,7 +65,7 @@ export class HumanPoseAnalyzer {
         // auxiliary human objects supporting fused human objects
         this.childHumanObjectsVisible = false;
 
-        this.jointConfidenceThreshold = 0.0;
+        this.jointConfidenceThreshold = 0.2;
 
         this.historyLines = {}; // Dictionary of {lensName: {(all | historical | live): Spaghetti}}, separated by historical and live
         this.historyLineContainers = {
@@ -311,6 +311,14 @@ export class HumanPoseAnalyzer {
         this.bulkUpdateSpaghetti(poses, true);
     }
 
+    markValidBodyParts(pose) {
+        // TODO: limit to limbs
+        // TODO: add adjacent bones
+        pose.forEachJoint(joint => {
+            joint.valid = (joint.confidence >= this.jointConfidenceThreshold);
+        });
+    }
+
     /**
      * Creates a new clone from a pose and adds it to the analyzer
      * @param {Pose} pose - the pose to clone
@@ -330,6 +338,7 @@ export class HumanPoseAnalyzer {
         } else {
             this.clones.live.push(poseRenderInstance);
         }
+        this.markValidBodyParts(pose)
         poseRenderInstance.setPose(pose); // Needs to be set before visible is set, setting a pose always makes visible at the moment
         const canBeVisible = this.childHumanObjectsVisible || !pose.metadata.poseHasParent;
         if (this.animationMode === AnimationMode.all) {
@@ -561,7 +570,6 @@ export class HumanPoseAnalyzer {
 
     setJointConfidenceThreshold(confidence) {
         this.jointConfidenceThreshold = confidence;
-        this.poseObjectIdLens.setJointConfidenceThreshold(confidence);
         console.info('jointConfidenceThreshold=', confidence);
         this.reprocessLens(this.activeLens, true);
         //this.applyCurrentLensToHistory(true); 

--- a/src/humanPose/HumanPoseAnalyzerSettingsUi.js
+++ b/src/humanPose/HumanPoseAnalyzerSettingsUi.js
@@ -28,6 +28,10 @@ export class HumanPoseAnalyzerSettingsUi {
                             <div class="hpa-settings-section-row-label">View auxiliary poses</div>
                             <input type="checkbox" class="hpa-settings-section-row-checkbox" id="hpa-settings-toggle-child-human-poses">
                         </div>
+                        <div class="hpa-settings-section-row">
+                            <div class="hpa-settings-section-row-label">Set joint confidence</div>
+                            <input type="text" id="hpa-settings-set-joint-confidence">
+                        </div>
                     </div>
                 </div>
                 <div class="hpa-settings-section hidden" id="hpa-live-settings">
@@ -146,6 +150,24 @@ export class HumanPoseAnalyzerSettingsUi {
 
         this.root.querySelector('#hpa-settings-select-lens').addEventListener('change', (event) => {
             this.humanPoseAnalyzer.setActiveLensByName(event.target.value);
+        });
+       
+        this.root.querySelector('#hpa-settings-set-joint-confidence').addEventListener('keydown', (event) => {
+            event.stopPropagation();
+        });
+
+        this.root.querySelector('#hpa-settings-set-joint-confidence').addEventListener('change', (event) => {
+            let num = parseFloat(event.target.value);
+            if(!isNaN(num)) {
+                if (num < 0.0) {
+                    num = 0.0;
+                }
+                if (num > 1.0) {
+                    num = 1.0;
+                }
+                this.humanPoseAnalyzer.setJointConfidenceThreshold(num);
+                this.setJointConfidenceThreshold(num);
+            }
         });
         
         this.root.querySelector('#hpa-settings-select-joint').addEventListener('change', (event) => {
@@ -302,6 +324,10 @@ export class HumanPoseAnalyzerSettingsUi {
 
     setActiveJointByName(_jointName) {
         // this.root.querySelector('#hpa-settings-select-joint').value = jointName; // TODO: re-add once implemented
+    }
+
+    setJointConfidenceThreshold(confidence) {
+        this.root.querySelector('#hpa-settings-set-joint-confidence').value = confidence;
     }
     
     markLive() {

--- a/src/humanPose/HumanPoseAnalyzerSettingsUi.js
+++ b/src/humanPose/HumanPoseAnalyzerSettingsUi.js
@@ -1,4 +1,4 @@
-import {JOINTS} from "./constants.js";
+import {JOINTS, JOINT_CONFIDENCE_THRESHOLD} from './constants.js';
 import {setChildHumanPosesVisible} from "./draw.js"
 
 export class HumanPoseAnalyzerSettingsUi {
@@ -29,8 +29,10 @@ export class HumanPoseAnalyzerSettingsUi {
                             <input type="checkbox" class="hpa-settings-section-row-checkbox" id="hpa-settings-toggle-child-human-poses">
                         </div>
                         <div class="hpa-settings-section-row">
-                            <div class="hpa-settings-section-row-label">Set joint confidence</div>
-                            <input type="text" id="hpa-settings-set-joint-confidence">
+ <!--                       <div class="hpa-settings-section-row-label">Set joint confidence</div> -->
+ <!--                       <input type="text" id="hpa-settings-set-joint-confidence"> --> 
+                            <div class="hpa-settings-section-row-label">Filter unreliable joints</div>
+                            <input type="checkbox" class="hpa-settings-section-row-checkbox" id="hpa-settings-toggle-joint-confidence">
                         </div>
                     </div>
                 </div>
@@ -152,10 +154,12 @@ export class HumanPoseAnalyzerSettingsUi {
             this.humanPoseAnalyzer.setActiveLensByName(event.target.value);
         });
        
+        /*
+        // for debugging purposes
         this.root.querySelector('#hpa-settings-set-joint-confidence').addEventListener('keydown', (event) => {
             event.stopPropagation();
         });
-
+        
         this.root.querySelector('#hpa-settings-set-joint-confidence').addEventListener('change', (event) => {
             let num = parseFloat(event.target.value);
             if(!isNaN(num)) {
@@ -167,6 +171,16 @@ export class HumanPoseAnalyzerSettingsUi {
                 }
                 this.humanPoseAnalyzer.setJointConfidenceThreshold(num);
                 this.setJointConfidenceThreshold(num);
+            }
+        });
+        */
+
+        this.root.querySelector('#hpa-settings-toggle-joint-confidence').addEventListener('change', (event) => {
+            if (event.target.checked) {
+                this.humanPoseAnalyzer.setJointConfidenceThreshold(JOINT_CONFIDENCE_THRESHOLD);
+            }
+            else {
+                this.humanPoseAnalyzer.setJointConfidenceThreshold(0.0);
             }
         });
         
@@ -326,8 +340,14 @@ export class HumanPoseAnalyzerSettingsUi {
         // this.root.querySelector('#hpa-settings-select-joint').value = jointName; // TODO: re-add once implemented
     }
 
+    /*
+    // for debugging purposes
     setJointConfidenceThreshold(confidence) {
         this.root.querySelector('#hpa-settings-set-joint-confidence').value = confidence;
+    }
+    */
+    setJointConfidenceFilter(filterOn) {
+        this.root.querySelector('#hpa-settings-toggle-joint-confidence').checked = filterOn;
     }
     
     markLive() {

--- a/src/humanPose/HumanPoseRenderInstance.js
+++ b/src/humanPose/HumanPoseRenderInstance.js
@@ -3,7 +3,6 @@ import {
     JOINT_TO_INDEX,
     BONE_TO_INDEX,
     SCALE,
-    RENDER_CONFIDENCE_COLOR,
     HIDDEN_JOINTS,
     HIDDEN_BONES,
     DISPLAY_HIDDEN_ELEMENTS,
@@ -223,7 +222,7 @@ export class HumanPoseRenderInstance {
         });
         // MK - why this condition (lens === this.lens)? When switching lens this is not true and this is not applied. 
         // Extra code needs to call this again after this.lens is updated to new lens.  
-        if (lens === this.lens && !RENDER_CONFIDENCE_COLOR) {
+        if (lens === this.lens) {
             this.pose.forEachJoint(joint => {
                 this.setJointColor(joint.name, this.lensColors[this.lens.name].joints[JOINT_TO_INDEX[joint.name]]);
             });
@@ -231,21 +230,6 @@ export class HumanPoseRenderInstance {
                 this.setBoneColor(bone.name, this.lensColors[this.lens.name].bones[BONE_TO_INDEX[bone.name]]);
             });
         }
-    }
-
-    /**
-     * Sets joint color using pose confidence
-     * @param {string} jointName - name of joint to set color of
-     * @param {number} confidence - confidence value to set color to
-     */
-    setJointConfidenceColor(jointName, confidence) {
-        if (typeof JOINT_TO_INDEX[jointName] === 'undefined') {
-            return;
-        }
-        let baseColorHSL = MotionStudyColors.base.getHSL({});
-        baseColorHSL.l = baseColorHSL.l * confidence;
-        let color = new THREE.Color().setHSL(baseColorHSL.h, baseColorHSL.s, baseColorHSL.l);
-        this.setJointColor(jointName, color);
     }
 
     setVisible(visible) {

--- a/src/humanPose/HumanPoseRenderInstance.js
+++ b/src/humanPose/HumanPoseRenderInstance.js
@@ -214,7 +214,12 @@ export class HumanPoseRenderInstance {
         });
         if (lens === this.lens && !RENDER_CONFIDENCE_COLOR) {
             this.pose.forEachJoint(joint => {
-                this.setJointColor(joint.name, this.lensColors[this.lens.name].joints[JOINT_TO_INDEX[joint.name]]);
+                if (joint.valid) {
+                    this.setJointColor(joint.name, this.lensColors[this.lens.name].joints[JOINT_TO_INDEX[joint.name]]);
+                }
+                else {
+                    this.setJointColor(joint.name, MotionStudyColors.undefined);
+                }
             });
             this.pose.forEachBone(bone => {
                 this.setBoneColor(bone.name, this.lensColors[this.lens.name].bones[BONE_TO_INDEX[bone.name]]);

--- a/src/humanPose/HumanPoseRenderInstance.js
+++ b/src/humanPose/HumanPoseRenderInstance.js
@@ -141,7 +141,8 @@ export class HumanPoseRenderInstance {
 
         this.pose.forEachBone(bone => {
             // hides hands in general at the moment. But one could use this also for hiding joints based on their low confidence.
-            let visible = DISPLAY_HIDDEN_ELEMENTS || !HIDDEN_BONES.includes(bone.name);
+            let visible = (DISPLAY_HIDDEN_ELEMENTS || !HIDDEN_BONES.includes(bone.name)) && 
+                          (DISPLAY_INVALID_ELEMENTS || bone.valid);
             this.updateBonePosition(bone, visible);
         });
     }
@@ -216,6 +217,9 @@ export class HumanPoseRenderInstance {
         });
         this.pose.forEachBone(bone => {
             this.lensColors[lens.name].bones[BONE_TO_INDEX[bone.name]] = lens.getColorForBone(bone);
+            if (!bone.valid) {
+                this.lensColors[lens.name].bones[BONE_TO_INDEX[bone.name]] = MotionStudyColors.undefined;
+            }
         });
         // MK - why this condition (lens === this.lens)? When switching lens this is not true and this is not applied. 
         // Extra code needs to call this again after this.lens is updated to new lens.  
@@ -282,7 +286,6 @@ export class HumanPoseRenderInstance {
      * @param {HumanPoseRenderInstance} other - the instance to copy from
      */
     copy(other) {
-        console.info('Copy ts=', other.pose.timestamp);
         this.lens = other.lens;
         this.lensColors = {};
         Object.keys(other.lensColors).forEach(lensName => {

--- a/src/humanPose/HumanPoseRenderInstance.js
+++ b/src/humanPose/HumanPoseRenderInstance.js
@@ -146,23 +146,12 @@ export class HumanPoseRenderInstance {
         });
     }
 
-    updateBodyPartValidity(jointConfidenceThreshold) {
-        // TODO: limit to limbs
-        // TODO: add adjacent bones
-        this.pose.forEachJoint(joint => {
-            joint.valid = (joint.confidence >= jointConfidenceThreshold);
-        });
-    }
-
     /**
      * Updates the pose displayed by the pose renderer
      * @param {Pose} pose The pose to display
      */
-    setPose(pose, jointConfidenceThreshold = 0.0) {
+    setPose(pose) {
         this.pose = pose;
-
-        // needs to be called before other updates becasue it generates data they use
-        this.updateBodyPartValidity(jointConfidenceThreshold); 
 
         this.updateJointPositions();
         this.updateBonePositions();
@@ -292,7 +281,7 @@ export class HumanPoseRenderInstance {
      * Copy all elements of the other pose render instance
      * @param {HumanPoseRenderInstance} other - the instance to copy from
      */
-    copy(other, jointConfidenceThreshold = 0) {
+    copy(other) {
         console.info('Copy ts=', other.pose.timestamp);
         this.lens = other.lens;
         this.lensColors = {};
@@ -302,7 +291,7 @@ export class HumanPoseRenderInstance {
                 bones: other.lensColors[lensName].bones.slice(),
             };
         });
-        this.setPose(other.pose, jointConfidenceThreshold);
+        this.setPose(other.pose);
         return this;
     }
 

--- a/src/humanPose/MotionStudyLens.js
+++ b/src/humanPose/MotionStudyLens.js
@@ -24,7 +24,7 @@ export class MotionStudyLens {
      * @param {Pose} _pose The pose to apply the lens to.
      * @return {boolean} True if the pose was modified, false otherwise.
      */
-    applyLensToPose(_pose) {
+    applyLensToPose(_pose, _force = false) {
         return false;
     }
 
@@ -33,7 +33,7 @@ export class MotionStudyLens {
      * @param {Pose[]} poseHistory An array of pose objects.
      * @return {boolean[]} An array of booleans, one for each pose in the history, indicating whether the pose was modified.
      */
-    applyLensToHistoryMinimally(poseHistory) {
+    applyLensToHistoryMinimally(poseHistory, _force = false) {
         return poseHistory.map(() => false);
     }
 
@@ -42,7 +42,7 @@ export class MotionStudyLens {
      * @param {Pose[]} poseHistory An array of pose objects.
      * @return {boolean[]} An array of booleans, one for each pose in the history, indicating whether the pose was modified.
      */
-    applyLensToHistory(poseHistory) {
+    applyLensToHistory(poseHistory, _force = false) {
         return poseHistory.map(() => false);
     }
 

--- a/src/humanPose/OverallRebaLens.js
+++ b/src/humanPose/OverallRebaLens.js
@@ -14,8 +14,8 @@ export class OverallRebaLens extends MotionStudyLens {
         super("REBA Ergonomics (Overall)");
     }
     
-    applyLensToPose(pose) {
-        if (Object.values(pose.joints).every(joint => joint.overallRebaScore)) {
+    applyLensToPose(pose, force = false) {
+        if (!force && Object.values(pose.joints).every(joint => joint.overallRebaScore)) {
             return false;
         }
         const rebaData = Reba.calculateForPose(pose);
@@ -30,16 +30,16 @@ export class OverallRebaLens extends MotionStudyLens {
         return true;
     }
 
-    applyLensToHistoryMinimally(poseHistory) {
-        const modified = this.applyLensToPose(poseHistory[poseHistory.length - 1]);
+    applyLensToHistoryMinimally(poseHistory, force = false) {
+        const modified = this.applyLensToPose(poseHistory[poseHistory.length - 1], force);
         const modifiedArray = poseHistory.map(() => false);
         modifiedArray[modifiedArray.length - 1] = modified;
         return modifiedArray;
     }
 
-    applyLensToHistory(poseHistory) {
+    applyLensToHistory(poseHistory, force = false) {
         return poseHistory.map(pose => {
-            return this.applyLensToPose(pose);
+            return this.applyLensToPose(pose, force);
         });
     }
 

--- a/src/humanPose/OverallRebaLens.js
+++ b/src/humanPose/OverallRebaLens.js
@@ -3,6 +3,9 @@ import * as Reba from "./rebaScore.js";
 import {MotionStudyColors} from "./MotionStudyColors.js";
 import {JOINTS} from "./constants.js";
 
+export const MIN_REBA_SCORE = 1;
+export const MAX_REBA_SCORE = 12;
+
 /**
  * OverallRebaLens is a lens that calculates the overall REBA score for the pose
  */

--- a/src/humanPose/Pose.js
+++ b/src/humanPose/Pose.js
@@ -3,7 +3,7 @@
  * It keeps track of the positions of each joint in the pose.
  * It also keeps track of the timestamp of when the pose was recorded.
  */
-import {JOINT_CONNECTIONS} from "./constants.js";
+import {JOINT_CONNECTIONS, JOINTS, LEFT_HAND_JOINTS, RIGHT_HAND_JOINTS} from "./constants.js";
 
 export class Pose {
     /**
@@ -76,11 +76,51 @@ export class Pose {
     }
 
     setBodyPartValidity(jointConfidenceThreshold) {
-        // TODO: limit to limbs
-        // TODO: add adjacent bones
-        this.forEachJoint(joint => {
-            joint.valid = (joint.confidence >= jointConfidenceThreshold);
+
+        // compute validity only for limbs (head and torso are valid by default)
+        const limbJoints = [JOINTS.LEFT_ANKLE, JOINTS.LEFT_KNEE, 
+                      JOINTS.RIGHT_ANKLE, JOINTS.RIGHT_KNEE,
+                      JOINTS.LEFT_ELBOW, JOINTS.LEFT_WRIST, ...LEFT_HAND_JOINTS,
+                      JOINTS.RIGHT_ELBOW, JOINTS.RIGHT_WRIST, ...RIGHT_HAND_JOINTS
+                     ];
+
+        limbJoints.forEach((jointName) => {
+            this.joints[jointName].valid = (this.joints[jointName].confidence >= jointConfidenceThreshold);
         });
+
+        // when knees are not valid, whole legs are invalid including ankles
+        if (!this.joints[JOINTS.LEFT_KNEE].valid) {
+            this.joints[JOINTS.LEFT_ANKLE].valid = false;
+        }
+        if (!this.joints[JOINTS.RIGHT_KNEE].valid) {
+            this.joints[JOINTS.RIGHT_ANKLE].valid = false;
+        }
+        // when wrists are not valid, whole hands are invalid
+        if (!this.joints[JOINTS.LEFT_WRIST].valid) {
+            LEFT_HAND_JOINTS.forEach((jointName) => {
+                this.joints[jointName].valid = false;
+            });
+        }
+        if (!this.joints[JOINTS.RIGHT_WRIST].valid) {
+            RIGHT_HAND_JOINTS.forEach((jointName) => {
+                this.joints[jointName].valid = false;
+            });
+        }
+        // when the hand and elbow are not valid, the wrist is invalid as well
+        if (!this.joints[JOINTS.LEFT_ELBOW].valid && !this.joints[JOINTS.LEFT_THUMB_CMC].valid) {
+            this.joints[JOINTS.LEFT_WRIST].valid = false;
+        }
+        if (!this.joints[JOINTS.RIGHT_ELBOW].valid && !this.joints[JOINTS.RIGHT_THUMB_CMC].valid) {
+            this.joints[JOINTS.RIGHT_WRIST].valid = false;
+        }
+
+        // make invalid the bones adjacent to invalid joints
+        Object.keys(this.bones).forEach((boneName) => {
+            const jointName0 = this.bones[boneName].joint0.name;
+            const jointName1 = this.bones[boneName].joint1.name;
+            this.bones[boneName].valid = this.joints[jointName0].valid && this.joints[jointName1].valid;
+        });
+
     }
 
 }

--- a/src/humanPose/Pose.js
+++ b/src/humanPose/Pose.js
@@ -19,7 +19,8 @@ export class Pose {
             this.joints[jointName] = {
                 position: jointPositions[jointName],
                 confidence: jointConfidences[jointName],
-                name: jointName
+                name: jointName,
+                valid: true
             }
         });
         this.bones = {}; // Maps bone names to bone data
@@ -29,7 +30,8 @@ export class Pose {
                 this.bones[boneName] = {
                     joint0: this.joints[joint0],
                     joint1: this.joints[joint1],
-                    name: boneName
+                    name: boneName,
+                    valid: true 
                 };
             }
         });
@@ -72,4 +74,13 @@ export class Pose {
             callback(this.bones[boneName], index);
         });
     }
+
+    setBodyPartValidity(jointConfidenceThreshold) {
+        // TODO: limit to limbs
+        // TODO: add adjacent bones
+        this.forEachJoint(joint => {
+            joint.valid = (joint.confidence >= jointConfidenceThreshold);
+        });
+    }
+
 }

--- a/src/humanPose/PoseObjectIdLens.js
+++ b/src/humanPose/PoseObjectIdLens.js
@@ -14,7 +14,6 @@ export class PoseObjectIdLens extends MotionStudyLens {
 
         this.poseObjectIds = [];
         this.numeratorsForDenominator = {};
-        this.jointConfidenceThreshold = 0.0;
     }
 
 
@@ -109,15 +108,8 @@ export class PoseObjectIdLens extends MotionStudyLens {
     getColorForJoint(joint) {
         const baseColor = this.getColorFromId(joint.poseObjectId);
         let baseColorHSL = baseColor.getHSL({});
-        let color;
-        if (joint.confidence >= this.jointConfidenceThreshold) {
-            baseColorHSL.l = baseColorHSL.l * joint.confidence;
-            color = new THREE.Color().setHSL(baseColorHSL.h, baseColorHSL.s, baseColorHSL.l);
-        }
-        else {
-            color = MotionStudyColors.gray;
-        }
-        return color;
+        baseColorHSL.l = baseColorHSL.l * joint.confidence;
+        return new THREE.Color().setHSL(baseColorHSL.h, baseColorHSL.s, baseColorHSL.l);
     }
 
     getColorForBone(bone) {
@@ -129,7 +121,4 @@ export class PoseObjectIdLens extends MotionStudyLens {
         return MotionStudyColors.fade(this.getColorFromId(pose.metadata.poseObjectId));
     }
 
-    setJointConfidenceThreshold(confidence) { 
-        this.jointConfidenceThreshold = confidence;
-    }
 }

--- a/src/humanPose/PoseObjectIdLens.js
+++ b/src/humanPose/PoseObjectIdLens.js
@@ -14,6 +14,7 @@ export class PoseObjectIdLens extends MotionStudyLens {
 
         this.poseObjectIds = [];
         this.numeratorsForDenominator = {};
+        this.jointConfidenceThreshold = 0.0;
     }
 
 
@@ -108,8 +109,15 @@ export class PoseObjectIdLens extends MotionStudyLens {
     getColorForJoint(joint) {
         const baseColor = this.getColorFromId(joint.poseObjectId);
         let baseColorHSL = baseColor.getHSL({});
-        baseColorHSL.l = baseColorHSL.l * joint.confidence;
-        return new THREE.Color().setHSL(baseColorHSL.h, baseColorHSL.s, baseColorHSL.l);
+        let color;
+        if (joint.confidence >= this.jointConfidenceThreshold) {
+            baseColorHSL.l = baseColorHSL.l * joint.confidence;
+            color = new THREE.Color().setHSL(baseColorHSL.h, baseColorHSL.s, baseColorHSL.l);
+        }
+        else {
+            color = MotionStudyColors.gray;
+        }
+        return color;
     }
 
     getColorForBone(bone) {
@@ -119,5 +127,9 @@ export class PoseObjectIdLens extends MotionStudyLens {
 
     getColorForPose(pose) {
         return MotionStudyColors.fade(this.getColorFromId(pose.metadata.poseObjectId));
+    }
+
+    setJointConfidenceThreshold(confidence) { 
+        this.jointConfidenceThreshold = confidence;
     }
 }

--- a/src/humanPose/RebaLens.js
+++ b/src/humanPose/RebaLens.js
@@ -15,9 +15,10 @@ export class RebaLens extends MotionStudyLens {
     }
     
     applyLensToPose(pose) {
+        /*
         if (Object.values(pose.joints).every(joint => joint.rebaScore)) {
             return false;
-        }
+        } */
         const rebaData = Reba.calculateForPose(pose);
         pose.forEachJoint(joint => {
             joint.rebaScore = rebaData.scores[joint.name];

--- a/src/humanPose/RebaLens.js
+++ b/src/humanPose/RebaLens.js
@@ -14,16 +14,15 @@ export class RebaLens extends MotionStudyLens {
         super("REBA Ergonomics");
     }
     
-    applyLensToPose(pose) {
-        /*
-        if (Object.values(pose.joints).every(joint => joint.rebaScore)) {
+    applyLensToPose(pose, force = false) {
+        if (!force && Object.values(pose.joints).every(joint => joint.rebaScore)) {
             return false;
-        } */
+        } 
         const rebaData = Reba.calculateForPose(pose);
         pose.forEachJoint(joint => {
             joint.rebaScore = rebaData.scores[joint.name];
             joint.rebaColor = rebaData.colors[joint.name];
-            joint.rebaScoreOverall = rebaData.overallRebaScore;
+            joint.rebaScoreOverall = rebaData.overallRebaScore; // not really used, overallRebaScore from REBA Ergonomics (Overall) is propagated into stats  
             joint.rebaColorOverall = rebaData.overallRebaColor;
         });
         pose.forEachBone(bone => {
@@ -33,16 +32,16 @@ export class RebaLens extends MotionStudyLens {
         return true;
     }
 
-    applyLensToHistoryMinimally(poseHistory) {
-        const modified = this.applyLensToPose(poseHistory[poseHistory.length - 1]);
+    applyLensToHistoryMinimally(poseHistory, force = false) {
+        const modified = this.applyLensToPose(poseHistory[poseHistory.length - 1], force);
         const modifiedArray = poseHistory.map(() => false);
         modifiedArray[modifiedArray.length - 1] = modified;
         return modifiedArray;
     }
 
-    applyLensToHistory(poseHistory) {
+    applyLensToHistory(poseHistory, force = false) {
         return poseHistory.map(pose => {
-            return this.applyLensToPose(pose);
+            return this.applyLensToPose(pose, force);
         });
     }
     

--- a/src/humanPose/TimeLens.js
+++ b/src/humanPose/TimeLens.js
@@ -9,7 +9,7 @@ const TIME_INTERVAL_DURATION = 10000; // 10 seconds
  */
 class TimeLens extends MotionStudyLens {
     /**
-     * Creates a new RebaLens object.
+     * Creates a new TimeLens object.
      */
     constructor() {
         super("Time");

--- a/src/humanPose/constants.js
+++ b/src/humanPose/constants.js
@@ -510,7 +510,6 @@ export const JOINT_RADIUS = 0.02; // unit: meters
 export const BONE_RADIUS = 0.01; // unit: meters
 export const SCALE = 1000; // we want to scale up the size of individual joints to milimeters, but not apply the scale to their positions
 
-export const RENDER_CONFIDENCE_COLOR = false;
 // Amount of pose instances per historical HumanPoseRenderer
 export const MAX_POSE_INSTANCES = 512;
 export const MAX_POSE_INSTANCES_MOBILE = 8;

--- a/src/humanPose/constants.js
+++ b/src/humanPose/constants.js
@@ -515,6 +515,9 @@ export const RENDER_CONFIDENCE_COLOR = false;
 export const MAX_POSE_INSTANCES = 512;
 export const MAX_POSE_INSTANCES_MOBILE = 8;
 
+// Threshold for joint confidence which determines validity of a joint and associated bones.
+export const JOINT_CONFIDENCE_THRESHOLD = 0.25;
+
 export function getBoneName(bone) {
     return Object.keys(JOINT_CONNECTIONS).find(boneName => JOINT_CONNECTIONS[boneName] === bone);
 }

--- a/src/humanPose/constants.js
+++ b/src/humanPose/constants.js
@@ -213,6 +213,8 @@ export const JOINT_CONNECTIONS = {
 export const JOINTS_PER_POSE = Object.keys(JOINTS).length;
 export const BONES_PER_POSE = Object.keys(JOINT_CONNECTIONS).length;
 
+export const DISPLAY_INVALID_ELEMENTS = false;
+
 // Flag for switching on/off an experimental feature of hand tracking
 export const TRACK_HANDS = true;
 

--- a/src/humanPose/constants.js
+++ b/src/humanPose/constants.js
@@ -213,15 +213,18 @@ export const JOINT_CONNECTIONS = {
 export const JOINTS_PER_POSE = Object.keys(JOINTS).length;
 export const BONES_PER_POSE = Object.keys(JOINT_CONNECTIONS).length;
 
+// Option to hide joints (+ adjacent bones) which have low confidence (thus considered poorly tracked)
+// This affects dynamic visualisation based on a given pose.
 export const DISPLAY_INVALID_ELEMENTS = false;
 
 // Flag for switching on/off an experimental feature of hand tracking
 export const TRACK_HANDS = true;
 
-// Option to hide joint/bones which are for example considered poorly tracked in general or redundant for a use case
+// Option to hide joints/bones which are for example considered poorly tracked in general or redundant for a use case
+// This affects visualisation of all poses the same way. 
 // Currently, defined according to debug switch TRACK_HANDS
 export const DISPLAY_HIDDEN_ELEMENTS = TRACK_HANDS;
-export const HIDDEN_JOINTS = [
+export const LEFT_HAND_JOINTS = [
     JOINTS.LEFT_THUMB_CMC,
     JOINTS.LEFT_THUMB_MCP,
     JOINTS.LEFT_THUMB_IP,
@@ -241,7 +244,9 @@ export const HIDDEN_JOINTS = [
     JOINTS.LEFT_PINKY_MCP,
     JOINTS.LEFT_PINKY_PIP,
     JOINTS.LEFT_PINKY_DIP,
-    JOINTS.LEFT_PINKY_TIP,
+    JOINTS.LEFT_PINKY_TIP
+];
+export const RIGHT_HAND_JOINTS = [
     JOINTS.RIGHT_THUMB_CMC,
     JOINTS.RIGHT_THUMB_MCP,
     JOINTS.RIGHT_THUMB_IP,
@@ -263,6 +268,8 @@ export const HIDDEN_JOINTS = [
     JOINTS.RIGHT_PINKY_DIP,
     JOINTS.RIGHT_PINKY_TIP
 ];
+export const HIDDEN_JOINTS = [...LEFT_HAND_JOINTS, ...RIGHT_HAND_JOINTS];
+
 export const HIDDEN_BONES = [
     getBoneName(JOINT_CONNECTIONS.thumb1Left),
     getBoneName(JOINT_CONNECTIONS.thumb2Left),

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -5,7 +5,7 @@ import {
     getGroundPlaneRelativeMatrix,
     setMatrixFromArray
 } from './utils.js';
-import {JOINTS,JOINT_CONNECTIONS, JOINT_TO_INDEX, RENDER_CONFIDENCE_COLOR} from './constants.js';
+import {JOINTS,JOINT_CONNECTIONS, JOINT_TO_INDEX} from './constants.js';
 import {Pose} from "./Pose.js";
 import {HumanPoseRenderInstance} from './HumanPoseRenderInstance.js';
 
@@ -129,11 +129,6 @@ function updateJointsAndBones(poseRenderInstance, poseObject, timestamp) {
             }
         }
         jointConfidences[jointId] = confidence;
-
-        if (RENDER_CONFIDENCE_COLOR) {
-
-            poseRenderInstance.setJointConfidenceColor(jointId, confidence);
-        }
     }
 
     const poseHasParent = poseObject.parent && (poseObject.parent !== 'none');

--- a/src/humanPose/draw.js
+++ b/src/humanPose/draw.js
@@ -140,6 +140,8 @@ function updateJointsAndBones(poseRenderInstance, poseObject, timestamp) {
     const pose = new Pose(jointPositions, jointConfidences, timestamp, {poseObjectId: poseObject.objectId, poseHasParent: poseHasParent});
     pose.metadata.previousPose = mostRecentPoseByObjectId[poseObject.objectId];
     mostRecentPoseByObjectId[poseObject.objectId] = pose;
+    // setBodyPartValidity() needs to be called before applyLensToPose(pose) and setPose(pose)
+    pose.setBodyPartValidity(liveHumanPoseAnalyzer.getJointConfidenceThreshold());
     liveHumanPoseAnalyzer.activeLens.applyLensToPose(pose);
     poseRenderInstance.setPose(pose);
     poseRenderInstance.setLens(liveHumanPoseAnalyzer.activeLens);

--- a/src/humanPose/rebaScore.js
+++ b/src/humanPose/rebaScore.js
@@ -200,7 +200,7 @@ function legsReba(rebaData) {
     let rightLegColor = MotionStudyColors.undefined;
     
     // Height difference for leg raise is not specified in REBA standard (we picked 10cm)
-    const footDifferenceCutoff = 0.1; // TODO: measure this to find a good cutoff
+    const footDifferenceCutoff = 100; // mm  // TODO: measure this to find a good cutoff
 
     /* left leg */
     // check if all needed joints have a valid position
@@ -320,7 +320,7 @@ function upperArmReba(rebaData) {
     
     // Angles for upper arm should be measured relative to world up, arms naturally hang straight down regardless of posture.
     const down = new THREE.Vector3(0, -1, 0);
-    const shoulderDifferenceCutoff = 0.1;  // TODO: measure this to find a good cutoff
+    const shoulderDifferenceCutoff = 100; // mm  // TODO: measure this to find a good cutoff
     
     /* left uppper arm */
     // check if all needed joints have a valid position

--- a/src/humanPose/rebaScore.js
+++ b/src/humanPose/rebaScore.js
@@ -221,11 +221,11 @@ function legsReba(rebaData) {
             }
         }
         
-        // Check for leg raising
-        const footHeightDifference = rebaData.joints[JOINTS.LEFT_ANKLE].y - rebaData.joints[JOINTS.RIGHT_ANKLE].y;
+        // Check for left leg bearing the body weight
+        const footHeightDifference = rebaData.joints[JOINTS.RIGHT_ANKLE].y - rebaData.joints[JOINTS.LEFT_ANKLE].y;
         // console.log(`footYDifference: ${footYDifference}\nCurrent cutoff: ${footDifferenceCutoff}`);
         if (rebaData.jointValidities[JOINTS.RIGHT_ANKLE] && footHeightDifference > footDifferenceCutoff) {
-            leftLegScore++; // +1 for left leg raised
+            leftLegScore++; 
         }
         
         leftLegScore = clamp(leftLegScore, 1, 4);
@@ -254,10 +254,10 @@ function legsReba(rebaData) {
             }
         }
 
-        // Check for leg raising    
-        const footHeightDifference = rebaData.joints[JOINTS.RIGHT_ANKLE].y - rebaData.joints[JOINTS.LEFT_ANKLE].y;
+        // Check for right leg bearing the body weight   
+        const footHeightDifference = rebaData.joints[JOINTS.LEFT_ANKLE].y - rebaData.joints[JOINTS.RIGHT_ANKLE].y;
         if (rebaData.jointValidities[JOINTS.LEFT_ANKLE] && footHeightDifference > footDifferenceCutoff) {
-            rightLegScore++; // +1 for left leg raised    
+            rightLegScore++;   
         }
 
         rightLegScore = clamp(rightLegScore, 1, 4);

--- a/src/motionStudy/motionStudy.js
+++ b/src/motionStudy/motionStudy.js
@@ -658,4 +658,17 @@ export class MotionStudy {
         });
         this.writeMotionStudyData();
     }
+
+    updateRegionCards() {
+        this.pinnedRegionCards.forEach(card => {
+            card.updateLensStatistics();
+        });
+        if (this.timeline.regionCard) {
+            this.timeline.regionCard.updateLensStatistics();
+        }
+
+        this.updateCsvExportLink();
+        //this.writeMotionStudyData();
+    }
+
 }

--- a/src/motionStudy/regionCard.js
+++ b/src/motionStudy/regionCard.js
@@ -1,5 +1,7 @@
 import {getMeasurementTextLabel} from '../humanPose/spaghetti.js';
 import {JOINTS} from '../humanPose/constants.js';
+import {MIN_ACCELERATION, MAX_ACCELERATION} from '../humanPose/AccelerationLens.js';
+import {MIN_REBA_SCORE, MAX_REBA_SCORE} from '../humanPose/OverallRebaLens.js';
 import {ValueAddWasteTimeTypes} from './ValueAddWasteTimeManager.js';
 
 const cardWidth = 200;
@@ -363,16 +365,7 @@ export class RegionCard {
         motionSummary.textContent = this.getMotionSummaryText();
 
         this.graphSummaryValues = {};
-        const minReba = 1;
-        const maxReba = 12;
-        this.updateGraphSection('reba', 'REBA', pose => pose.getJoint(JOINTS.HEAD).overallRebaScore, minReba, maxReba);
-        this.updateGraphSection('accel', 'Accel', pose => {
-            let maxAcceleration = 0;
-            pose.forEachJoint(joint => {
-                maxAcceleration = Math.max(maxAcceleration, joint.accelerationMagnitude || 0);
-            });
-            return maxAcceleration;
-        }, 0, 40);
+        this.updateLensStatistics();
     }
 
     getMotionSummaryText() {
@@ -456,6 +449,21 @@ export class RegionCard {
         let maximum = this.element.querySelector('.analytics-region-card-graph-section-maximum-' + id);
         maximum.textContent = 'Max: ';
         maximum.appendChild(this.makeSummaryValue(summaryValues.maximum, minValue, maxValue));
+    }
+
+    updateLensStatistics() {
+        if (this.poses.length === 0) {
+            return;
+        }
+        
+        this.updateGraphSection('reba', 'REBA', pose => pose.getJoint(JOINTS.HEAD).overallRebaScore, MIN_REBA_SCORE, MAX_REBA_SCORE);
+        this.updateGraphSection('accel', 'Accel', pose => {
+            let maxAcceleration = 0;
+            pose.forEachJoint(joint => {
+                maxAcceleration = Math.max(maxAcceleration, joint.accelerationMagnitude || 0);
+            });
+            return maxAcceleration;
+        }, MIN_ACCELERATION, MAX_ACCELERATION);
     }
 
     /**


### PR DESCRIPTION
General idea is to filter out joints which have a low confidence. The confidence is essentially a visibility score we get from mediapipe for limbs (not torso and head). The filtered joints and adjacent bones are not displayed. Also, some analytics calculations are affected by this (eg. REBA score of a leg should not be calculated if ankle joint is filtered. We then default to the lowest score 1). However, it is not relevant for all lens (Waste/Value does not care about pose directly).

I tried to make the changes not very invasive and shared by all relevant analytics lens. All joints and bones in Pose class has new valid attribute which is calculated based on a given confidence threshold (or recalculated when the threshold is changed on the fly). This attribute is used to show/hide body parts in HumanRenderInstance. Also, it is used in lens-specific calculations such as rebaScore.js.  HPA.setJointConfidenceThreshold(confidence) tries to dynamically propagate new state of joint/bone validity and lens metrics to relevant analytics elements. 
I'm tuning the right level of confidence threshold. Eventually, input text field in analytics settings will be swapped for a checkbox whether to apply filtering with own internal threshold. 

This is to check if you see any conceptual issues with how this is implemented. It influences most parts of analytics tool (skeletons, spaghetti, region cards ...), so let me know if there are still corners where this filtering might not be propagated properly. Missing bits on my list:
- Acceleration lens
- Immediate refresh of pinned region cards when the confidence threshold changes
- Immediate refresh of temporary region card for new time interval when the confidence threshold changes