### PR TITLE
Clean up various uses of `port` and APIs that want `port`

### DIFF
--- a/src/device/videoRecording.js
+++ b/src/device/videoRecording.js
@@ -309,6 +309,7 @@ createNameSpace("realityEditor.device.videoRecording");
             console.log(`Starting virtualizer recording on ${bestWorldObject.ip} with ${networkId} and ${networkSecret}`);
             realityEditor.app.appFunctionCall("enablePoseTracking", {
                 ip: bestWorldObject.ip,
+                port: bestWorldObject.port.toString(),
                 networkId,
                 networkSecret,
             });

--- a/src/gui/settings/setupSettingsMenu.js
+++ b/src/gui/settings/setupSettingsMenu.js
@@ -117,7 +117,10 @@ createNameSpace('realityEditor.gui.settings.setupSettingsMenu');
                         enablePoseTrackingTimeout = setTimeout(enablePoseTracking, 100);
                         return;
                     }
-                    realityEditor.app.appFunctionCall("enablePoseTracking", {ip: bestWorldObject.ip});
+                    realityEditor.app.appFunctionCall("enablePoseTracking", {
+                        ip: bestWorldObject.ip,
+                        port: bestWorldObject.port.toString(),
+                    });
 
                     let recordButton = document.getElementById('recordPointCloudsButton');
                     if (!recordButton) {

--- a/src/worldObjects.js
+++ b/src/worldObjects.js
@@ -171,7 +171,7 @@ createNameSpace("realityEditor.worldObjects");
         }
         
         // REST endpoint for for downloading the world object for that server
-        var urlEndpoint = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object.port), '/worldObject/');
+        var urlEndpoint = realityEditor.network.getURL(object.ip, realityEditor.network.getPort(object), '/worldObject/');
         realityEditor.network.getData(null, null, null, urlEndpoint, function (objectKey, frameKey, nodeKey, msg) {
             if (msg && Object.keys(msg).length > 0) {
                 initializeWorldObject(msg);


### PR DESCRIPTION
Much ado about sweet wine

Fixes one exception from getPort using `object`, not `object.port`

Fixes some swift-side issues where the missing port would cause pose tracking's connection to fail