### PR TITLE
disable the comma keyboard shortcut unless you've already shown the splat at least once

### DIFF
--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -1261,6 +1261,8 @@ import { MapShaderSettingsUI } from "../measure/mapShaderSettingsUI.js";
         }
         // hide the ground plane holodeck visualizer
         realityEditor.gui.ar.groundPlaneRenderer.stopVisualization();
+        // update the spatial cursor internal state
+        realityEditor.spatialCursor.gsToggleActive(true);
         // update the renderMode of the world object and broadcast to other clients
         let worldObject = realityEditor.worldObjects.getBestWorldObject();
         if (worldObject) {
@@ -1285,6 +1287,7 @@ import { MapShaderSettingsUI } from "../measure/mapShaderSettingsUI.js";
             areaMesh.visible = true;
         }
         realityEditor.gui.ar.groundPlaneRenderer.startVisualization();
+        realityEditor.spatialCursor.gsToggleActive(false);
         let worldObject = realityEditor.worldObjects.getBestWorldObject();
         if (worldObject) {
             worldObject.renderMode = RENDER_MODES.mesh;

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -943,41 +943,24 @@ async function main(initialFilePath) {
     }
 }
 
+// The comma key can be used to toggle the splat rendering visibility after it's been loaded at least once
 window.addEventListener("keydown", e => {
     if (e.key === ',') {
         if (!gsInitialized) {
-            gsInitialized = true;
-            gsContainer = document.querySelector('#gsContainer');
-            gsContainer.style.opacity = 1.0;
-            // gsContainer.style.position = 'absolute';
-            // gsContainer.style.left = '0';
-            // gsContainer.style.top = '0';
-            // gsContainer.style.zIndex = '-1'; // use this when in normal action
-            // gsContainer.style.opacity = '1';
-            // gsContainer.style.pointerEvents = 'none';
-            // gsContainer.style.width = '100vw';
-            // gsContainer.style.height = '100vh';
-            main().catch((err) => {
-                document.getElementById("gsSpinner").style.display = "none";
-                document.getElementById("gsMessage").innerText = err.toString();
-            });
+            return; // must be initialized using UI button before comma key can be used
         }
         gsContainer.classList.toggle('hidden');
         gsActive = !gsContainer.classList.contains('hidden');
         if(gsActive)
         {
-            realityEditor.gui.threejsScene.getObjectByName('areaTargetMesh').visible = false;
-            realityEditor.gui.ar.groundPlaneRenderer.stopVisualization();
-            realityEditor.spatialCursor.gsToggleActive(true);
+            realityEditor.gui.threejsScene.enableExternalSceneRendering(true);
             callbacks.onSplatShown.forEach(cb => {
                 cb();
             });
         }
         else
         {
-            realityEditor.gui.threejsScene.getObjectByName('areaTargetMesh').visible = true;
-            realityEditor.gui.ar.groundPlaneRenderer.startVisualization();
-            realityEditor.spatialCursor.gsToggleActive(false);
+            realityEditor.gui.threejsScene.disableExternalSceneRendering(true);
             callbacks.onSplatHidden.forEach(cb => {
                 cb();
             });


### PR DESCRIPTION
Prevents you from accidentally displaying a black screen with an error message if you hit the comma key before the splat has been loaded properly.

Also moves cursor gsToggleActive to better location – (removes lines from here https://github.com/ptcrealitylab/pop-up-onboarding-addon/pull/128)