### PR TITLE
Fixed GS raycasting cursor jumping around bug + all math functions refactor

### DIFF
--- a/src/gui/shaders.js
+++ b/src/gui/shaders.js
@@ -1,4 +1,5 @@
 import {ShaderChunk} from "../../thirdPartyCode/three/three.module.js";
+import {mathUtilShader} from "../utilities/MathUtils.js";
 
 createNameSpace("realityEditor.gui.shaders");
 
@@ -21,13 +22,7 @@ createNameSpace("realityEditor.gui.shaders");
             return vec3(255.0 * f0, 255.0 * f8, 255.0 * f4) / 255.0;
         }
      
-        float Remap01 (float x, float low, float high) {
-            return clamp((x - low) / (high - low), 0., 1.);
-        }
-    
-        float Remap (float x, float lowIn, float highIn, float lowOut, float highOut) {
-            return lowOut + (highOut - lowOut) * Remap01(x, lowIn, highIn);
-        }
+        ${mathUtilShader}
     `;
     function heightMapVertexShader() {
         // return `

--- a/src/gui/spatialArrow.js
+++ b/src/gui/spatialArrow.js
@@ -1,6 +1,7 @@
 createNameSpace("realityEditor.gui.spatialArrow");
 
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
+import { remap } from "../utilities/MathUtils.js";
 
 (function (exports) {
     
@@ -56,18 +57,6 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
             canvas.width = screenW;
             canvas.height = screenH;
         }
-    }
-
-    const clamp = (x, low, high) => {
-        return Math.min(Math.max(x, low), high);
-    }
-
-    const remap01 = (x, low, high) => {
-        return clamp((x - low) / (high - low), 0, 1);
-    }
-
-    const remap = (x, lowIn, highIn, lowOut, highOut) => {
-        return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
     }
 
     let translateX = 0, translateY = 0;

--- a/src/gui/spatialIndicator.js
+++ b/src/gui/spatialIndicator.js
@@ -2,6 +2,7 @@ createNameSpace("realityEditor.gui.spatialIndicator");
 
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import { mergeBufferGeometries } from '../../thirdPartyCode/three/BufferGeometryUtils.module.js';
+import { remap } from "../utilities/MathUtils.js";
 
 (function (exports) {
     let camera;
@@ -126,18 +127,6 @@ import { mergeBufferGeometries } from '../../thirdPartyCode/three/BufferGeometry
         transparent: true,
         side: THREE.DoubleSide,
     });
-
-    const clamp = (x, low, high) => {
-        return Math.min(Math.max(x, low), high);
-    }
-
-    const remap01 = (x, low, high) => {
-        return clamp((x - low) / (high - low), 0, 1);
-    }
-
-    const remap = (x, lowIn, highIn, lowOut, highOut) => {
-        return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
-    }
 
     if (!DISABLE_SPATIAL_INDICATORS) {
         window.addEventListener('pointerdown', (e) => {

--- a/src/spatialCursor/index.js
+++ b/src/spatialCursor/index.js
@@ -1,6 +1,7 @@
 createNameSpace("realityEditor.spatialCursor");
 
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
+import { fract, clamp, remap, mathUtilShader } from "../utilities/MathUtils.js";
 
 (function(exports) {
 
@@ -64,13 +65,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     }
     `;
     const commonShader = `
-        float Remap01 (float x, float low, float high) {
-            return clamp((x - low) / (high - low), 0., 1.);
-        }
-    
-        float Remap (float x, float lowIn, float highIn, float lowOut, float highOut) {
-            return lowOut + (highOut - lowOut) * Remap01(x, lowIn, highIn);
-        }
+        ${mathUtilShader}
     
         vec2 Rot(vec2 uv, float a) {
             return mat2(cos(a), -sin(a), sin(a), cos(a)) * vec2(uv);
@@ -272,22 +267,6 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     //     blending: THREE.AdditiveBlending,
     //     side: THREE.DoubleSide,
     // });
-
-    const clamp = (x, low, high) => {
-        return Math.min(Math.max(x, low), high);
-    }
-
-    const remap01 = (x, low, high) => {
-        return clamp((x - low) / (high - low), 0, 1);
-    }
-
-    const remap = (x, lowIn, highIn, lowOut, highOut) => {
-        return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
-    }
-    
-    const fract = (x) => {
-        return x - Math.floor(x);
-    }
 
     async function getMyAvatarColor() {
         let myAvatarColor = await realityEditor.avatar.getMyAvatarColor();

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -8,6 +8,7 @@
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import GUI from '../../thirdPartyCode/lil-gui.esm.js';
 import { getPendingCapture } from '../gui/sceneCapture.js';
+import { remap } from "../utilities/MathUtils.js";
 
 let gsInitialized = false;
 let gsActive = false;
@@ -889,34 +890,6 @@ async function main(initialFilePath) {
     window.addEventListener("resize", resize);
     resize();
 
-    const clamp = (x, low, high) => {
-        return Math.min(Math.max(x, low), high);
-    }
-
-    const remap01 = (x, low, high) => {
-        return clamp((x - low) / (high - low), 0, 1);
-    }
-
-    const _remap01Curve1 = (x, low, high) => {
-        let r = remap01(x, low, high);
-        let a = 2;
-        return (1 - r) * Math.pow(r, a) + r * (-Math.pow(r - 1, a) + 1);
-    }
-
-    const remap01Curve2 = (x, low, high) => {
-        let r = remap01(x, low, high);
-        let a = 2;
-        return -Math.pow(r - 1, a) + 1;
-    }
-
-    const _remap = (x, lowIn, highIn, lowOut, highOut) => {
-        return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
-    }
-
-    const _remapCurve = (x, lowIn, highIn, lowOut, highOut) => {
-        return lowOut + (highOut - lowOut) * remap01Curve2(x, lowIn, highIn);
-    }
-
     worker.onmessage = (e) => {
         if (e.data.buffer) {
             splatData = new Uint8Array(e.data.buffer);
@@ -1060,8 +1033,8 @@ async function main(initialFilePath) {
                 const pixelBuffer = new Float32Array(4); // 4 components for RGBA
                 gl.readPixels(Math.floor(uMouseScreen[0]), Math.floor(innerHeight - uMouseScreen[1]), 1, 1, gl.RGBA, gl.FLOAT, pixelBuffer);
                 let camDepth = pixelBuffer[0];
-                let xOffset = _remap(uMouse[0], -1, 1, -camNearWidth / 2, camNearWidth / 2) / camNear * camDepth;
-                let yOffset = _remap(uMouse[1], -1, 1, camNearHeight / 2, -camNearHeight / 2) / camNear * camDepth;
+                let xOffset = remap(uMouse[0], -1, 1, -camNearWidth / 2, camNearWidth / 2) / camNear * camDepth;
+                let yOffset = remap(uMouse[1], -1, 1, camNearHeight / 2, -camNearHeight / 2) / camNear * camDepth;
                 let camSpacePosition = [xOffset, yOffset, camDepth, 1];
                 let worldSpacePosition = multiply4v(resultMatrix_1, camSpacePosition);
                 vWorld.set(worldSpacePosition[0], worldSpacePosition[1], worldSpacePosition[2]);

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -138,6 +138,15 @@ function multiply4(a, b) {
     ];
 }
 
+function multiply4v(m, v) {
+    return [
+        v[0] * m[0] + v[1] * m[4] + v[2] * m[8] + v[3] * m[12],
+        v[0] * m[1] + v[1] * m[5] + v[2] * m[9] + v[3] * m[13],
+        v[0] * m[2] + v[1] * m[6] + v[2] * m[10] + v[3] * m[14],
+        v[0] * m[3] + v[1] * m[7] + v[2] * m[11] + v[3] * m[15]
+    ]
+}
+
 function invert4(a) {
     let b00 = a[0] * a[5] - a[1] * a[4];
     let b01 = a[0] * a[6] - a[2] * a[4];
@@ -567,7 +576,6 @@ uniform bool uToggleBoundary;
 uniform float uWorldLowAlpha;
 
 uniform int uCollideIndex;
-uniform vec3 uCollidePosition;
 uniform bool uShouldDraw;
 
 in vec2 position;
@@ -620,19 +628,10 @@ void main () {
     vec2 vCenter = vec2(pos2d) / pos2d.w;
     
     
-    // implement accurate mouse raycasting
-    float majorAxisOffset = dot(uMouse - vCenter, normalize(majorAxis)) / ( abs(position.x) * length(majorAxis / viewport) );
-    float minorAxisOffset = dot(uMouse - vCenter, normalize(minorAxis)) / ( abs(position.y) * length(minorAxis / viewport) );
-    vec4 actualCam = cam;
-    vec4 offset1 = vec4(majorAxisOffset * (abs(position.x) * majorAxis / viewport), 0., 0.);
-    offset1 = inverse(projection) * (offset1 * pos2d.w);
-    vec4 offset2 = vec4(minorAxisOffset * (abs(position.y) * minorAxis / viewport), 0., 0.);
-    offset2 = inverse(projection) * (offset2 * pos2d.w);
-    actualCam = actualCam + offset1 + offset2;
-    vFBOPosColor = inverse(view) * actualCam;
-    vFBOPosColor.a = 1.;
+    // output cam space z depth for accurate mouse raycasting, also output splat index for raycast highlighting --- if want to do it in the future
+    vFBOPosColor = vec4(cam.z, index, 0., 1.);
     
-    if (vFBOPosColor.xyz == uCollidePosition) {
+    if (index == uCollideIndex) {
         vIndex = 1.;
     } else {
         vIndex = 0.;
@@ -775,7 +774,7 @@ async function main(initialFilePath) {
     const u_focal = gl.getUniformLocation(program, "focal");
     const u_view = gl.getUniformLocation(program, "view");
     const u_mouse = gl.getUniformLocation(program, "uMouse");
-    const u_collidePosition = gl.getUniformLocation(program, "uCollidePosition");
+    const u_collideIndex = gl.getUniformLocation(program, "uCollideIndex");
     const u_shouldDraw = gl.getUniformLocation(program, "uShouldDraw");
     const u_uIsGSRaycasting = gl.getUniformLocation(program, "uIsGSRaycasting");
     const u_toggleBoundary = gl.getUniformLocation(program, "uToggleBoundary");
@@ -806,6 +805,7 @@ async function main(initialFilePath) {
     gl.vertexAttribDivisor(a_index, 1);
 
     let projectionMatrix;
+    let camNear, camNearWidth, camNearHeight;
 
     // set up an off-screen frame buffer object texture
     let offscreenTexture = gl.createTexture();
@@ -860,6 +860,10 @@ async function main(initialFilePath) {
         // near and far plane defined in mm as in the rest of Toolbox
         projectionMatrix = projectionMatrixFrom(iPhoneVerticalFOV, window.innerWidth / window.innerHeight, 10, 300000);
 
+        camNear = 10 / 1000;
+        camNearHeight = camNear * Math.tan(iPhoneVerticalFOV * (Math.PI / 180) / 2) * 2;
+        camNearWidth = camNearHeight / window.innerHeight * window.innerWidth;
+
         // compute horizontal and vertical focal length in pixels from projection matrix. This is needed in shaders.
         const fx = projectionMatrix[0] * window.innerWidth / 2.0;
         const fy = projectionMatrix[5] * -window.innerHeight / 2.0;
@@ -884,6 +888,34 @@ async function main(initialFilePath) {
 
     window.addEventListener("resize", resize);
     resize();
+
+    const clamp = (x, low, high) => {
+        return Math.min(Math.max(x, low), high);
+    }
+
+    const remap01 = (x, low, high) => {
+        return clamp((x - low) / (high - low), 0, 1);
+    }
+
+    const _remap01Curve1 = (x, low, high) => {
+        let r = remap01(x, low, high);
+        let a = 2;
+        return (1 - r) * Math.pow(r, a) + r * (-Math.pow(r - 1, a) + 1);
+    }
+
+    const remap01Curve2 = (x, low, high) => {
+        let r = remap01(x, low, high);
+        let a = 2;
+        return -Math.pow(r - 1, a) + 1;
+    }
+
+    const _remap = (x, lowIn, highIn, lowOut, highOut) => {
+        return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
+    }
+
+    const remapCurve = (x, lowIn, highIn, lowOut, highOut) => {
+        return lowOut + (highOut - lowOut) * remap01Curve2(x, lowIn, highIn);
+    }
 
     worker.onmessage = (e) => {
         if (e.data.buffer) {
@@ -1027,8 +1059,13 @@ async function main(initialFilePath) {
                 // read the texture
                 const pixelBuffer = new Float32Array(4); // 4 components for RGBA
                 gl.readPixels(Math.floor(uMouseScreen[0]), Math.floor(innerHeight - uMouseScreen[1]), 1, 1, gl.RGBA, gl.FLOAT, pixelBuffer);
-                gl.uniform3fv(u_collidePosition, new Float32Array([pixelBuffer[0], pixelBuffer[1], pixelBuffer[2]]));
-                vWorld.set(pixelBuffer[0], pixelBuffer[1], pixelBuffer[2]);
+                let camDepth = pixelBuffer[0];
+                let xOffset = _remap(uMouse[0], -1, 1, -camNearWidth / 2, camNearWidth / 2) / camNear * camDepth;
+                let yOffset = _remap(uMouse[1], -1, 1, camNearHeight / 2, -camNearHeight / 2) / camNear * camDepth;
+                let camSpacePosition = [xOffset, yOffset, camDepth, 1];
+                let worldSpacePosition = multiply4v(resultMatrix_1, camSpacePosition);
+                vWorld.set(worldSpacePosition[0], worldSpacePosition[1], worldSpacePosition[2]);
+                gl.uniform1i(u_collideIndex, pixelBuffer[1]);
                 vWorld.x = (vWorld.x / scaleF - offset_x) / SCALE;
                 vWorld.y = (vWorld.y / scaleF - offset_y) / SCALE - floorOffset;
                 vWorld.z = (vWorld.z / scaleF - offset_z) / SCALE;

--- a/src/splatting/Splatting.js
+++ b/src/splatting/Splatting.js
@@ -913,7 +913,7 @@ async function main(initialFilePath) {
         return lowOut + (highOut - lowOut) * remap01(x, lowIn, highIn);
     }
 
-    const remapCurve = (x, lowIn, highIn, lowOut, highOut) => {
+    const _remapCurve = (x, lowIn, highIn, lowOut, highOut) => {
         return lowOut + (highOut - lowOut) * remap01Curve2(x, lowIn, highIn);
     }
 

--- a/src/utilities/MathUtils.js
+++ b/src/utilities/MathUtils.js
@@ -1,0 +1,67 @@
+// output the fractional part of a number
+export function fract(x) {
+    return x - Math.floor(x);
+}
+
+// clamps a number ∈ [low, high]
+export function clamp(x, low, high) {
+    return Math.min(Math.max(x, low), high);
+}
+
+// output a number ∈ [a, b]; when n === 0, output a; when n === 1, output b
+export function mix(a, b, n) {
+    n = clamp(n, 0, 1);
+    return a * (1 - n) + b * n;
+}
+
+// inverse function of mix(), output a number ∈ [0, 1]; when x === low, output 0; when x === b, output 1
+export function remap01(x, low, high) {
+    return clamp((x - low) / (high - low), 0, 1);
+}
+
+// remaps x from [lowIn, highIn] to [lowOut, highOut]
+export function remap(x, lowIn, highIn, lowOut, highOut) {
+    return mix(lowOut, highOut, remap01(x, lowIn, highIn));
+}
+
+/**
+ * function that generates an s-curve ∈ [0, 1], sort of like:
+ * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve approaches y = x
+     __
+    /
+   |
+__/
+**/
+export function remap01CurveS(x, low, high, a = 2) {
+    let r = remap01(x, low, high);
+    a = Math.ceil(Math.max(a, 2) / 2) * 2;
+    return (1 - r) * Math.pow(r, a) + r * (-Math.pow(r - 1, a) + 1);
+}
+
+/**
+ * function that generates a curve within [0, 1] that tapers off, sort of like:
+ * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve initial slope becomes bigger
+    __
+  /
+ |
+|
+**/
+export function remap01CurveEaseOut(x, low, high, a = 2) {
+    let r = remap01(x, low, high);
+    a = Math.ceil(Math.max(a, 2) / 2) * 2;
+    return -Math.pow(r - 1, a) + 1;
+}
+
+export function remapCurveEaseOut(x, lowIn, highIn, lowOut, highOut) {
+    return mix(lowOut, highOut, remap01CurveEaseOut(x, lowIn, highIn));
+}
+
+export const mathUtilShader = `
+    float Remap01 (float x, float low, float high) {
+        return clamp((x - low) / (high - low), 0., 1.);
+    }
+
+    float Remap (float x, float lowIn, float highIn, float lowOut, float highOut) {
+        return mix(lowOut, highOut, Remap01(x, lowIn, highIn));
+    }
+`;

--- a/src/utilities/MathUtils.js
+++ b/src/utilities/MathUtils.js
@@ -26,11 +26,11 @@ export function remap(x, lowIn, highIn, lowOut, highOut) {
 
 /**
  * function that generates an s-curve ∈ [0, 1], sort of like:
- * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve approaches y = x
      __
     /
    |
 __/
+ * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve approaches y = x
 **/
 export function remap01CurveS(x, low, high, a = 2) {
     let r = remap01(x, low, high);
@@ -40,11 +40,11 @@ export function remap01CurveS(x, low, high, a = 2) {
 
 /**
  * function that generates a curve within [0, 1] that tapers off, sort of like:
- * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve initial slope becomes bigger
     __
   /
  |
 |
+ * a ∈ [2, 4, 6, 8, 10, ...]. a ↑ --> curve initial slope becomes bigger
 **/
 export function remap01CurveEaseOut(x, low, high, a = 2) {
     let r = remap01(x, low, high);


### PR DESCRIPTION
Old GS raycasting method has a fundamental flaw which makes calculating cursor world position dependent on screen aspect ratio, specifically only accurate when screen is 1:1. Now introducing a new way to get raycast position. We use the camera space depth to compute the offset between camera and raycast position, and converting it back to world space. The result is a smooth & accurate spatial cursor, always at the center of mouse cursor, regardless of the screen aspect ratio.

https://github.com/user-attachments/assets/4642e6dc-e7f5-4b1c-8ce6-7d4f656698a6

