### PR TITLE
Capture canvas screenshot (for camera perspective memory bar)

### DIFF
--- a/src/gui/sceneCapture.js
+++ b/src/gui/sceneCapture.js
@@ -1,0 +1,153 @@
+/**
+ * Coordinates with canvases in the scene to asynchronously take a screenshot at the proper time in the render loop
+ *
+ * To make use of this with a new canvas, do the following:
+ * 1. import { getPendingCapture } from './memory/sceneCapture.js';
+ *    ...
+ *    // In the main render loop, directly after finishing drawing, do:
+ *    let pendingCapture = getPendingCapture('thisCanvasId');
+ *    if (pendingCapture) {
+ *      pendingCapture.performCapture();
+ *    }
+ * 2. Then when you want to take a screenshot of the canvas elsewhere, do:
+ *    import { captureScreenshot } from '../../src/gui/memory/sceneCapture.js';
+ *    ...
+ *    captureScreenshot('thisCanvasId', options).then(screenshotImageSrc => {
+ *      console.log(screenshotImageSrc);
+ *    });
+ */
+class SceneCapture {
+    constructor() {
+        this.pendingCaptures = {};
+    }
+
+    /**
+     * Resolves a pending capture with a base-64 encoded image of the specified canvas
+     * @param {string} canvasId
+     * @param {number|undefined} outputWidth
+     * @param {number|undefined} outputHeight
+     * @param {Object} [compressionOptions]
+     * @param {boolean} [compressionOptions.useJpg] - Uses PNG if false, JPG if true
+     * @param {number} [compressionOptions.quality] - Quality of JPG, if used (0 to 1)
+     */
+    capture(canvasId, outputWidth, outputHeight, compressionOptions) {
+        let sourceCanvas = document.getElementById(canvasId); // document.getElementById('mainThreejsCanvas');
+        if (!sourceCanvas) {
+            console.warn(`trying to capture a non-existent canvas ${canvasId}`);
+            return;
+        }
+        let pendingCapture = this.pendingCaptures[canvasId];
+        if (!pendingCapture) {
+            console.warn(`capture called on ${canvasId} when there are no pendingCaptures waiting on this data`);
+            return;
+        }
+
+        if (outputWidth || outputHeight) {
+            let originalWidth = sourceCanvas.width;
+            let originalHeight = sourceCanvas.height;
+
+            if (!outputHeight) {
+                // Calculate height to preserve aspect ratio
+                outputHeight = outputWidth * (originalHeight / originalWidth);
+            } else if (!outputWidth) {
+                // Calculate width to preserve aspect ratio
+                outputWidth = outputHeight * (originalWidth / originalHeight);
+            }
+
+            // Create an off-screen canvas for resizing
+            let offScreenCanvas = document.createElement('canvas');
+            offScreenCanvas.width = outputWidth;
+            offScreenCanvas.height = outputHeight;
+            let ctx = offScreenCanvas.getContext('2d');
+
+            // Draw the original canvas onto the off-screen canvas at the desired size
+            ctx.drawImage(sourceCanvas, 0, 0, offScreenCanvas.width, offScreenCanvas.height);
+            sourceCanvas = offScreenCanvas;
+        }
+
+        let mostRecentCapture;
+        if (compressionOptions.useJpg) {
+            // Get the data URL of the resized canvas as JPEG
+            let quality = compressionOptions.quality || 0.7; // Adjust the quality parameter (0.0 to 1.0) as needed
+            mostRecentCapture = sourceCanvas.toDataURL('image/jpeg', quality);
+        } else {
+            mostRecentCapture = sourceCanvas.toDataURL('image/png');
+        }
+
+        if (pendingCapture.promiseResolve) {
+            pendingCapture.promiseResolve(mostRecentCapture);
+            pendingCapture.promiseResolve = null;
+        }
+        delete this.pendingCaptures[canvasId];
+    }
+}
+
+/**
+ * Pending canvas capture information, which can be performed at a future time using its `SceneCapture` instance
+ */
+class PendingCapture {
+    /**
+     * @param {SceneCapture} sceneCaptureInstance
+     * @param {string} canvasId
+     * @param {number|undefined} outputWidth
+     * @param {number|undefined} outputHeight
+     * @param {boolean} useJpgCompression
+     * @param {number} jpgQuality
+     */
+    constructor(sceneCaptureInstance, canvasId, outputWidth, outputHeight, useJpgCompression, jpgQuality) {
+        this.sceneCaptureInstance = sceneCaptureInstance;
+        this.canvasId = canvasId;
+        this.outputWidth = outputWidth;
+        this.outputHeight = outputHeight;
+        this.jpgCompression = {
+            useJpg: useJpgCompression,
+            quality: jpgQuality
+        };
+        this.promiseResolve = null; // gets set after initialization
+    }
+
+    /**
+     * Triggers the actual capture
+     */
+    performCapture() {
+        this.sceneCaptureInstance.capture(this.canvasId, this.outputWidth, this.outputHeight, this.jpgCompression);
+    }
+}
+
+const sceneCapture = new SceneCapture();
+
+/**
+ * Captures a screenshot of the canvas by creating a PendingCapture and returning a promise that will resolve when
+ * the PendingCapture finishes performing the capture
+ * @param {string} canvasId
+ * @param {Object} [options] - The options for capturing the screenshot.
+ * @param {number} [options.outputWidth] - The desired width. Only one of width/height needs to be specified.
+ * @param {number} [options.outputHeight] - The desired height. If both unspecified, uses full width/height of canvas.
+ * @param {boolean} [options.useJpgCompression=false] - Uses PNG if false, JPG if true.
+ * @param {number} [options.jpgQuality=0.7] - The quality of the JPG compression, if used. Value should be between 0 and 1.
+ * @return {Promise<string>} - resolves with the screenshot src as a base-64 encoded string (from `canvas.toDataURL`)
+ */
+export const captureScreenshot = (canvasId, options = {outputWidth: undefined, outputHeight: undefined, useJpgCompression: false, jpgQuality: 0.7}) => {
+    if (sceneCapture.pendingCaptures[canvasId]) console.warn('wait for previous capture to finish before capturing again');
+
+    let pendingCapture = new PendingCapture(sceneCapture, canvasId,
+        options.outputWidth, options.outputHeight, options.useJpgCompression, options.jpgQuality);
+
+    sceneCapture.pendingCaptures[canvasId] = pendingCapture;
+
+    return new Promise((resolve) => {
+        pendingCapture.promiseResolve = resolve;
+    });
+};
+
+/**
+ * Checks if there is a pending capture for the specified canvas
+ * @param {string} canvasId
+ * @return {PendingCapture}
+ */
+export const getPendingCapture = (canvasId) => {
+    return sceneCapture.pendingCaptures[canvasId];
+};
+
+
+

--- a/src/gui/sceneCapture.js
+++ b/src/gui/sceneCapture.js
@@ -2,7 +2,7 @@
  * Coordinates with canvases in the scene to asynchronously take a screenshot at the proper time in the render loop
  *
  * To make use of this with a new canvas, do the following:
- * 1. import { getPendingCapture } from './memory/sceneCapture.js';
+ * 1. import { getPendingCapture } from './sceneCapture.js';
  *    ...
  *    // In the main render loop, directly after finishing drawing, do:
  *    let pendingCapture = getPendingCapture('thisCanvasId');
@@ -10,7 +10,7 @@
  *      pendingCapture.performCapture();
  *    }
  * 2. Then when you want to take a screenshot of the canvas elsewhere, do:
- *    import { captureScreenshot } from '../../src/gui/memory/sceneCapture.js';
+ *    import { captureScreenshot } from '../../src/gui/sceneCapture.js';
  *    ...
  *    captureScreenshot('thisCanvasId', options).then(screenshotImageSrc => {
  *      console.log(screenshotImageSrc);

--- a/src/gui/threejsScene.js
+++ b/src/gui/threejsScene.js
@@ -14,6 +14,7 @@ import AnchoredGroup from "./scene/AnchoredGroup.js";
 import { WebXRCamera, DefaultCamera, LayerConfig } from "./scene/Camera.js";
 import { Renderer } from "./scene/Renderer.js";
 import {setMatrixFromArray} from "./scene/utils.js";
+import { getPendingCapture } from './sceneCapture.js';
 
 (function(exports) {
 
@@ -286,8 +287,10 @@ import {setMatrixFromArray} from "./scene/utils.js";
         if (isProjectionMatrixSet) {
             mainRenderer.render();
 
-            // capture screenshots directly after render to ensure canvas isn't empty
-            if (pendingCapture) capture(pendingCapture.outputWidth, pendingCapture.outputHeight, pendingCapture.jpgCompression);
+            let pendingCapture = getPendingCapture('mainThreejsCanvas');
+            if (pendingCapture) {
+                pendingCapture.performCapture();
+            }
         }
     }
 
@@ -1247,52 +1250,6 @@ import {setMatrixFromArray} from "./scene/utils.js";
         return new THREE.Vector3(x, y, z);
     }
 
-    let pendingCapture = null;
-
-    function capture(outputWidth, outputHeight, compressionOptions) {
-        console.log('capturing......');
-        let canvas = document.getElementById('mainThreejsCanvas');
-
-        if (outputWidth || outputHeight) {
-            let originalWidth = canvas.width;
-            let originalHeight = canvas.height;
-
-            if (!outputHeight) {
-                // Calculate height to preserve aspect ratio
-                outputHeight = outputWidth * (originalHeight / originalWidth);
-            } else if (!outputWidth) {
-                // Calculate width to preserve aspect ratio
-                outputWidth = outputHeight * (originalWidth / originalHeight);
-            }
-
-            // Create an off-screen canvas for resizing
-            let offScreenCanvas = document.createElement('canvas');
-            offScreenCanvas.width = outputWidth;
-            offScreenCanvas.height = outputHeight;
-            let ctx = offScreenCanvas.getContext('2d');
-
-            // Draw the original canvas onto the off-screen canvas at the desired size
-            ctx.drawImage(canvas, 0, 0, offScreenCanvas.width, offScreenCanvas.height);
-            canvas = offScreenCanvas;
-        }
-
-        let mostRecentCapture = null;
-
-        if (compressionOptions.useJpg) {
-            // Get the data URL of the resized canvas as JPEG
-            let quality = compressionOptions.quality || 0.7; // Adjust the quality parameter (0.0 to 1.0) as needed
-            mostRecentCapture = canvas.toDataURL('image/jpeg', quality);
-        } else {
-            mostRecentCapture = canvas.toDataURL('image/png');
-        }
-
-        if (pendingCapture.promiseResolve) {
-            pendingCapture.promiseResolve(mostRecentCapture);
-            pendingCapture.promiseResolve = null;
-        }
-        pendingCapture = null;
-    }
-
     exports.initService = initService;
     exports.setCameraPosition = setCameraPosition;
     exports.addOcclusionGltf = addOcclusionGltf;
@@ -1335,22 +1292,4 @@ import {setMatrixFromArray} from "./scene/utils.js";
     exports.disableExternalSceneRendering = disableExternalSceneRendering;
     exports.RENDER_MODES = RENDER_MODES;
     exports.convertToVector3 = convertToVector3;
-    // need to do this in a particular order otherwise you might capture
-    // the screenshot of the canvas after it's been cleared
-    exports.captureScreenshot = (options = {outputWidth: undefined, outputHeight: undefined, useJpgCompression: false, jpgQuality: 0.7}) => {
-        if (pendingCapture) console.warn('wait for previous capture to finish before capturing again');
-
-        pendingCapture = {
-            outputWidth: options.outputWidth,
-            outputHeight: options.outputHeight,
-            jpgCompression: {
-                useJpg: options.useJpgCompression,
-                quality: options.jpgQuality
-            }
-        };
-
-        return new Promise((resolve) => {
-            pendingCapture.promiseResolve = resolve;
-        });
-    };
 })(realityEditor.gui.threejsScene);

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -1042,7 +1042,7 @@ async function main(initialFilePath) {
             gl.uniform1i(u_shouldDraw, 1);
             gl.clear(gl.COLOR_BUFFER_BIT);
             gl.drawArraysInstanced(gl.TRIANGLE_FAN, 0, 4, vertexCount);
-            if (shouldCapture) capture();
+            if (pendingCapture) capture(pendingCapture.outputWidth, pendingCapture.outputHeight, pendingCapture.jpgCompression);
         } else {
             gl.clear(gl.COLOR_BUFFER_BIT);
             document.getElementById("gsSpinner").style.display = "";
@@ -1177,14 +1177,45 @@ async function main(initialFilePath) {
     }
 }
 
-let shouldCapture = false;
+let pendingCapture = null;
 let mostRecentCapture = null;
 
-function capture() {
+function capture(outputWidth, outputHeight, compressionOptions) {
     console.log('capturing......');
     let canvas = gsActive ? document.getElementById('gsCanvas') : document.getElementById('mainThreejsCanvas');
-    mostRecentCapture = canvas.toDataURL('image/png');
-    shouldCapture = false;
+
+    if (outputWidth || outputHeight) {
+        let originalWidth = canvas.width;
+        let originalHeight = canvas.height;
+
+        if (!outputHeight) {
+            // Calculate height to preserve aspect ratio
+            outputHeight = outputWidth * (originalHeight / originalWidth);
+        } else if (!outputWidth) {
+            // Calculate width to preserve aspect ratio
+            outputWidth = outputHeight * (originalWidth / originalHeight);
+        }
+
+        // Create an off-screen canvas for resizing
+        let offScreenCanvas = document.createElement('canvas');
+        offScreenCanvas.width = outputWidth;
+        offScreenCanvas.height = outputHeight;
+        let ctx = offScreenCanvas.getContext('2d');
+
+        // Draw the original canvas onto the off-screen canvas at the desired size
+        ctx.drawImage(canvas, 0, 0, offScreenCanvas.width, offScreenCanvas.height);
+        canvas = offScreenCanvas;
+    }
+
+    if (compressionOptions.useJpg) {
+        // Get the data URL of the resized canvas as JPEG
+        let quality = compressionOptions.quality || 0.7; // Adjust the quality parameter (0.0 to 1.0) as needed
+        mostRecentCapture = canvas.toDataURL('image/jpeg', quality);
+    } else {
+        mostRecentCapture = canvas.toDataURL('image/png');
+    }
+
+    pendingCapture = null;
 }
 
 // The comma key can be used to toggle the splat rendering visibility after it's been loaded at least once
@@ -1268,8 +1299,15 @@ export default {
     },
     // need to do this in a particular order otherwise you might capture
     // the screenshot of the canvas after it's been cleared
-    captureScreenshot() {
-        shouldCapture = true;
+    captureScreenshot(options = {outputWidth: undefined, outputHeight: undefined, useJpgCompression: false, jpgQuality: 0.7}) {
+        pendingCapture = {
+            outputWidth: options.outputWidth,
+            outputHeight: options.outputHeight,
+            jpgCompression: {
+                useJpg: options.useJpgCompression,
+                quality: options.jpgQuality
+            }
+        };
     },
     getMostRecentScreenshot() {
         return mostRecentCapture;

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -1042,6 +1042,7 @@ async function main(initialFilePath) {
             gl.uniform1i(u_shouldDraw, 1);
             gl.clear(gl.COLOR_BUFFER_BIT);
             gl.drawArraysInstanced(gl.TRIANGLE_FAN, 0, 4, vertexCount);
+            if (shouldCapture) capture();
         } else {
             gl.clear(gl.COLOR_BUFFER_BIT);
             document.getElementById("gsSpinner").style.display = "";
@@ -1176,6 +1177,16 @@ async function main(initialFilePath) {
     }
 }
 
+let shouldCapture = false;
+let mostRecentCapture = null;
+
+function capture() {
+    console.log('capturing......');
+    let canvas = gsActive ? document.getElementById('gsCanvas') : document.getElementById('mainThreejsCanvas');
+    mostRecentCapture = canvas.toDataURL('image/png');
+    shouldCapture = false;
+}
+
 // The comma key can be used to toggle the splat rendering visibility after it's been loaded at least once
 window.addEventListener("keydown", e => {
     if (e.key === ',') {
@@ -1255,4 +1266,12 @@ export default {
     hideGSSettingsPanel() {
         gsSettingsPanel.domElement.style.display = 'none';
     },
+    // need to do this in a particular order otherwise you might capture
+    // the screenshot of the canvas after it's been cleared
+    captureScreenshot() {
+        shouldCapture = true;
+    },
+    getMostRecentScreenshot() {
+        return mostRecentCapture;
+    }
 }


### PR DESCRIPTION
Goes with: https://github.com/ptcrealitylab/vuforia-spatial-remote-operator-addon/pull/202, to enable getting a thumbnail image of the scene. Just doing canvas.toDataURL at arbitrary moments elsewhere in the code may result in an empty image in between canvas draw calls.

![camera-position-memory-bar-v5](https://github.com/user-attachments/assets/7eb55483-cf4e-4b67-9730-f2c4f4559e0b)
