### PR TITLE
Added support to read new GS Segmentation ply data

### DIFF
--- a/css/splatting.css
+++ b/css/splatting.css
@@ -168,3 +168,51 @@
 #gsContainer body.nohf #gsProgress, #gsContainer body.nohf .cube-face {
     background: #ff9d0d;
 }
+
+.cluster-label {
+    font-size: 2rem;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: fit-content;
+
+    color: white;
+    transition: color 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.cluster-label:hover {
+    color: cyan;
+}
+
+.cluster-label-number {
+    color: white;
+    font-size: 1rem;
+    pointer-events: none;
+    
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: fit-content;
+    
+    opacity: 0;
+    transform: translate(-50%, 0);
+    transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.cluster-label:hover .cluster-label-number {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+}
+
+#label-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+
+    /*width: 100vw;*/
+    /*height: 100vh;*/
+    
+    /*pointer-events: none;*/
+}


### PR DESCRIPTION
1. Updated training pipeline to incorporate [SAGA](https://github.com/Jumpat/SegAnyGAussians) 3D segmentation data into .ply file.
2. Updated .ply / splat file parser to be compatible with the new .ply file structure
3. Added "segmentation mode" besides regular color mode to the splat viewer, triggered by keyboard "J"
4. Visualized segmentation cluster center points in the splat viewer. Point size corresponds to cluster size (bigger point means there are more splats in this cluster / category), and hovering over the points gives cluster label.
Example screenshot & video:
<img width="1663" alt="GS 3D Segmentation GUI" src="https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/111802681/429e50eb-7591-4b87-8ce5-405a109f91d2">

https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/assets/111802681/df8a24af-a107-4dc8-80ab-8ff8533182a4

Will work with Dan to update the training pipeline automation. For now, if you want to try it out, see Teams chat for an example new version of the reality lab splat file.