### PR TITLE
fixes bug where analytics tool doesnt delete properly in some cases

### DIFF
--- a/src/motionStudy/motionStudy.js
+++ b/src/motionStudy/motionStudy.js
@@ -155,7 +155,9 @@ export class MotionStudy {
         this.resetPatchVisibility();
         // Reset the highlight region (and any animation)
         this.setHighlightRegion(null);
-        this.videoPlayer.hide();
+        if (this.videoPlayer) {
+            this.videoPlayer.hide();
+        }
     }
 
     /**


### PR DESCRIPTION
Bug happens if you add it, minimize it without recording anything, and drag the icon to the trash. The video player is null in that case.