### PR TITLE
Always enable depthTest on CameraVis shader

### DIFF
--- a/src/spatialCapture/Shaders.js
+++ b/src/spatialCapture/Shaders.js
@@ -321,7 +321,7 @@ export function createPointCloudMaterial(texture, textureDepth, shaderMode, bord
         vertexShader,
         fragmentShader,
         // blending: THREE.AdditiveBlending,
-        depthTest: shaderMode !== ShaderMode.FIRST_PERSON,
+        depthTest: true,
         // depthWrite: false,
         transparent: true
     });


### PR DESCRIPTION
Previously depthTest would be disabled in first person mode which drew correctly in the previous system. Now with the depth-based system replacing layers, depthTest is required to draw above the ground plane visualization.

Adjacent to this, the current state draws first person video above the pose renderers and it would be nice (but not required) to be able to see the pose renderers in first person if you have any free time in search of a use @ptc-rdeleeuw 
