### PR TITLE
Re-enable frameNeedsToBeRendered in iOS app

### DIFF
--- a/src/gui/ar/draw.js
+++ b/src/gui/ar/draw.js
@@ -277,9 +277,13 @@ realityEditor.gui.ar.draw.update = function (visibleObjects) {
         });
     }
 
-    //if (!realityEditor.gui.ar.draw.frameNeedsToBeRendered) { return; } // don't recompute multiple times between a single animation frames (not compatible with WebXR)
+    if (!realityEditor.gui.ar.draw.frameNeedsToBeRendered &&
+        realityEditor.device.environment.isWithinToolboxApp()) {
+        // don't recompute multiple times between a single animation frames (not compatible with WebXR)
+        return;
+    }
     realityEditor.gui.ar.draw.frameNeedsToBeRendered = false; // gets set back to true by requestAnimationFrame code
-    
+
     var objectKey;
     var frameKey;
     var nodeKey;


### PR DESCRIPTION
iOS sends a ton of matrix update messages which in turn redraw. The app can't keep up with the stream so this reinstates previous behavior of discarding updates if a new frame hasn't been rendered yet.