### PR TITLE
Touchscreen camera buttons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2315,6 +2315,7 @@ Logic Interface CSS
     left: calc(100vw/2 - 300px/2 - 16px);
     top: calc(100vh/2 - 300px/2 - 16px);
     pointer-events: auto;
+    opacity: 0.7;
 }
 
 .tool-color-gradient {

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -641,13 +641,43 @@ realityEditor.device.disablePinchToScale = function() {
 };
 
 /**
+ * This system allows any number of modules to mark with a flag that they're
+ * currently claiming the pointer events for a camera control mode.
+ * @type {Object.<string, boolean>}
+ */
+realityEditor.device.manualCameraControlFlags = {};
+/**
+ * @param {string} flagName - the name of the module/reason that the pointer is claimed by
+ */
+realityEditor.device.setFlagForPointerOccupiedByCamera = function(flagName) {
+    realityEditor.device.manualCameraControlFlags[flagName] = true;
+};
+/**
+ * @param {string} flagName - provide the same name used in setFlagForPointerOccupiedByCamera, to release the pointer
+ */
+realityEditor.device.clearFlagForPointerOccupiedByCamera = function(flagName) {
+    delete realityEditor.device.manualCameraControlFlags[flagName];
+};
+/**
+ * @return {boolean}
+ */
+realityEditor.device.isPointerOccupiedByCameraControl = function() {
+    return Object.keys(realityEditor.device.manualCameraControlFlags).length > 0;
+};
+
+/**
  * @return {boolean} If the event is intended to control the camera and not the
- *   AR elements
+ *   AR elements, avatar pointer beams, or other pointer interactions
  */
 realityEditor.device.isMouseEventCameraControl = function(event) {
-  // If mouse events are enabled ignore right clicks and middle clicks
-  return realityEditor.device.environment.requiresMouseEvents() &&
-    (event.button === 2 || event.button === 1);
+    // first check if anything is manually taking claim over the pointer events
+    if (realityEditor.device.isPointerOccupiedByCameraControl()) {
+        return true;
+    }
+    // If mouse events are enabled ignore right clicks and middle clicks
+    // otherwise the pointer is presumed to not be being used for camera controls
+    return realityEditor.device.environment.requiresMouseEvents() &&
+        (event.button === 2 || event.button === 1);
 };
 
 /**

--- a/src/device/modeTransition.js
+++ b/src/device/modeTransition.js
@@ -32,6 +32,11 @@ let prevMatrices = {
     function initService() {
         currentMode = getInitialMode();
 
+        // disables AR<>VR slider if not in the Toolbox AR app
+        if (!realityEditor.device.environment.isWithinToolboxApp()) {
+            return;
+        }
+
         // set up the pinch gesture to transition from AR to VR mode
         let pinchGestureRecognizer = new PinchGestureRecognizer();
 
@@ -143,6 +148,7 @@ let prevMatrices = {
 
     // the pinch gesture or the slider component can both trigger the transition using this
     function setTransitionPercent(percent) {
+        if (!realityEditor.device.environment.isWithinToolboxApp()) return;
         if (percent < 0.01) {
             switchToAR();
         } else {

--- a/src/gui/envelopeIcons.js
+++ b/src/gui/envelopeIcons.js
@@ -169,11 +169,8 @@ class EnvelopeIconRenderer {
         let icon = document.createElement('img');
         icon.src = src;
         icon.classList.add('minimizedEnvelopeIcon', 'tool-color-gradient');
+        icon.setAttribute('frameId', frameId);
         container.appendChild(icon);
-
-        icon.addEventListener('pointerup', () => {
-            realityEditor.envelopeManager.focusEnvelope(frameId);
-        });
 
         return container;
     }
@@ -218,13 +215,19 @@ class EnvelopeIconRenderer {
     }
 
     onIconPointerDown(event) {
+        if (realityEditor.device.isMouseEventCameraControl(event)) return;
         const iconElt = event.target;
         this.setDragTarget(iconElt.dataset.objectId, iconElt.dataset.frameId);
         this.dragState.pointerDown = true;
     }
 
-    onIconPointerUp() {
+    onIconPointerUp(event) {
+        if (realityEditor.device.isMouseEventCameraControl(event)) return;
         this.dragState.pointerDown = false;
+        let frameId = event.currentTarget.getAttribute('frameId');
+        if (frameId) {
+            realityEditor.envelopeManager.focusEnvelope(frameId);
+        }
     }
 
     onIconPointerOut(event) {
@@ -269,6 +272,7 @@ class EnvelopeIconRenderer {
         if (!this.dragState.pointerDown) return;
         if (!this.dragState.didStartDrag) return;
         if (!this.dragState.draggedIcon) return;
+        if (realityEditor.device.isMouseEventCameraControl(event)) return;
 
         let boundingRect = this.dragState.draggedIcon.getBoundingClientRect();
 


### PR DESCRIPTION
Updates the userinterface to support the ability for the addon to temporarily take control of the pointerevents, preventing the avatar pointer or tool icon interactions when camera control mode has been activated: https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/pull/178