### PR TITLE
Fix the Spatial Pointer canvas's vertical offset

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -18,7 +18,6 @@ createNameSpace("realityEditor.avatar");
 
     let linkCanvas = null, linkCanvasCtx = null;
     let linkCanvasNeedsClear = true;
-    let menuBarHeight;
     
     let myAvatarId = null;
     let myAvatarObject = null;
@@ -224,8 +223,7 @@ createNameSpace("realityEditor.avatar");
         linkCanvas = document.createElement('canvas');
         linkCanvas.className = 'link-canvas';
         linkCanvas.style.position = 'absolute';
-        menuBarHeight = realityEditor.device.environment.variables.screenTopOffset;
-        linkCanvas.style.top = `${menuBarHeight}px`;
+        linkCanvas.style.top = '0';
         linkCanvas.style.left = '0';
         linkCanvas.style.zIndex = '3001';
         linkCanvasContainer.appendChild(linkCanvas);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -114,7 +114,6 @@ createNameSpace("realityEditor.avatar");
             isDesktop = realityEditor.device.environment.isDesktop();
             addLinkCanvas();
             resizeLinkCanvas();
-            translateLinkCanvas();
             window.addEventListener('resize', () => {
                 realityEditor.avatar.setLinkCanvasNeedsClear(true);
                 resizeLinkCanvas();
@@ -237,16 +236,12 @@ createNameSpace("realityEditor.avatar");
     function resizeLinkCanvas() {
         if (linkCanvas !== undefined) {
             linkCanvas.width = window.innerWidth;
-            linkCanvas.height = window.innerHeight - menuBarHeight;
+            linkCanvas.height = window.innerHeight;
         }
-    }
-    
-    function translateLinkCanvas() {
-        linkCanvasCtx.translate(0, -menuBarHeight);
     }
 
     function clearLinkCanvas() {
-        linkCanvasCtx.clearRect(0, menuBarHeight, window.innerWidth, window.innerHeight - menuBarHeight);
+        linkCanvasCtx.clearRect(0, 0, window.innerWidth, window.innerHeight);
         linkCanvasNeedsClear = false;
     }
 


### PR DESCRIPTION
Fixes 2 problems that were happening after you've resized the window at least once:

1. Properly clears the top edge of the screen of the spatial pointer graphics
2. Properly aligns the endpoint of the spatial pointer with your pointer position

Both are fixed by removing references to the menuBarHeight that added a vertical offset to the canvas, and just making the canvas occupy the entire screen and clear the entire screen, removing any chances for misalignment.

Before:

<img width="1656" alt="Screenshot 2024-04-02 at 2 33 33 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/9f3adaef-c3e5-4a16-a3db-77ee12bd45c7">

After:

<img width="1688" alt="Screenshot 2024-04-02 at 2 30 29 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/6b466c6b-e0e3-46a9-a003-33616c2e6235">
