### PR TITLE
Optimize network bandwidth used while in avatar following mode

### DIFF
--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -165,11 +165,11 @@ createNameSpace("realityEditor.avatar");
 
             try {
                 // rate limit your avatar updates when you are following someone else, so as not to congest the network
+                let myAvatarFPS = 10;
                 if (connectedAvatarUserProfiles[myAvatarId] && connectedAvatarUserProfiles[myAvatarId].lockOnMode) {
-                    updateMyAvatar({ broadcastFps: 1});
-                } else {
-                    updateMyAvatar({ broadcastFps: 10});
+                    myAvatarFPS = 1;
                 }
+                updateMyAvatar({ broadcastFps: myAvatarFPS });
 
                 sendMySpatialCursorPosition();
 

--- a/src/avatar/index.js
+++ b/src/avatar/index.js
@@ -164,7 +164,12 @@ createNameSpace("realityEditor.avatar");
             if (!myAvatarObject || globalStates.freezeButtonState) { return; }
 
             try {
-                updateMyAvatar();
+                // rate limit your avatar updates when you are following someone else, so as not to congest the network
+                if (connectedAvatarUserProfiles[myAvatarId] && connectedAvatarUserProfiles[myAvatarId].lockOnMode) {
+                    updateMyAvatar({ broadcastFps: 1});
+                } else {
+                    updateMyAvatar({ broadcastFps: 10});
+                }
 
                 sendMySpatialCursorPosition();
 
@@ -343,7 +348,7 @@ createNameSpace("realityEditor.avatar");
     }
 
     // update the avatar object to match the camera position each frame (if it exists), and realtime broadcast to others
-    function updateMyAvatar() {
+    function updateMyAvatar(options = { broadcastFps: 10 }) {
         let avatarSceneNode = realityEditor.sceneGraph.getSceneNodeById(myAvatarId);
         let cameraNode = realityEditor.sceneGraph.getSceneNodeById(realityEditor.sceneGraph.NAMES.CAMERA);
         if (!avatarSceneNode || !cameraNode) { return; }
@@ -356,7 +361,7 @@ createNameSpace("realityEditor.avatar");
         let worldNode = realityEditor.sceneGraph.getSceneNodeById(worldObjectId);
         let relativeMatrix = avatarSceneNode.getMatrixRelativeTo(worldNode);
 
-        network.realtimeSendAvatarPosition(myAvatarObject, relativeMatrix);
+        network.realtimeSendAvatarPosition(myAvatarObject, relativeMatrix, options.broadcastFps);
     }
     
     function sendMySpatialCursorPosition() {

--- a/src/avatar/network.js
+++ b/src/avatar/network.js
@@ -127,7 +127,7 @@ createNameSpace("realityEditor.avatar.network");
     }
 
     // if the object has moved at all, and enough time has passed (FPS_LIMIT), realtime broadcast the new avatar matrix
-    function realtimeSendAvatarPosition(avatarObject, matrix) {
+    function realtimeSendAvatarPosition(avatarObject, matrix, broadcastRateLimitFps = DATA_SEND_FPS_LIMIT) {
         // only send a data update if the matrix has changed since last time
         if (avatarObject.matrix.length !== 16) { avatarObject.matrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]; }
         let totalDifference = realityEditor.avatar.utils.sumOfElementDifferences(avatarObject.matrix, matrix);
@@ -138,11 +138,14 @@ createNameSpace("realityEditor.avatar.network");
         // already gets uploaded to server but isn't set locally yet
         avatarObject.matrix = matrix;
 
+        // rate limit can be lowered below DATA_SEND_FPS_LIMIT by providing a broadcastRateLimitFps
+        let rateLimitFps = Math.min(DATA_SEND_FPS_LIMIT, broadcastRateLimitFps);
         // sceneGraph uploads object position to server every 1 second via REST, but we can stream updates in realtime here
-        if (Date.now() - lastBroadcastPositionTimestamp < (1000 / DATA_SEND_FPS_LIMIT)) {
+        if (Date.now() - lastBroadcastPositionTimestamp < (1000 / rateLimitFps)) {
             return;
         }
         realityEditor.network.realtime.broadcastUpdate(avatarObject.objectId, null, null, 'matrix', matrix);
+        // console.log('broadcast avatar position');
         lastBroadcastPositionTimestamp = Date.now();
     }
 


### PR DESCRIPTION
Reduces the rate that you send your avatar position to the server; uses 10 fps normally, but reduces it to 1 fps if you're following another user's avatar (referred to in the code as `lockOnMode`). This is to prevent everyone from spamming the server at the same time while a large group is following a single avatar that's moving around.

Works best in combination with https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/1125