### PR TITLE
Non-fullscreen full2D mode for tool, with draggable title bar

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2362,12 +2362,9 @@ Logic Interface CSS
 }
 
 .tool-title-bar-overlay {
+    /* can add styles here to affect the visual style of the window cover while dragging */
     /*background-color: rgba(255, 0, 0, 0.2);*/
 }
-
-/*.tool-title-bar-dragging {*/
-/*    */
-/*}*/
 
 .tool-title-bar-iframe-background {
     position: fixed;

--- a/css/index.css
+++ b/css/index.css
@@ -2344,6 +2344,37 @@ Logic Interface CSS
     font-size: 20px;
 }
 
+.tool-title-bar {
+    position: fixed;
+    background-color: #0f0f0f;
+    opacity: 0.9;
+    border-radius: 20px;
+    width: 100%;
+    height: 50px;
+}
+
+.tool-title-bar-icon {
+    height: 32px;
+    width: 32px;
+    margin: 8px;
+    opacity: 0.7;
+    transform: scale(0.8);
+}
+
+.tool-title-bar-overlay {
+    /*background-color: rgba(255, 0, 0, 0.2);*/
+}
+
+/*.tool-title-bar-dragging {*/
+/*    */
+/*}*/
+
+.tool-title-bar-iframe-background {
+    position: fixed;
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 20px;
+}
+
 /* Slight variation of popUpModal (and associated CSS classes), but available in userinterface rather than pop-up-addon */
 .inputModalCard {
     position: absolute;

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -509,6 +509,9 @@ createNameSpace("realityEditor.avatar");
                     y: e.pageY
                 };
                 lastPointerState.timestamp = Date.now();
+
+                // allow laser beam to pass through full2D tools with title bars, if started outside them
+                realityEditor.gui.ar.positioning.coverFull2DTools(true);
             }
         });
 
@@ -517,6 +520,8 @@ createNameSpace("realityEditor.avatar");
                 if (realityEditor.device.isMouseEventCameraControl(e)) { return; }
                 setBeamOff();
                 lastPointerState.position = null;
+
+                realityEditor.gui.ar.positioning.coverFull2DTools(false);
             });
         });
 

--- a/src/device/index.js
+++ b/src/device/index.js
@@ -719,6 +719,8 @@ realityEditor.device.beginTouchEditing = function(objectKey, frameKey, nodeKey) 
 
     globalDOMCache[(nodeKey || frameKey)].querySelector('.corners').style.visibility = 'visible';
 
+    realityEditor.gui.ar.positioning.coverFull2DTools(true);
+
     this.sendEditingStateToFrameContents(frameKey, true);
 
     this.callbackHandler.triggerCallbacks('beginTouchEditing');
@@ -1815,6 +1817,8 @@ realityEditor.device.onDocumentMultiTouchEnd = function (event) {
 
             if (activeVehicle && !globalStates.editingMode) {
                 globalDOMCache[(this.editingState.node || this.editingState.frame)].querySelector('.corners').style.visibility = 'hidden';
+
+                realityEditor.gui.ar.positioning.coverFull2DTools(false);
             }
 
             this.resetEditingState();

--- a/src/gui/ar/positioning.js
+++ b/src/gui/ar/positioning.js
@@ -760,6 +760,208 @@ realityEditor.gui.ar.positioning.getObjectPositionsOfTypes = function(objectType
     return dataToSend;
 };
 
+let previousMoveDelays = {};
+
+realityEditor.gui.ar.positioning.addTitleBarToTool = function(objectKey, frameKey) {
+    let toolContainer = globalDOMCache[`object${frameKey}`];
+    let toolIframe = globalDOMCache[`iframe${frameKey}`];
+    let toolOverlay = globalDOMCache[frameKey];
+    if (!toolContainer || !toolIframe || !toolOverlay) return;
+
+    let existingTitleBar = toolContainer.querySelector('.tool-title-bar');
+    if (existingTitleBar) return;
+
+    let thisTool = realityEditor.getFrame(objectKey, frameKey);
+    previousMoveDelays[frameKey] = thisTool.moveDelay;
+    thisTool.moveDelay = 10;
+
+    // create a new domElement to visually look like the tool title bar
+    let titleBar = document.createElement('div');
+    titleBar.classList.add('tool-title-bar');
+    let titleBarDragHandleIcon = document.createElement('img');
+    titleBarDragHandleIcon.classList.add('tool-title-bar-icon');
+    titleBarDragHandleIcon.src = 'svg/draggable-handle-white.svg';
+    titleBar.appendChild(titleBarDragHandleIcon);
+    titleBar.style.width = toolIframe.style.width;
+    // titleBar.style.height = toolIframe.style.height;
+    titleBar.style.left = toolIframe.style.left;
+    let top = parseInt(toolIframe.style.top)
+    titleBar.style.top = `${(top - 70)}px`;
+    titleBar.style.height = '50px';
+
+    toolContainer.appendChild(titleBar);
+
+    // add a semi-transparent background behind the iframe, in case it takes awhile to load
+    let iframeBackground = document.createElement('div');
+    iframeBackground.classList.add('tool-title-bar-iframe-background');
+    iframeBackground.style.width = toolIframe.style.width;
+    iframeBackground.style.height = toolIframe.style.height;
+    iframeBackground.style.top = toolIframe.style.top;
+    iframeBackground.style.left = toolIframe.style.left;
+    toolContainer.insertBefore(iframeBackground, toolContainer.firstChild); // add in the beginning so it renders behind the iframe
+
+    // reshape the tool overlay to cover the new title bar element, so existing touch events work on title bar
+    toolOverlay.classList.add('tool-title-bar-overlay');
+    // toolOverlay.classList.remove('deactivatedIframeOverlay');
+    toolOverlay.style.height = titleBar.style.height;
+    toolOverlay.style.top = titleBar.style.top;
+
+    // TODO: also add a background div that shows the size of the window, in case it's still loading
+
+    let cornersContainer = globalDOMCache[frameKey].querySelector('.corners');
+    cornersContainer.classList.add('corners-title-bar');
+
+    realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, frameKey);
+};
+
+// Adds a draggable bar above the tool, and removes the touchOverlay from the regular tool window
+realityEditor.gui.ar.positioning.removeTitleBarFromTool = function(objectKey, frameKey) {
+    let toolContainer = globalDOMCache[`object${frameKey}`];
+    let toolIframe = globalDOMCache[`iframe${frameKey}`];
+    let toolOverlay = globalDOMCache[frameKey];
+    if (!toolContainer || !toolIframe || !toolOverlay) return;
+    let titleBar = toolContainer.querySelector('.tool-title-bar');
+    if (!titleBar) return;
+
+    let thisTool = realityEditor.getFrame(objectKey, frameKey);
+    if (typeof previousMoveDelays[frameKey] !== 'undefined') {
+        thisTool.moveDelay = previousMoveDelays[frameKey];
+    }
+
+    // remove the title bar
+    toolContainer.removeChild(titleBar);
+
+    // remove the iframe background
+    let iframeBackground = toolContainer.querySelector('.tool-title-bar-iframe-background');
+    if (iframeBackground) {
+        toolContainer.removeChild(iframeBackground);
+    }
+
+    // reshape the tool overlay to cover the iframe again
+    toolOverlay.classList.remove('tool-title-bar-overlay');
+    // toolOverlay.classList.remove('deactivatedIframeOverlay');
+    toolOverlay.style.height = toolIframe.style.height;
+    toolOverlay.style.top = toolIframe.style.top;
+
+    // TODO: also remove the background div that shows the size of the window
+
+    let cornersContainer = globalDOMCache[frameKey].querySelector('.corners');
+    cornersContainer.classList.remove('corners-title-bar');
+
+    realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, frameKey);
+};
+
+realityEditor.gui.ar.positioning.updateTitleBarIfNeeded = function(objectKey, frameKey) {
+    let toolContainer = globalDOMCache[`object${frameKey}`];
+    let toolIframe = globalDOMCache[`iframe${frameKey}`];
+    let toolOverlay = globalDOMCache[frameKey];
+    if (!toolContainer || !toolIframe || !toolOverlay) return;
+    let titleBar = toolContainer.querySelector('.tool-title-bar');
+    if (!titleBar) return;
+
+    // make sure that the title bar's width and position still matches the iframe after it loaded
+    titleBar.style.width = toolIframe.style.width;
+    // titleBar.style.height = toolIframe.style.height;
+    titleBar.style.left = toolIframe.style.left;
+    let top = parseInt(toolIframe.style.top)
+    titleBar.style.top = `${(top - 70)}px`;
+    titleBar.style.height = '50px';
+
+    toolOverlay.style.height = titleBar.style.height;
+    toolOverlay.style.top = titleBar.style.top;
+
+    // also updates the iframe background
+    let iframeBackground = toolContainer.querySelector('.tool-title-bar-iframe-background');
+    if (iframeBackground) {
+        iframeBackground.style.width = toolIframe.style.width;
+        iframeBackground.style.height = toolIframe.style.height;
+        iframeBackground.style.top = toolIframe.style.top;
+        iframeBackground.style.left = toolIframe.style.left;
+    }
+
+    realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, frameKey);
+}
+
+// Removes the draggable bar from above the tool, and restores the touchOverlay to cover the regular tool window
+realityEditor.gui.ar.positioning.updateMoveabilityCorners = function(objectKey, frameKey) {
+    let toolOverlay = globalDOMCache[frameKey];
+    if (!toolOverlay) return;
+
+    let width = parseInt(toolOverlay.style.width);
+    let height = parseInt(toolOverlay.style.height);
+    // console.log('size moveability corners: ' + frameKey, width, height);
+
+    let cornersContainer = globalDOMCache[frameKey].querySelector('.corners');
+    // cornersContainer.classList.add('corners-title-bar');
+
+    // adjust move-ability corner UI to match true width and height of frame overlay
+    const cornerPadding = 24;
+    cornersContainer.style.width = `${width + cornerPadding * 2}px`;
+    cornersContainer.style.height = `${height + cornerPadding * 2}px`;
+};
+
+realityEditor.gui.ar.positioning.updateCornersForTitleBarIfNeeded = function(objectKey, frameKey) {
+    if (!globalDOMCache[frameKey]) return;
+    let cornersContainer = globalDOMCache[frameKey].querySelector('.corners');
+    if (!cornersContainer.classList.contains('corners-title-bar')) return;
+
+    // console.log('make the corners and overlay cover the entire iframe while dragging');
+
+    let toolIframe = globalDOMCache[`iframe${frameKey}`];
+    let toolOverlay = globalDOMCache[frameKey];
+
+    if (!toolOverlay || !toolIframe) return;
+
+    toolOverlay.style.height = toolIframe.style.height;
+    toolOverlay.style.top = toolIframe.style.top;
+
+    // const cornerPadding = 24;
+    // cornersContainer.style.width = `${width + cornerPadding * 2}px`;
+    // cornersContainer.style.height = `${height + cornerPadding * 2}px`;
+
+    realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, frameKey);
+};
+
+realityEditor.gui.ar.positioning.resetCornersForTitleBarIfNeeded = function(objectKey, frameKey) {
+    if (!globalDOMCache[frameKey]) return;
+    let cornersContainer = globalDOMCache[frameKey].querySelector('.corners');
+    if (!cornersContainer.classList.contains('corners-title-bar')) return;
+
+    console.log('reset the corners and overlay to just cover the title bar again');
+
+    let toolContainer = globalDOMCache[`object${frameKey}`];
+
+    if (!toolContainer) return;
+
+    let titleBar = toolContainer.querySelector('.tool-title-bar');
+    // let toolIframe = globalDOMCache[`iframe${frameKey}`];
+    let toolOverlay = globalDOMCache[frameKey];
+
+    if (!toolOverlay || !titleBar) return;
+
+    toolOverlay.style.height = titleBar.style.height;
+    toolOverlay.style.top = titleBar.style.top;
+
+    // const cornerPadding = 24;
+    // cornersContainer.style.width = `${width + cornerPadding * 2}px`;
+    // cornersContainer.style.height = `${height + cornerPadding * 2}px`;
+
+    realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, frameKey);
+
+};
+
+// smooth the camera controls while there are full2D tools with title bars
+realityEditor.gui.ar.positioning.coverFull2DTools = function(shouldCover) {
+    realityEditor.forEachFrameInAllObjects(function(objectKey, frameKey) {
+        // var thisFrame = realityEditor.getFrame(objectKey, frameKey);
+        if (shouldCover) {
+            realityEditor.gui.ar.positioning.updateCornersForTitleBarIfNeeded(objectKey, frameKey);
+        } else {
+            realityEditor.gui.ar.positioning.resetCornersForTitleBarIfNeeded(objectKey, frameKey);
+        }
+    });
+}
+
 // adjusts the screenZ (modelViewProjection[14]) to give values that correctly determine stacking order based on distance
 // to screen. if you don't do this, CSS-3D tools/icons have opposite stacking order compared to how you might expect.
 realityEditor.gui.ar.positioning.getFinalMatrixScreenZ = function(originalScreenZ, thisIsBeingEdited = false, shouldRenderFramesInNodeView = false) {

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -1782,8 +1782,12 @@ realityEditor.network.onInternalPostMessage = function (e) {
                 realityEditor.gui.ar.positioning.setVehicleScale(activeVehicle, 3.0);
             }
 
-            if (globalDOMCache[msgContent.frame]) {
-                globalDOMCache[msgContent.frame].classList.add('deactivatedIframeOverlay');
+            if (msgContent.showWindowTitleBar) {
+                realityEditor.gui.ar.positioning.addTitleBarToTool(msgContent.object, msgContent.frame);
+            } else {
+                if (globalDOMCache[msgContent.frame]) {
+                    globalDOMCache[msgContent.frame].classList.add('deactivatedIframeOverlay');
+                }
             }
         } else {
             if (globalDOMCache[msgContent.frame]) {
@@ -3257,14 +3261,8 @@ realityEditor.network.onElementLoad = function (objectKey, frameKey, nodeKey) {
     // adjust move-ability corner UI to match true width and height of frame contents
     if (globalDOMCache['iframe' + activeKey].clientWidth > 0) { // get around a bug where corners would resize to 0 for new logic nodes
         setTimeout(function() {
-            var trueSize = {
-                width: globalDOMCache['iframe' + activeKey].clientWidth,
-                height: globalDOMCache['iframe' + activeKey].clientHeight
-            };
-
-            var cornerPadding = 24;
-            globalDOMCache[activeKey].querySelector('.corners').style.width = trueSize.width + cornerPadding*2 + 'px';
-            globalDOMCache[activeKey].querySelector('.corners').style.height = trueSize.height + cornerPadding*2 + 'px';
+            realityEditor.gui.ar.positioning.updateTitleBarIfNeeded(objectKey, activeKey);
+            realityEditor.gui.ar.positioning.updateMoveabilityCorners(objectKey, activeKey);
         }, 100); // resize corners after a slight delay to ensure that the frame has fully initialized with the correct size
     }
 

--- a/svg/draggable-handle-white.svg
+++ b/svg/draggable-handle-white.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.9.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 11.7 18.7" style="enable-background:new 0 0 11.7 18.7;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<circle class="st0" cx="2.3" cy="2.3" r="2.1"/>
+<circle class="st0" cx="9.3" cy="2.3" r="2.1"/>
+<circle class="st0" cx="9.3" cy="9.3" r="2.1"/>
+<circle class="st0" cx="9.3" cy="16.3" r="2.1"/>
+<circle class="st0" cx="2.3" cy="9.3" r="2.1"/>
+<circle class="st0" cx="2.3" cy="16.3" r="2.1"/>
+</svg>


### PR DESCRIPTION
I've been meaning to merge this in for the better part of a year, but it always got mixed up in other PRs that I didn't end up merging. This allows for the mashup embed in the thingworx tool, by adding an API that lets you turn the tool into a floating window with a draggable bar above it, and removing the overlay div from the iframe so that you can naturally scroll/type/click on its contents. The iframe gets temporarily covered/protected when you perform certain gestures outside of the iframe, such as rotating the camera or starting the pointer, so that those gestures don't get interrupted if your cursor passes over the iframe.

To use this in a tool, call `spatialInterface.setFull2D(true, { showWindowTitleBar: true });`

![full-2d-windowed-tool](https://github.com/user-attachments/assets/7234ce60-a758-4ef0-9890-a51637008935)
