### PR TITLE
Error handling around navmesh write to local storage

### DIFF
--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -104,8 +104,8 @@ createNameSpace("realityEditor.app.targetDownloader");
             }
         }
 
+        // save the navmesh into localStorage if it's small enough, otherwise recalculate it each time
         if (fitsInLocalStorage(navmesh)) {
-            // save to localStorage, and delete old thumbnails from other worlds from localStorage if there are too many
             try {
                 window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
             } catch (e) {

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -105,7 +105,16 @@ createNameSpace("realityEditor.app.targetDownloader");
         }
 
         if (fitsInLocalStorage(navmesh)) {
-            window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
+            // save to localStorage, and delete old thumbnails from other worlds from localStorage if there are too many
+            try {
+                window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
+            } catch (e) {
+                if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+                    console.error('Local storage quota exceeded. Cannot store navmesh.');
+                } else {
+                    console.error('Error storing navmesh in local storage:', e);
+                }
+            }
         } else {
             console.warn(`navmesh for ${objectID} doesn't fit in localStorage; will be recalculated on each page load`);
         }

--- a/src/app/targetDownloader.js
+++ b/src/app/targetDownloader.js
@@ -103,7 +103,12 @@ createNameSpace("realityEditor.app.targetDownloader");
                 i--;
             }
         }
-        window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
+
+        if (fitsInLocalStorage(navmesh)) {
+            window.localStorage.setItem(`realityEditor.navmesh.${objectID}`, JSON.stringify(navmesh));
+        } else {
+            console.warn(`navmesh for ${objectID} doesn't fit in localStorage; will be recalculated on each page load`);
+        }
 
         if (realityEditor.device.environment.variables.addOcclusionGltf) {
             let object = realityEditor.getObject(objectID);
@@ -121,6 +126,27 @@ createNameSpace("realityEditor.app.targetDownloader");
     }
     navmeshWorker.onerror = function(error) {
         console.error(`navmeshWorker: '${error.message}' on line ${error.lineno}`);
+    }
+
+    /**
+     * Check if the jsonObject will fit in the specified percentage of the localStorage capacity
+     * (assuming 5MB localStorage capacity)
+     * @param {*} jsonObject
+     * @param {number} maxAmountUsedForSingleObject
+     * @return {boolean}
+     */
+    function fitsInLocalStorage(jsonObject, maxAmountUsedForSingleObject = 0.2) {
+        // Convert your object to a JSON string
+        const objectString = JSON.stringify(jsonObject);
+
+        // Calculate the size in bytes
+        const sizeInBytes = new Blob([objectString]).size;
+
+        // Define the maximum size for localStorage (in bytes)
+        const maxLocalStorageSize = 5 * 1024 * 1024; // 5MB
+
+        // Check if it exceeds the limit
+        return sizeInBytes <= maxLocalStorageSize * maxAmountUsedForSingleObject
     }
 
     /**


### PR DESCRIPTION
Prevents the session from breaking when trying to load an unusually large area target, e.g. this scan of the 17th floor

<img width="1805" alt="Screenshot 2024-08-20 at 11 47 18 AM" src="https://github.com/user-attachments/assets/df78a07b-5a32-48a5-9058-a03953098a9c">
