### PR TITLE
move avatar container z index above the fullscreen tool z index

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1827,6 +1827,7 @@ Logic Interface CSS
     background-color: rgba(0,0,0,0.5);
     height: 50px;
     border-radius: 25px;
+    z-index: 1000;
 }
 
 .avatarListIcon {

--- a/css/index.css
+++ b/css/index.css
@@ -1823,7 +1823,7 @@ Logic Interface CSS
     position: absolute;
     top: 60px;
     left: 50vw;
-    transform: translateX(-50%);
+    transform: translate3d(-50%, 0, 1000px);
     background-color: rgba(0,0,0,0.5);
     height: 50px;
     border-radius: 25px;


### PR DESCRIPTION
Puts avatar icon container above drawings and fullscreen chat.

Fixes issue https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/issues/673. Fullscreen tools have z index 100, but I put it even higher to give it additional priority.

Before:

<img width="1390" alt="Screenshot 2024-04-02 at 3 07 29 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/774208f6-6f1a-4f01-93bc-40c18b2f56d6">

After:

<img width="1109" alt="Screenshot 2024-04-02 at 2 48 45 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/33f491e0-0ca3-4d53-8bfe-92a57e9d5c5c">

Before:

<img width="1387" alt="Screenshot 2024-04-02 at 3 07 36 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/e938ce04-f3a3-42d4-9caa-d63f29854a5a">

After:

<img width="1107" alt="Screenshot 2024-04-02 at 2 48 53 PM" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/32580292/ee9fca7b-f28d-450b-bb09-6d7c0eedbba5">
