### PR TITLE
calculate avatar beam endpoint using groundplane even if no occlusion object

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -432,7 +432,7 @@ createNameSpace("realityEditor.avatar");
         subscriptionCallbacks[utils.PUBLIC_DATA_KEYS.aiApiKeys] = (msgContent) => {
             let endpoint = msgContent.publicData.aiApiKeys.endpoint;
             let azureApiKey = msgContent.publicData.aiApiKeys.azureApiKey;
-            realityEditor.network.postAiApiKeys(endpoint, azureApiKey, false);
+            // realityEditor.network.postAiApiKeys(endpoint, azureApiKey, false); // TODO: bring this back if needed
         }
 
         network.subscribeToAvatarPublicData(thatAvatarObject, subscriptionCallbacks);

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -464,30 +464,30 @@ createNameSpace("realityEditor.avatar");
             objectsToCheck.push(cachedOcclusionObject);
         }
 
-        if (!cachedWorldObject) return null;
-
-        // by default, three.js raycast returns coordinates in the top-level scene coordinate system
-        let raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, objectsToCheck);
-        if (raycastIntersects.length > 0) {
-            worldIntersectPoint = raycastIntersects[0].scenePoint;
-
-        // if we don't hit against the area target mesh, try colliding with the ground plane (if mode is enabled)
-        } else if (RAYCAST_AGAINST_GROUNDPLANE) {
-            let groundPlane = realityEditor.gui.threejsScene.getGroundPlaneCollider();
-            raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, [groundPlane.getInternalObject()]);
-            groundPlane.updateWorldMatrix(true, false);
+        if (cachedWorldObject) {
+            // by default, three.js raycast returns coordinates in the top-level scene coordinate system
+            let raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, objectsToCheck);
             if (raycastIntersects.length > 0) {
                 worldIntersectPoint = raycastIntersects[0].scenePoint;
-            }
-        }
 
-        if (worldIntersectPoint) {
-            // multiplying the point by the inverse world matrix seems to get it in the right coordinate system
-            let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
-            let matrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
-            realityEditor.gui.threejsScene.setMatrixFromArray(matrix, worldSceneNode.worldMatrix);
-            matrix.invert();
-            worldIntersectPoint.applyMatrix4(matrix);
+            // if we don't hit against the area target mesh, try colliding with the ground plane (if mode is enabled)
+            } else if (RAYCAST_AGAINST_GROUNDPLANE) {
+                let groundPlane = realityEditor.gui.threejsScene.getGroundPlaneCollider();
+                raycastIntersects = realityEditor.gui.threejsScene.getRaycastIntersects(screenX, screenY, [groundPlane.getInternalObject()]);
+                groundPlane.updateWorldMatrix(true, false);
+                if (raycastIntersects.length > 0) {
+                    worldIntersectPoint = raycastIntersects[0].scenePoint;
+                }
+            }
+
+            if (worldIntersectPoint) {
+                // multiplying the point by the inverse world matrix seems to get it in the right coordinate system
+                let worldSceneNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.getWorldId());
+                let matrix = new realityEditor.gui.threejsScene.THREE.Matrix4();
+                realityEditor.gui.threejsScene.setMatrixFromArray(matrix, worldSceneNode.worldMatrix);
+                matrix.invert();
+                worldIntersectPoint.applyMatrix4(matrix);
+            }
         }
 
         return worldIntersectPoint; // these are relative to the world object


### PR DESCRIPTION
Fixes the bug we noticed where the pointer beams weren't being sent when collaborating on a CAD model in an empty world, because the avatars were relying on the mesh having loaded in order to get into the logic of the raycast function.

I also commented out the `realityEditor.network.postAiApiKeys` as that function doesn't exist anymore (with that name), so sometimes the pointer synchronization was being broken by that line being triggered in the public data synchronization of avatars. I don't know in the long term if we want to keep that mechanism in there or remove it entirely – I think we discussed before that sending the keys like that is a security problem, but I didn't want to take out that syncing mechanism entirely if you're still using it @Steve-KX-RL 