### PR TITLE
Add part of solution for portrait videos; Flip iPad video to match testflight orientation

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2049,7 +2049,7 @@ Logic Interface CSS
     bottom: calc(320px + 91px); /* guess at video top */
 }
 
-.analytics-video {
+.analytics-video, .analytics-video-background {
     position: absolute;
     left: 35px;
     bottom: calc(320px - 66px - 66px + 14px);
@@ -2057,9 +2057,18 @@ Logic Interface CSS
     height: 151px;
 
     z-index: 2900;
-    transform: translateZ(2900px);
+    transform: translateZ(2900px) rotate(180deg);
 
     pointer-events: all;
+}
+
+.analytics-video-background {
+    background-color: rgba(0, 0, 0, 0.7);
+    pointer-events: none;
+}
+
+.analytics-video-portrait {
+    transform: translateZ(2900px) rotate(-90deg) scale(calc(151 / 268));
 }
 
 .analytics-video-toggle {

--- a/src/motionStudy/motionStudy.js
+++ b/src/motionStudy/motionStudy.js
@@ -493,6 +493,7 @@ export class MotionStudy {
             const colorVideo = this.videoPlayer.colorVideo;
 
             colorVideo.style.display = '';
+            colorVideo.controls = true;
             colorVideo.classList.add('analytics-video');
 
             // This could expand to cover all the various orientations but for

--- a/src/motionStudy/motionStudy.js
+++ b/src/motionStudy/motionStudy.js
@@ -490,14 +490,24 @@ export class MotionStudy {
                 this.videoStartTime = parseFloat(matches[1]);
             }
             this.videoPlayer.hide();
-            this.videoPlayer.colorVideo.controls = true;
-            this.videoPlayer.colorVideo.style.display = '';
-            this.videoPlayer.colorVideo.classList.add('analytics-video');
+            const colorVideo = this.videoPlayer.colorVideo;
+
+            colorVideo.style.display = '';
+            colorVideo.classList.add('analytics-video');
+            // TODO(hobinjk): need way to differentiate iPhone video (portrait)
+            // from iPad (landscape)
+            // if (isPortrait) {
+            //     colorVideo.classList.add('analytics-video-portrait');
+            // }
             this.pinnedRegionCardsContainer.classList.add('analytics-has-video');
 
             this.createVideoPlayerShowHideButton();
 
-            this.container.appendChild(this.videoPlayer.colorVideo);
+            const videoPlayerBackground = document.createElement('div');
+            videoPlayerBackground.classList.add('analytics-video-background');
+            this.container.appendChild(videoPlayerBackground);
+
+            this.container.appendChild(colorVideo);
         }
 
         if (data.valueAddWasteTime) {

--- a/src/motionStudy/motionStudy.js
+++ b/src/motionStudy/motionStudy.js
@@ -494,11 +494,13 @@ export class MotionStudy {
 
             colorVideo.style.display = '';
             colorVideo.classList.add('analytics-video');
-            // TODO(hobinjk): need way to differentiate iPhone video (portrait)
-            // from iPad (landscape)
-            // if (isPortrait) {
-            //     colorVideo.classList.add('analytics-video-portrait');
-            // }
+
+            // This could expand to cover all the various orientations but for
+            // now we just care about iPad (landscape) vs iPhone
+            const isPortrait = parseInt(data.orientation) === 1;
+            if (isPortrait) {
+                colorVideo.classList.add('analytics-video-portrait');
+            }
             this.pinnedRegionCardsContainer.classList.add('analytics-has-video');
 
             this.createVideoPlayerShowHideButton();


### PR DESCRIPTION
Still need to think of a way to determine if the raw, oriented-relative-to-vuforia's-idea-of-the-world video came from portrait or landscape recording but this at least flips iPad video while laying the groundwork