### PR TITLE
hide UI that says X users are following you, until your avatar has finished initializing

### DIFF
--- a/src/avatar/iconMenu.js
+++ b/src/avatar/iconMenu.js
@@ -169,7 +169,7 @@ createNameSpace("realityEditor.avatar.iconMenu");
         let myId = realityEditor.avatar.getMyAvatarId();
         let usersFollowingMe = realityEditor.avatar.utils.getUsersFollowingUser(myId, connectedAvatars);
 
-        if (usersFollowingMe.length > 0) {
+        if (myId && usersFollowingMe.length > 0) {
             let plural = usersFollowingMe.length > 1;
             leaderContainer.textContent = `${usersFollowingMe.length} ${plural ? 'users are' : 'user is'} following your perspective. Click here to stop sharing.`;
             leaderContainer.style.display = '';


### PR DESCRIPTION
Fixes bug where `myId` starts out null, so when the page is loading it might look like other users are following you if they aren't following anyone (because their lock on ID is also null).

<img width="444" alt="Screenshot 2024-09-11 at 12 35 32 PM" src="https://github.com/user-attachments/assets/ece53ba3-82df-4642-a0d0-0828ef93a152">
