### PR TITLE
move shouldShowIntroModal logic from onLoad.js to setupSettingsMenu.js

### DIFF
--- a/src/device/onLoad.js
+++ b/src/device/onLoad.js
@@ -259,26 +259,6 @@ realityEditor.device.onload = async function () {
         });
     }
 
-    // see if we should open the modal - defaults hidden but can be turned on from menu
-    let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';
-
-    if (shouldShowIntroModal) {
-        let modalBody = "The Vuforia Spatial Toolbox is an open source research platform for exploring Augmented Reality and Spatial Computing.<br>" +
-            "<ul>" +
-            "</li>1. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/using-the-app'>Learn how to use the Spatial Toolbox</a><br><br></li>" +
-            "</li>2. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/connect-to-the-physical-world/startSystem'> Learn how to connect the Physical World</a><br><br></li>" +
-            "</li>3. <a class='modalLink' href='https://forum.spatialtoolbox.vuforia.com'> Join the conversation with your questions, ideas and collaboration</a><br><br></li>" +
-            "</li>4. <a class='modalLink' href='https://github.com/ptcrealitylab'> Browse the Open Source Code on Github</a><br><br></li>" +
-            "</ul>";
-
-        realityEditor.gui.modal.openClassicModal('Welcome to the Vuforia Spatial Toolbox!', modalBody, 'Close', 'Close and Don\'t Show Again', function() {
-            // console.log('Closed');
-        }, function() {
-            // console.log('Closed and Don\'t Show Again!');
-            introToggle.setValue(false);
-        });
-    }
-
     this.cout("onload");
 
     realityEditor.device.loaded = true;

--- a/src/gui/settings/setupSettingsMenu.js
+++ b/src/gui/settings/setupSettingsMenu.js
@@ -208,7 +208,26 @@ createNameSpace('realityEditor.gui.settings.setupSettingsMenu');
         realityEditor.network.realtime.subscribeToInterfaceSettings('edgeAgent', settings => {
             processNewSettings(settings);
         });
-        
+
+        // see if we should open the modal - defaults hidden but can be turned on from menu
+        let shouldShowIntroModal = window.localStorage.getItem('neverAgainShowIntroTips') !== 'true';
+
+        if (shouldShowIntroModal) {
+            let modalBody = "The Vuforia Spatial Toolbox is an open source research platform for exploring Augmented Reality and Spatial Computing.<br>" +
+                "<ul>" +
+                "</li>1. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/using-the-app'>Learn how to use the Spatial Toolbox</a><br><br></li>" +
+                "</li>2. <a class='modalLink' href='https://spatialtoolbox.vuforia.com/docs/use/connect-to-the-physical-world/startSystem'> Learn how to connect the Physical World</a><br><br></li>" +
+                "</li>3. <a class='modalLink' href='https://forum.spatialtoolbox.vuforia.com'> Join the conversation with your questions, ideas and collaboration</a><br><br></li>" +
+                "</li>4. <a class='modalLink' href='https://github.com/ptcrealitylab'> Browse the Open Source Code on Github</a><br><br></li>" +
+                "</ul>";
+
+            realityEditor.gui.modal.openClassicModal('Welcome to the Vuforia Spatial Toolbox!', modalBody, 'Close', 'Close and Don\'t Show Again', function() {
+                // console.log('Closed');
+            }, function() {
+                // console.log('Closed and Don\'t Show Again!');
+                introToggle.setValue(false);
+            });
+        }
     }
     exports.initService = initService;
 


### PR DESCRIPTION
I missed one part of the onLoad.js that should have been moved in PR #675. Moving it fixes a bug / linting error that doesn't surface in the pop-up version of the app.